### PR TITLE
Fixes #132: Ensure resetting session dependent sagas.

### DIFF
--- a/scripts/sagas/collection.js
+++ b/scripts/sagas/collection.js
@@ -198,8 +198,9 @@ export function* watchCollectionRecords() {
   }
 }
 
-export function* watchRecordCreate() {
-  const {serverInfo} = yield take(SESSION_SERVERINFO_SUCCESS);
+export function* watchRecordCreate(serverInfoAction) {
+  // Note: serverInfoAction is provided by takeLatest in the rootSaga
+  const {serverInfo} = serverInfoAction;
   while(true) { // eslint-disable-line
     const {bid, cid, record} = yield take(RECORD_CREATE_REQUEST);
     // Check if we have to deal with attachments
@@ -211,8 +212,9 @@ export function* watchRecordCreate() {
   }
 }
 
-export function* watchRecordUpdate() {
-  const {serverInfo} = yield take(SESSION_SERVERINFO_SUCCESS);
+export function* watchRecordUpdate(serverInfoAction) {
+  // Note: serverInfoAction is provided by takeLatest in the rootSaga
+  const {serverInfo} = serverInfoAction;
   while(true) { // eslint-disable-line
     const {bid, cid, rid, record} = yield take(RECORD_UPDATE_REQUEST);
     // Check if we have to deal with attachments

--- a/scripts/sagas/index.js
+++ b/scripts/sagas/index.js
@@ -1,5 +1,7 @@
+import { takeLatest } from "redux-saga";
 import { fork } from "redux-saga/effects";
 
+import { SESSION_SERVERINFO_SUCCESS } from "../constants";
 import * as sessionSagas from "./session";
 import * as routeSagas from "./route";
 import * as bucketSagas from "./bucket";
@@ -24,10 +26,17 @@ export default function* rootSaga() {
     fork(bucketSagas.watchCollectionDelete),
     // collection/records
     fork(collectionSagas.watchCollectionRecords),
-    fork(collectionSagas.watchRecordCreate),
-    fork(collectionSagas.watchRecordUpdate),
     fork(collectionSagas.watchRecordDelete),
     fork(collectionSagas.watchBulkCreateRecords),
     fork(collectionSagas.watchAttachmentDelete),
+    // Ensure restarting session info dependent watchers when info are updated
+    fork(function* () {
+      yield* takeLatest(SESSION_SERVERINFO_SUCCESS,
+                        collectionSagas.watchRecordCreate);
+    }),
+    fork(function* () {
+      yield* takeLatest(SESSION_SERVERINFO_SUCCESS,
+                        collectionSagas.watchRecordUpdate);
+    }),
   ];
 }

--- a/test/sagas/collection_test.js
+++ b/test/sagas/collection_test.js
@@ -13,6 +13,7 @@ import {
   ROUTE_LOAD_SUCCESS,
 } from "../../scripts/constants";
 import { notifyError, notifySuccess } from "../../scripts/actions/notifications";
+import * as sessionActions from "../../scripts/actions/session";
 import * as collectionActions from "../../scripts/actions/collection";
 import * as recordActions from "../../scripts/actions/record";
 import * as saga from "../../scripts/sagas/collection";
@@ -633,16 +634,12 @@ describe("collection sagas", () => {
     describe("watchRecordCreate()", () => {
       describe("Attachments enabled", () => {
         it("should watch for the createRecordWithAttachment action", () => {
-          const watchRecordCreate = saga.watchRecordCreate();
+          const action = sessionActions.serverInfoSuccess({
+            capabilities: {attachments: {}}
+          });
+          const watchRecordCreate = saga.watchRecordCreate(action);
 
           expect(watchRecordCreate.next().value)
-            .eql(take(SESSION_SERVERINFO_SUCCESS));
-
-          const serverInfoAction = {
-            serverInfo: {capabilities: {attachments: {}}}
-          };
-
-          expect(watchRecordCreate.next(serverInfoAction).value)
             .eql(take(RECORD_CREATE_REQUEST));
 
           const record = {__attachment__: {}};
@@ -654,16 +651,12 @@ describe("collection sagas", () => {
 
       describe("Attachments disabled", () => {
         it("should watch for the createRecord action", () => {
-          const watchRecordCreate = saga.watchRecordCreate();
+          const action = sessionActions.serverInfoSuccess({
+            capabilities: {}
+          });
+          const watchRecordCreate = saga.watchRecordCreate(action);
 
           expect(watchRecordCreate.next().value)
-            .eql(take(SESSION_SERVERINFO_SUCCESS));
-
-          const serverInfoAction = {
-            serverInfo: {capabilities: {}}
-          };
-
-          expect(watchRecordCreate.next(serverInfoAction).value)
             .eql(take(RECORD_CREATE_REQUEST));
 
           expect(watchRecordCreate.next(
@@ -676,16 +669,12 @@ describe("collection sagas", () => {
     describe("watchRecordUpdate()", () => {
       describe("Attachments enabled", () => {
         it("should watch for the updateRecordWithAttachment action", () => {
-          const watchRecordUpdate = saga.watchRecordUpdate();
+          const action = sessionActions.serverInfoSuccess({
+            capabilities: {attachments: {}}
+          });
+          const watchRecordUpdate = saga.watchRecordUpdate(action);
 
           expect(watchRecordUpdate.next().value)
-            .eql(take(SESSION_SERVERINFO_SUCCESS));
-
-          const serverInfoAction = {
-            serverInfo: {capabilities: {attachments: {}}}
-          };
-
-          expect(watchRecordUpdate.next(serverInfoAction).value)
             .eql(take(RECORD_UPDATE_REQUEST));
 
           const record = {__attachment__: {}};
@@ -697,16 +686,12 @@ describe("collection sagas", () => {
 
       describe("Attachments disabled", () => {
         it("should watch for the updateRecord action", () => {
-          const watchRecordUpdate = saga.watchRecordUpdate();
+          const action = sessionActions.serverInfoSuccess({
+            capabilities: {}
+          });
+          const watchRecordUpdate = saga.watchRecordUpdate(action);
 
           expect(watchRecordUpdate.next().value)
-            .eql(take(SESSION_SERVERINFO_SUCCESS));
-
-          const serverInfoAction = {
-            serverInfo: {capabilities: {}}
-          };
-
-          expect(watchRecordUpdate.next(serverInfoAction).value)
             .eql(take(RECORD_UPDATE_REQUEST));
 
           expect(watchRecordUpdate.next(


### PR DESCRIPTION
Refs #132. Basically when we start watching for record create/update events, we need to check that the server actually supports attachments; to achieve that we wait for the "server information loaded" event to be triggered, then we wait forever for record create/update events. The problem is when you log out and log in again using a different Kinto server, you're still stuck within that neverending loop, and you're processing files using the previous server information. Bad.

So the fix consists on resetting the neverending watchers for create/update record events anytime we receive new server information. Which is precisely the purpose of `takeLatest` http://yelouafi.github.io/redux-saga/docs/api/index.html#takelatestpattern-saga-args

r=? @Natim @leplatrem @glasserc 