### PR TITLE
Saga refactor

### DIFF
--- a/scripts/sagas/index.js
+++ b/scripts/sagas/index.js
@@ -8,7 +8,7 @@ import * as bucketSagas from "./bucket";
 import * as collectionSagas from "./collection";
 
 
-export default function* rootSaga() {
+export default function* rootSaga(getState) {
   yield [
     // session
     fork(sessionSagas.watchSessionSetup),
@@ -29,14 +29,11 @@ export default function* rootSaga() {
     fork(collectionSagas.watchRecordDelete),
     fork(collectionSagas.watchBulkCreateRecords),
     fork(collectionSagas.watchAttachmentDelete),
+    fork(collectionSagas.watchRecordUpdate, getState),
     // Ensure resetting context dependant watchers when context changes
     fork(function* () {
       yield* takeLatest(SESSION_SERVERINFO_SUCCESS,
                         collectionSagas.watchRecordCreate);
-    }),
-    fork(function* () {
-      yield* takeLatest(SESSION_SERVERINFO_SUCCESS,
-                        collectionSagas.watchRecordUpdate);
     }),
   ];
 }

--- a/scripts/store/configureStore.js
+++ b/scripts/store/configureStore.js
@@ -14,6 +14,7 @@ const finalCreateStore = compose(
 
 export default function configureStore(initialState) {
   const store = finalCreateStore(rootReducer, initialState);
-  sagaMiddleware.run(rootSaga);
+  const getState = store.getState.bind(store);
+  sagaMiddleware.run(rootSaga.bind(null, getState));
   return store;
 }

--- a/test/sagas/index_test.js
+++ b/test/sagas/index_test.js
@@ -12,10 +12,11 @@ import configureStore from "../../scripts/store/configureStore";
 
 
 describe("root saga", () => {
-  let sandbox;
+  let sandbox, getState;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    getState = () => {};
   });
 
   afterEach(() => {
@@ -26,7 +27,7 @@ describe("root saga", () => {
     let registered;
 
     beforeEach(() => {
-      registered = rootSaga().next().value;
+      registered = rootSaga(getState).next().value;
     });
 
     it("should register the watchRecordDelete watcher", () => {
@@ -77,6 +78,10 @@ describe("root saga", () => {
       expect(registered).to.include(fork(collectionSagas.watchListRecords));
     });
 
+    it("should register the watchRecordUpdate watcher", () => {
+      expect(registered).to.include(fork(collectionSagas.watchRecordUpdate, getState));
+    });
+
     it("should register the watchRecordDelete watcher", () => {
       expect(registered).to.include(fork(collectionSagas.watchRecordDelete));
     });
@@ -99,16 +104,6 @@ describe("root saga", () => {
       store.dispatch(action);
 
       sinon.assert.calledWithExactly(watchRecordCreate, action);
-    });
-
-    it("should reset the watchRecordUpdate watcher on new session info", () => {
-      const watchRecordUpdate = sandbox.stub(collectionSagas, "watchRecordUpdate");
-      const store = configureStore();
-      const action = {type: SESSION_SERVERINFO_SUCCESS};
-
-      store.dispatch(action);
-
-      sinon.assert.calledWithExactly(watchRecordUpdate, action);
     });
   });
 });


### PR DESCRIPTION
WiP. This patch is about simplifying sagas and making them more powerful and easy to use, by passing them a simple way to access current store state. This will be super useful when we're gonna need to contextually check current state (eg. config, user permissions, etc) during async flows.

The first saga fully leveraging this feature is `updateRecord`, which contextually checks for attachment support. That makes a "rather" short patch to grab feedback from. If the approach is good, I can migrate other sagas as well.

If you look carefully at the `updateRecord` signature, you'll see it accepts `getState` and `action` arguments; this is likely to become the generic signature for *all* sagas, which makes adding new ones a no brainer.

Feedback=? @leplatrem as we discussed this already. 