### PR TITLE
Fixes #51: Synchronization strategy selector.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -108,3 +108,18 @@ table.record-list td.actions {
 .list-actions .label {
   margin-left: 1em;
 }
+
+.sync-btn-group .dropdown-menu a {
+  padding-left: 1em;
+  padding-right: 2em;
+}
+
+.sync-btn-group .dropdown-menu .glyphicon {
+  float: right;
+  margin: .15em -1.5em 0 0;
+  color: #888;
+}
+
+.sync-btn-group .dropdown-menu .active .glyphicon {
+  color: #fff;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -104,3 +104,7 @@ table.record-list td.actions {
 .json-record {
   min-height: 300px;
 }
+
+.list-actions .label {
+  margin-left: 1em;
+}

--- a/scripts/components/CollectionList.js
+++ b/scripts/components/CollectionList.js
@@ -201,7 +201,10 @@ class SyncButton extends Component {
     return (
       <div className={`btn-group ${open ? "open" : ""}`}>
         <button type="button" className="btn btn-info btn-sync"
-          onClick={this.doSync}>Synchronize ({strategy.toUpperCase()})</button>
+          onClick={this.doSync}>
+          <span className="caption">Synchronize</span>
+          <span className="label label-primary">{strategy.toUpperCase()}</span>
+        </button>
         <button type="button" className="btn btn-info dropdown-toggle"
           title="Select alternative strategy"
           onClick={open ? this.closeMenu : this.openMenu}>

--- a/scripts/components/CollectionList.js
+++ b/scripts/components/CollectionList.js
@@ -173,6 +173,12 @@ class SyncButton extends Component {
     this.state = {open: false};
   }
 
+  static strategies = {
+    [MANUAL]: "MANUAL resolution",
+    [CLIENT_WINS]: "CLIENT_WINS resolution",
+    [SERVER_WINS]: "SERVER_WINS resolution",
+  }
+
   openMenu = () => this.setState({open: true});
   closeMenu = () => this.setState({open: false});
 
@@ -201,17 +207,17 @@ class SyncButton extends Component {
           onClick={open ? this.closeMenu : this.openMenu}>
           <span className="caret"></span>
         </button>
-        <ul className="dropdown-menu">
-          <li onClick={this.selectStrategy(MANUAL)}>
-            <a href="#">MANUAL resolution</a>
-          </li>
-          <li onClick={this.selectStrategy(CLIENT_WINS)}>
-            <a href="#">CLIENT_WINS</a>
-          </li>
-          <li onClick={this.selectStrategy(SERVER_WINS)}>
-            <a href="#">SERVER_WINS</a>
-          </li>
-        </ul>
+        <ul className="dropdown-menu">{
+          Object.keys(SyncButton.strategies).map((strat, i) => {
+            const classes = strategy === strat ? "active" : "";
+            return (
+              <li className={classes} onClick={this.selectStrategy(strat)}>
+                <a className={`sync_${strat}`} href="#">
+                  {SyncButton.strategies[strat]}</a>
+              </li>
+            );
+          })
+        }</ul>
       </div>
     );
   }

--- a/scripts/components/CollectionList.js
+++ b/scripts/components/CollectionList.js
@@ -5,7 +5,7 @@ import Kinto from "kinto";
 import BusyIndicator from "./BusyIndicator";
 
 
-const {CLIENT_WINS, SERVER_WINS} = Kinto.syncStrategy;
+const {MANUAL, CLIENT_WINS, SERVER_WINS} = Kinto.syncStrategy;
 
 class AdvancedActions extends React.Component {
   constructor(props) {
@@ -170,43 +170,45 @@ class Table extends Component {
 class SyncButton extends Component {
   constructor(props) {
     super(props);
-    this.state = {open: false};
+    this.state = {open: false, strategy: MANUAL};
   }
 
-  // menu state handlers
   openMenu = () => this.setState({open: true});
   closeMenu = () => this.setState({open: false});
 
-  // sync action handlers
-  processSyncClick = (event, syncOptions) => {
-    event.preventDefault();
-    this.props.sync(syncOptions);
+  doSync = () => {
+    this.props.sync({strategy: this.state.strategy});
     this.setState({open: false});
+  };
+
+  selectStrategy = (strategy) => {
+    return (event) => {
+      event.preventDefault();
+      this.setState({strategy, open: false});
+    };
   }
-  manualSync = (event) => this.processSyncClick(event)
-  clientWinsSync = (event) => this.processSyncClick(event, {
-    strategy: CLIENT_WINS
-  });
-  serverWinsSync = (event) => this.processSyncClick(event, {
-    strategy: SERVER_WINS
-  });
 
   render() {
-    const {sync} = this.props;
-    const {open} = this.state;
+    const {open, strategy} = this.state;
     return (
       <div className={`btn-group ${open ? "open" : ""}`}>
         <button type="button" className="btn btn-info btn-sync"
-          onClick={sync.bind(null, "manual")}>Synchronize</button>
+          onClick={this.doSync}>Synchronize ({strategy.toUpperCase()})</button>
         <button type="button" className="btn btn-info dropdown-toggle"
           title="Select alternative strategy"
           onClick={open ? this.closeMenu : this.openMenu}>
           <span className="caret"></span>
         </button>
         <ul className="dropdown-menu">
-          <li onClick={this.manualSync}><a href="#">Manual</a></li>
-          <li onClick={this.clientWinsSync}><a href="#">Client wins</a></li>
-          <li onClick={this.serverWinsSync}><a href="#">Server wins</a></li>
+          <li onClick={this.selectStrategy(MANUAL)}>
+            <a href="#">Manual</a>
+          </li>
+          <li onClick={this.selectStrategy(CLIENT_WINS)}>
+            <a href="#">Client wins</a>
+          </li>
+          <li onClick={this.selectStrategy(SERVER_WINS)}>
+            <a href="#">Server wins</a>
+          </li>
         </ul>
       </div>
     );

--- a/scripts/components/CollectionList.js
+++ b/scripts/components/CollectionList.js
@@ -174,9 +174,18 @@ class SyncButton extends Component {
   }
 
   static strategies = {
-    [MANUAL]: "MANUAL resolution",
-    [CLIENT_WINS]: "CLIENT_WINS resolution",
-    [SERVER_WINS]: "SERVER_WINS resolution",
+    [MANUAL]: {
+      label: "MANUAL resolution",
+      help: "Do not automatically resolve conflicts.",
+    },
+    [CLIENT_WINS]: {
+      label: "CLIENT_WINS resolution",
+      help: "Overwrite remote conflicting records with local data.",
+    },
+    [SERVER_WINS]: {
+      label: "SERVER_WINS resolution",
+      help: "Overwrite local conflicting records with remote data.",
+    },
   }
 
   openMenu = () => this.setState({open: true});
@@ -199,7 +208,7 @@ class SyncButton extends Component {
     const {strategy} = this.props;
     const {open} = this.state;
     return (
-      <div className={`btn-group ${open ? "open" : ""}`}>
+      <div className={`sync-btn-group btn-group ${open ? "open" : ""}`}>
         <button type="button" className="btn btn-info btn-sync"
           onClick={this.doSync}>
           <span className="caption">Synchronize</span>
@@ -212,11 +221,13 @@ class SyncButton extends Component {
         </button>
         <ul className="dropdown-menu">{
           Object.keys(SyncButton.strategies).map((strat, i) => {
-            const classes = strategy === strat ? "active" : "";
+            const {label, help} = SyncButton.strategies[strat];
+            const cls = strategy === strat ? "active" : "";
             return (
-              <li className={classes} onClick={this.selectStrategy(strat)}>
-                <a className={`sync_${strat}`} href="#">
-                  {SyncButton.strategies[strat]}</a>
+              <li key={i} className={cls} onClick={this.selectStrategy(strat)}>
+                <a className={`sync_${strat}`} title={help} href="#">
+                  <i className="glyphicon glyphicon-info-sign" />
+                  {label}</a>
               </li>
             );
           })

--- a/scripts/components/CollectionList.js
+++ b/scripts/components/CollectionList.js
@@ -170,26 +170,28 @@ class Table extends Component {
 class SyncButton extends Component {
   constructor(props) {
     super(props);
-    this.state = {open: false, strategy: MANUAL};
+    this.state = {open: false};
   }
 
   openMenu = () => this.setState({open: true});
   closeMenu = () => this.setState({open: false});
 
   doSync = () => {
-    this.props.sync({strategy: this.state.strategy});
+    this.props.sync();
     this.setState({open: false});
   };
 
   selectStrategy = (strategy) => {
     return (event) => {
       event.preventDefault();
-      this.setState({strategy, open: false});
+      this.props.selectStrategy(strategy);
+      this.setState({open: false});
     };
   }
 
   render() {
-    const {open, strategy} = this.state;
+    const {strategy} = this.props;
+    const {open} = this.state;
     return (
       <div className={`btn-group ${open ? "open" : ""}`}>
         <button type="button" className="btn btn-info btn-sync"
@@ -216,10 +218,13 @@ class SyncButton extends Component {
 }
 
 function ListActions(props) {
-  const {name, sync, reset} = props;
+  const {name, sync, reset, strategy, selectStrategy} = props;
   return (
     <div className="list-actions">
-      <SyncButton sync={sync} />
+      <SyncButton
+        sync={sync}
+        selectStrategy={selectStrategy}
+        strategy={strategy} />
       <Link to={`/collections/${name}/add`} className="btn btn-info">Add</Link>
       <AdvancedActions collection={name} resetSync={reset} />
     </div>
@@ -227,7 +232,16 @@ function ListActions(props) {
 }
 
 export default class CollectionList extends Component {
-  onResetSyncClick() {
+  constructor(props) {
+    super(props);
+    this.state = {strategy: MANUAL};
+  }
+
+  selectStrategy = (strategy) => this.setState({strategy});
+
+  sync = () => this.props.sync({strategy: this.state.strategy});
+
+  onResetSyncClick = () => {
     if (confirm("Are you sure?")) {
       this.props.resetSync();
     }
@@ -236,15 +250,18 @@ export default class CollectionList extends Component {
   render() {
     const {name, busy, schema, records, config} = this.props.collection;
     const {server} = this.props.settings;
-    const {deleteRecord, conflicts, sync} = this.props;
+    const {deleteRecord, conflicts} = this.props;
+    const {strategy} = this.state;
     if (!name) {
       return <p>Loading...</p>;
     }
     const listActions = (
       <ListActions
         name={name}
-        sync={sync}
-        reset={this.onResetSyncClick.bind(this)} />
+        strategy={strategy}
+        selectStrategy={this.selectStrategy}
+        sync={this.sync}
+        reset={this.onResetSyncClick} />
     );
     return (
       <div className="collection-page">

--- a/scripts/components/CollectionList.js
+++ b/scripts/components/CollectionList.js
@@ -201,13 +201,13 @@ class SyncButton extends Component {
         </button>
         <ul className="dropdown-menu">
           <li onClick={this.selectStrategy(MANUAL)}>
-            <a href="#">Manual</a>
+            <a href="#">MANUAL resolution</a>
           </li>
           <li onClick={this.selectStrategy(CLIENT_WINS)}>
-            <a href="#">Client wins</a>
+            <a href="#">CLIENT_WINS</a>
           </li>
           <li onClick={this.selectStrategy(SERVER_WINS)}>
-            <a href="#">Server wins</a>
+            <a href="#">SERVER_WINS</a>
           </li>
         </ul>
       </div>

--- a/scripts/components/CollectionList.js
+++ b/scripts/components/CollectionList.js
@@ -178,20 +178,18 @@ class SyncButton extends Component {
   closeMenu = () => this.setState({open: false});
 
   // sync action handlers
-  manualSync = (event) => {
+  processSyncClick = (event, syncOptions) => {
     event.preventDefault();
-    this.props.sync();
+    this.props.sync(syncOptions);
+    this.setState({open: false});
   }
-
-  clientWinsSync = (event) => {
-    event.preventDefault();
-    this.props.sync({strategy: CLIENT_WINS});
-  }
-
-  serverWinsSync = (event) => {
-    event.preventDefault();
-    this.props.sync({strategy: SERVER_WINS});
-  }
+  manualSync = (event) => this.processSyncClick(event)
+  clientWinsSync = (event) => this.processSyncClick(event, {
+    strategy: CLIENT_WINS
+  });
+  serverWinsSync = (event) => this.processSyncClick(event, {
+    strategy: SERVER_WINS
+  });
 
   render() {
     const {sync} = this.props;

--- a/scripts/components/CollectionList.js
+++ b/scripts/components/CollectionList.js
@@ -175,15 +175,15 @@ class SyncButton extends Component {
 
   static strategies = {
     [MANUAL]: {
-      label: "MANUAL resolution",
-      help: "Do not automatically resolve conflicts.",
+      label: "Manual resolution",
+      help: "Prompt when a conflict occurs.",
     },
     [CLIENT_WINS]: {
-      label: "CLIENT_WINS resolution",
+      label: "Client wins",
       help: "Overwrite remote conflicting records with local data.",
     },
     [SERVER_WINS]: {
-      label: "SERVER_WINS resolution",
+      label: "Server wins",
       help: "Overwrite local conflicting records with remote data.",
     },
   }
@@ -193,14 +193,14 @@ class SyncButton extends Component {
 
   doSync = () => {
     this.props.sync();
-    this.setState({open: false});
+    this.closeMenu();
   };
 
   selectStrategy = (strategy) => {
     return (event) => {
       event.preventDefault();
       this.props.selectStrategy(strategy);
-      this.setState({open: false});
+      this.closeMenu();
     };
   }
 
@@ -212,10 +212,12 @@ class SyncButton extends Component {
         <button type="button" className="btn btn-info btn-sync"
           onClick={this.doSync}>
           <span className="caption">Synchronize</span>
-          <span className="label label-primary">{strategy.toUpperCase()}</span>
+          <span className="label label-primary">
+            {strategy.toUpperCase().replace("_", " ")}
+          </span>
         </button>
         <button type="button" className="btn btn-info dropdown-toggle"
-          title="Select alternative strategy"
+          title="Select conflict resolution strategy"
           onClick={open ? this.closeMenu : this.openMenu}>
           <span className="caret"></span>
         </button>

--- a/test/containers/CollectionList_test.js
+++ b/test/containers/CollectionList_test.js
@@ -91,15 +91,15 @@ describe("CollectionListPage container", () => {
 
     describe("Collection action buttons", () => {
       it("should render collection action buttons", () => {
-        expect(nodeTexts(comp, "p.list-actions button")).eql(
-            ["Synchronize", "Synchronize"]);
+        expect(nodeTexts(comp, ".list-actions .btn-sync")).eql(
+            ["Synchronize (MANUAL)", "Synchronize (MANUAL)"]);
       });
 
       it("should call kinto collection sync()", () => {
         const sync = sandbox.stub(KintoCollection.prototype, "sync")
           .returns(Promise.resolve({ok: true}));
 
-        click(comp, "p.list-actions button.btn-sync");
+        click(comp, ".list-actions button.btn-sync");
 
         sinon.assert.called(sync);
       });

--- a/test/containers/CollectionList_test.js
+++ b/test/containers/CollectionList_test.js
@@ -1,7 +1,11 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import React from "react";
+import Kinto from "kinto";
 import KintoCollection from "kinto/lib/collection";
+
+
+const {MANUAL, CLIENT_WINS, SERVER_WINS} = Kinto.syncStrategy;
 
 import { setupContainer, nodeText, nodeTexts, click } from "../test-utils";
 import CollectionListPage from "../../scripts/containers/CollectionListPage";
@@ -90,18 +94,36 @@ describe("CollectionListPage container", () => {
     });
 
     describe("Collection action buttons", () => {
+      let sync;
+
+      beforeEach(() => {
+        sync = sandbox.stub(KintoCollection.prototype, "sync")
+          .returns(Promise.resolve({ok: true}));
+      });
+
       it("should render collection action buttons", () => {
         expect(nodeTexts(comp, ".list-actions .btn-sync")).eql(
             ["Synchronize (MANUAL)", "Synchronize (MANUAL)"]);
       });
 
       it("should call kinto collection sync()", () => {
-        const sync = sandbox.stub(KintoCollection.prototype, "sync")
-          .returns(Promise.resolve({ok: true}));
+        click(comp, ".list-actions .btn-sync");
 
-        click(comp, ".list-actions button.btn-sync");
+        sinon.assert.calledWithMatch(sync, {strategy: MANUAL});
+      });
 
-        sinon.assert.called(sync);
+      it("should allow selecting the CLIENT_WINS sync strategy", () => {
+        click(comp, ".list-actions .sync_client_wins");
+        click(comp, ".list-actions .btn-sync");
+
+        sinon.assert.calledWithMatch(sync, {strategy: CLIENT_WINS});
+      });
+
+      it("should allow selecting the SERVER_WINS sync strategy", () => {
+        click(comp, ".list-actions .sync_server_wins");
+        click(comp, ".list-actions .btn-sync");
+
+        sinon.assert.calledWithMatch(sync, {strategy: SERVER_WINS});
       });
     });
   });

--- a/test/containers/CollectionList_test.js
+++ b/test/containers/CollectionList_test.js
@@ -118,7 +118,7 @@ describe("CollectionListPage container", () => {
         click(comp, ".list-actions .sync_client_wins");
 
         expect(nodeText(comp, ".list-actions .btn-sync .label"))
-          .eql("CLIENT_WINS");
+          .eql("CLIENT WINS");
 
         click(comp, ".list-actions .btn-sync");
 
@@ -129,7 +129,7 @@ describe("CollectionListPage container", () => {
         click(comp, ".list-actions .sync_server_wins");
 
         expect(nodeText(comp, ".list-actions .btn-sync .label"))
-          .eql("SERVER_WINS");
+          .eql("SERVER WINS");
 
         click(comp, ".list-actions .btn-sync");
 

--- a/test/containers/CollectionList_test.js
+++ b/test/containers/CollectionList_test.js
@@ -102,8 +102,10 @@ describe("CollectionListPage container", () => {
       });
 
       it("should render collection action buttons", () => {
-        expect(nodeTexts(comp, ".list-actions .btn-sync")).eql(
-            ["Synchronize (MANUAL)", "Synchronize (MANUAL)"]);
+        expect(nodeTexts(comp, ".list-actions .btn-sync .caption")).eql(
+            ["Synchronize", "Synchronize"]);
+        expect(nodeTexts(comp, ".list-actions .btn-sync .label")).eql(
+            ["MANUAL", "MANUAL"]);
       });
 
       it("should call kinto collection sync()", () => {
@@ -114,6 +116,10 @@ describe("CollectionListPage container", () => {
 
       it("should allow selecting the CLIENT_WINS sync strategy", () => {
         click(comp, ".list-actions .sync_client_wins");
+
+        expect(nodeText(comp, ".list-actions .btn-sync .label"))
+          .eql("CLIENT_WINS");
+
         click(comp, ".list-actions .btn-sync");
 
         sinon.assert.calledWithMatch(sync, {strategy: CLIENT_WINS});
@@ -121,6 +127,10 @@ describe("CollectionListPage container", () => {
 
       it("should allow selecting the SERVER_WINS sync strategy", () => {
         click(comp, ".list-actions .sync_server_wins");
+
+        expect(nodeText(comp, ".list-actions .btn-sync .label"))
+          .eql("SERVER_WINS");
+
         click(comp, ".list-actions .btn-sync");
 
         sinon.assert.calledWithMatch(sync, {strategy: SERVER_WINS});


### PR DESCRIPTION
WiP, refs #51.

This introduces a new dropdown menu for the synchronization strategy to use next to the *Synchronize* button:

![](http://i.imgur.com/nEpYwb2.png) 

Feedback=? @leplatrem @glasserc @Natim 