### PR TITLE
use a pretty label for collection button

### DIFF
--- a/scripts/components/Sidebar.js
+++ b/scripts/components/Sidebar.js
@@ -29,9 +29,10 @@ export default class Sidebar extends Component {
                 "list-group-item",
                 params.name === name ? "active" : "",
               ].join(" ");
+              const label = collections[name].name || name;
               return (
                 <Link key={i} to={`/collections/${name}`} className={classes}>
-                  {name + (!collections[name].synced ? "*" : "")}
+                  {label + (!collections[name].synced ? "*" : "")}
                 </Link>
               );
             })

--- a/test/containers/Sidebar_test.js
+++ b/test/containers/Sidebar_test.js
@@ -18,7 +18,7 @@ describe("Sidebar container", () => {
     expect(nodeTexts(comp, "a")).eql([
       "Home",
       "Settings",
-      "tasks",
+      "Todo tasks",
     ]);
   });
 
@@ -41,7 +41,7 @@ describe("Sidebar container", () => {
     const comp = setupContainer(<Sidebar {...props} />);
     comp.store.dispatch(CollectionsActions.collectionsListReceived(collections));
 
-    expect(nodeText(comp, "a.active")).eql("tasks");
+    expect(nodeText(comp, "a.active")).eql("Todo tasks");
   });
 
   it("should denote an unsynced collection", () => {


### PR DESCRIPTION
Take the `name` field from the collection info in the config.

Fixes #40.