### PR TITLE
Fixes #101: Basic validation of JSON schema + sensible default.

### DIFF
--- a/scripts/components/CollectionForm.js
+++ b/scripts/components/CollectionForm.js
@@ -2,8 +2,23 @@ import React, { Component } from "react";
 import Form from "react-jsonschema-form";
 
 import JSONEditor from "./JSONEditor";
-import { validJSON } from "./../utils";
+import { validJSON, validateSchema } from "./../utils";
 
+
+const defaultSchema = JSON.stringify({
+  type: "object",
+  properties: {
+    field1: {type: "string"},
+    field2: {type: "string"},
+  }
+}, null, 2);
+
+const defaultUiSchema = JSON.stringify({
+  "ui:order": ["field1", "field2"],
+  field2: {
+    "ui:widget": "textarea"
+  }
+}, null, 2);
 
 const schema = {
   type: "object",
@@ -18,35 +33,62 @@ const schema = {
     schema: {
       type: "string",
       title: "JSON schema",
-      default: "{}",
+      default: defaultSchema,
     },
     uiSchema: {
       type: "string",
       title: "UI schema",
-      default: "{}",
+      default: defaultUiSchema,
     },
     displayFields: {
       type: "array",
+      default: ["field1", "field2"],
       items: {
         type: "string",
-        description: "Enter a field name. i.e: name, attachment.filename"
+        description: "Enter a field name. i.e: name, attachment.filename",
       }
     },
   }
 };
 
 const uiSchema = {
+  name: {
+    "ui:help": "The name should only contain letters, numbers, dashes or underscores."
+  },
   schema: {
     "ui:widget": JSONEditor,
+    "ui:help": (
+      <p>
+        This must be a valid
+        <a href="http://json-schema.org/" target="_blank"> JSON schema </a>
+        defining an object representing the structure of your collection records.
+        You may find this
+        <a href="http://jsonschema.net/" target="_blank"> online schema builder </a>
+        useful to create your own.
+      </p>
+    )
   },
   uiSchema: {
     "ui:widget": JSONEditor,
+    "ui:help": (
+      <p>
+        Learn more about
+        <a href="https://git.io/vrbKn" target="_blank"> what a uiSchema is </a> and
+        how to leverage it to enhance how JSON schema forms are rendered in the admin.
+      </p>
+    )
+  },
+  displayFields: {
+    "ui:help": "This field allows defining the record object properties " +
+               "to display as columns in the main records list table."
   }
 };
 
 function validate({schema, uiSchema}, errors) {
-  if (!validJSON(schema)) {
-    errors.schema.addError("Invalid JSON.");
+  try {
+    validateSchema(schema);
+  } catch(error) {
+    errors.schema.addError(error);
   }
   if (!validJSON(uiSchema)) {
     errors.uiSchema.addError("Invalid JSON.");

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -18,6 +18,10 @@ export function omit(obj, keys=[]) {
   }, {});
 }
 
+export function isObject(thing) {
+  return typeof thing === "object" && thing !== null && !Array.isArray(thing);
+}
+
 export function validJSON(string) {
   try {
     JSON.parse(string);
@@ -25,6 +29,46 @@ export function validJSON(string) {
   } catch(err) {
     return false;
   }
+}
+
+export function validateSchema(jsonSchema) {
+  let schema;
+  try {
+    schema = JSON.parse(jsonSchema);
+  } catch(err) {
+    throw "The schema is not valid JSON";
+  }
+  const checks = [
+    {
+      test: () => isObject(schema),
+      error: "The schema is not an object",
+    },
+    {
+      test: () => schema.hasOwnProperty("type"),
+      error: "The schema has no type",
+    },
+    {
+      test: () => schema.type === "object",
+      error: "The schema type is not 'object'",
+    },
+    {
+      test: () => schema.hasOwnProperty("properties"),
+      error: "The schema has no 'properties' property",
+    },
+    {
+      test: () => isObject(schema.properties),
+      error: "The 'properties' property is not an object",
+    },
+    {
+      test: () => Object.keys(schema.properties).length > 0,
+      error: "The 'properties' property object has no properties",
+    },
+  ];
+  checks.forEach(({test, error}) => {
+    if (!test()) {
+      throw error;
+    }
+  });
 }
 
 export function cleanRecord(record) {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1,6 +1,11 @@
 import { expect } from "chai";
 
-import {cleanRecord, renderDisplayField} from "../scripts/utils";
+import {
+  cleanRecord,
+  renderDisplayField,
+  validateSchema,
+} from "../scripts/utils";
+
 
 describe("cleanRecord", () => {
   it("should remove id, schema and last_modified from properties", () => {
@@ -28,7 +33,7 @@ describe("renderDisplayField", () => {
       "supported.strange.nested": {"tree": "foobar", "tree.value": "bar"}
     };
   });
-  
+
   it("should return the title field as a string", () => {
     expect(renderDisplayField(record, "title"))
       .eql("I am a title");
@@ -72,5 +77,42 @@ describe("renderDisplayField", () => {
   it("should return support strange nested tree value missing.", () => {
     expect(renderDisplayField(record, "supported.strange.nested.tree.missing"))
       .eql("<unknown>");
+  });
+});
+
+describe("validateSchema()", () => {
+  it("should validate that the schema is valid JSON", () => {
+    expect(() => validateSchema("invalid"))
+      .to.Throw("The schema is not valid JSON");
+  });
+
+  it("should validate that the schema is an object", () => {
+    expect(() => validateSchema("[]"))
+      .to.Throw("The schema is not an object");
+  });
+
+  it("should validate that the schema has a type property", () => {
+    expect(() => validateSchema("{}"))
+      .to.Throw("The schema has no type");
+  });
+
+  it("should validate that the schema has an 'object' type", () => {
+    expect(() => validateSchema(JSON.stringify({type: "string"})))
+      .to.Throw("The schema type is not 'object'");
+  });
+
+  it("should validate that the schema declare properties", () => {
+    expect(() => validateSchema(JSON.stringify({type: "object"})))
+      .to.Throw("The schema has no 'properties' property");
+  });
+
+  it("should validate that the schema properties are an object", () => {
+    expect(() => validateSchema(JSON.stringify({type: "object", properties: 2})))
+      .to.Throw("The 'properties' property is not an object");
+  });
+
+  it("should validate that the schema properties has properties", () => {
+    expect(() => validateSchema(JSON.stringify({type: "object", properties: {}})))
+      .to.Throw("The 'properties' property object has no properties");
   });
 });


### PR DESCRIPTION
Refs #101, WiP. This adds slightly more sensible JSON schema field default value in the collection settings form, and performs a very basic validation of it.

Deployed to gh-pages.

Default values:

![](http://i.imgur.com/KxPjWv6.png)

Validation errors:

![](http://i.imgur.com/QfX0ky8.png)

Feedback=? @Natim @almet @leplatrem