### PR TITLE
Validate provided displayFields against the json schema.

### DIFF
--- a/scripts/components/CollectionForm.js
+++ b/scripts/components/CollectionForm.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import Form from "react-jsonschema-form";
 
 import JSONEditor from "./JSONEditor";
-import { validJSON, validateSchema } from "./../utils";
+import { validJSON, validateSchema, validateDisplayFields } from "./../utils";
 
 
 const defaultSchema = JSON.stringify({
@@ -98,6 +98,11 @@ function validate({schema, uiSchema, displayFields}, errors) {
   }
   if (!validJSON(uiSchema)) {
     errors.uiSchema.addError("Invalid JSON.");
+  }
+  try {
+    validateDisplayFields(schema, displayFields);
+  } catch(error) {
+    errors.displayFields.addError(error);
   }
   return errors;
 }

--- a/scripts/components/CollectionForm.js
+++ b/scripts/components/CollectionForm.js
@@ -91,18 +91,22 @@ const uiSchema = {
 };
 
 function validate({schema, uiSchema, displayFields}, errors) {
+  let _schema;
   try {
-    validateSchema(schema);
+    _schema = validateSchema(schema);
   } catch(error) {
     errors.schema.addError(error);
   }
   if (!validJSON(uiSchema)) {
     errors.uiSchema.addError("Invalid JSON.");
   }
-  try {
-    validateDisplayFields(schema, displayFields);
-  } catch(error) {
-    errors.displayFields.addError(error);
+  const displayFieldsErrors = validateDisplayFields(_schema, displayFields);
+  if (displayFieldsErrors.length > 0) {
+    // XXX would be nice to attach the errors to their respective array items
+    // https://github.com/mozilla-services/react-jsonschema-form/issues/223
+    for (const error of displayFieldsErrors) {
+      errors.displayFields.addError(error);
+    }
   }
   return errors;
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -72,6 +72,16 @@ export function validateSchema(jsonSchema) {
   return schema;
 }
 
+export function validateDisplayFields(schema, displayFields) {
+  const {properties} = JSON.parse(schema);
+  const fieldRoots = displayFields.map((field) => field.split(".")[0]);
+  fieldRoots.forEach((root) => {
+    if (!properties.hasOwnProperty(root)) {
+      throw `The JSON schema does not define a ${root} field`;
+    }
+  });
+}
+
 export function cleanRecord(record) {
   return omit(record, ["id", "schema", "last_modified"]);
 }

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -4,6 +4,7 @@ import {
   cleanRecord,
   renderDisplayField,
   validateSchema,
+  validateDisplayFields,
 } from "../scripts/utils";
 
 
@@ -114,5 +115,53 @@ describe("validateSchema()", () => {
   it("should validate that the schema properties has properties", () => {
     expect(() => validateSchema(JSON.stringify({type: "object", properties: {}})))
       .to.Throw("The 'properties' property object has no properties");
+  });
+});
+
+describe("validateDisplayFields", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      foo: {type: "string"},
+      bar: {
+        type: "object",
+        properties: {
+          baz: {
+            type: "object",
+            properties: {
+              qux: {type: "string"}
+            }
+          }
+        }
+      }
+    }
+  };
+
+  it("should return no errors fields are in the schema", () => {
+    expect(validateDisplayFields(schema, ["foo", "bar"]))
+      .eql([]);
+  });
+
+  it("should return an error if a field is not in the schema", () => {
+    expect(validateDisplayFields(schema, ["xxx"]))
+      .eql(["The JSON schema does not define a xxx field"]);
+  });
+
+  it("should return multiple errors if fields are not in the schema", () => {
+    expect(validateDisplayFields(schema, ["xxx", "yyy"]))
+      .eql([
+        "The JSON schema does not define a xxx field",
+        "The JSON schema does not define a yyy field"
+      ]);
+  });
+
+  it("should return an error if deeply nested field is not in schema", () => {
+    expect(validateDisplayFields(schema, ["bar.baz.nope"]))
+      .eql(["The JSON schema does not define a bar.baz.nope field"]);
+  });
+
+  it("should return no error if deeply nested field is in the schema", () => {
+    expect(validateDisplayFields(schema, ["bar.baz.qux"]))
+      .eql([]);
   });
 });


### PR DESCRIPTION
This adds validation to the Collection creation/edition form to ensure that entered _displayFields_ actually match the provided json schema.

r=? @Natim @leplatrem 
