### PR TITLE
Fixes #96: Allow editing raw JSON contents for records.

### DIFF
--- a/scripts/components/JSONRecordForm.js
+++ b/scripts/components/JSONRecordForm.js
@@ -32,11 +32,6 @@ export default class JSONRecordForm extends Component {
     const {record, disabled, children} = this.props;
     return (
       <div>
-        {disabled ? null :
-          <div className="alert alert-warning">
-            This collection doesn't have any JSON schema defined, though you can
-            create free-form records entering raw JSON.
-          </div>}
         <Form
           schema={schema}
           formData={record}


### PR DESCRIPTION
This adds links for switching from record HTML form to a raw JSON editor in record record create/edit views. 

Deployed to gh-pages.