### PR TITLE
history package added in --save-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint": "^1.8.0",
     "eslint-plugin-react": "^3.6.3",
     "gh-pages": "^0.4.0",
+    "history": "^2.0.0",
     "jsdom": "^7.1.0",
     "json-loader": "^0.5.4",
     "mocha": "^2.3.0",


### PR DESCRIPTION
history package a peer dependency of React Router and won't automatically be installed for you in npm 3+.
Run `npm install history` 