### PR TITLE
Fixed erroneous Kinto lib import.

### DIFF
--- a/scripts/actions/form.js
+++ b/scripts/actions/form.js
@@ -1,4 +1,8 @@
+import { cleanRecord } from "kinto/lib/collection";
+
 import { update } from "./collection";
+import { FORMDATA_IGNORE_FIELDS } from "../reducers/form";
+
 
 export const FORM_RECORD_LOADED = "FORM_RECORD_LOADED";
 export const FORM_RECORD_UNLOADED = "FORM_RECORD_UNLOADED";
@@ -19,6 +23,7 @@ export function formDataReceived(formData) {
 export function submitForm() {
   return (dispatch, getState) => {
     const {record, formData} = getState().form;
-    dispatch(update(Object.assign({}, record, formData)));
+    const cleanFormData = cleanRecord(formData, FORMDATA_IGNORE_FIELDS);
+    dispatch(update(Object.assign({}, record, cleanFormData)));
   };
 }

--- a/scripts/reducers/form.js
+++ b/scripts/reducers/form.js
@@ -1,10 +1,12 @@
-import { cleanRecord } from "kinto/lib/api";
+import { cleanRecord } from "kinto/lib/collection";
 
 import {
   FORM_RECORD_LOADED,
   FORM_RECORD_UNLOADED,
   FORM_DATA_RECEIVED,
 } from "../actions/form";
+
+export const FORMDATA_IGNORE_FIELDS = ["id", "_status", "last_modified"];
 
 const INITIAL_STATE = {
   record: null,
@@ -17,7 +19,7 @@ export default function form(state = INITIAL_STATE, action) {
     return {
       ...state,
       record: action.record,
-      formData: cleanRecord(action.record, ["id", "_status", "last_modified"]),
+      formData: cleanRecord(action.record, FORMDATA_IGNORE_FIELDS),
     };
   case FORM_RECORD_UNLOADED:
     return {...state, record: null, formData: null};

--- a/test/actions/form_test.js
+++ b/test/actions/form_test.js
@@ -1,0 +1,53 @@
+import sinon from "sinon";
+
+import * as actions from "../../scripts/actions/form";
+import * as CollectionActions from "../../scripts/actions/collection";
+
+
+describe("form actions", () => {
+  var sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("submitForm()", () => {
+    let dispatch, getState, update;
+
+    beforeEach(() => {
+      dispatch = sandbox.spy();
+      getState = () => ({
+        form: {
+          record: {
+            id: "toto",
+            last_modified: 42,
+            _status: "updated"
+          },
+          formData: {
+            id: undefined,
+            foo: "bar"
+          },
+        }
+      });
+      update = sandbox.stub(CollectionActions, "update");
+    });
+
+    it("should strip ignored fields from provided formData", (done) => {
+      actions.submitForm()(dispatch, getState);
+
+      setImmediate(() => {
+        sinon.assert.calledWith(update, {
+          id: "toto",
+          last_modified: 42,
+          _status: "updated",
+          foo: "bar"
+        });
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Strange we missed this since the release of Kinto 2.0.0 as the import path for `cleanRecord` has changed.

pair=@Natim