### PR TITLE
Remove session watchers

### DIFF
--- a/scripts/sagas/index.js
+++ b/scripts/sagas/index.js
@@ -3,8 +3,10 @@ import { fork } from "redux-saga/effects";
 
 import {
   SESSION_SETUP,
+  SESSION_SETUP_COMPLETE,
   SESSION_BUCKETS_REQUEST,
   SESSION_SERVERINFO_SUCCESS,
+  SESSION_LOGOUT,
   BUCKET_CREATE_REQUEST,
   BUCKET_UPDATE_REQUEST,
   BUCKET_DELETE_REQUEST,
@@ -25,10 +27,9 @@ export default function* rootSaga(getState) {
   yield [
     // session
     takeEvery(SESSION_SETUP, sessionSagas.setupSession, getState),
+    takeEvery(SESSION_SETUP_COMPLETE, sessionSagas.handleSessionRedirect, getState),
     takeEvery(SESSION_BUCKETS_REQUEST, sessionSagas.listBuckets, getState),
-    // fork(sessionSagas.watchSessionSetupComplete),
-    // fork(sessionSagas.watchSessionLogout),
-    // fork(sessionSagas.watchSessionBuckets),
+    takeEvery(SESSION_LOGOUT, sessionSagas.sessionLogout, getState),
     // route
     fork(routeSagas.watchRouteUpdated),
     // bucket/collections

--- a/scripts/sagas/index.js
+++ b/scripts/sagas/index.js
@@ -2,6 +2,8 @@ import { takeEvery, takeLatest } from "redux-saga";
 import { fork } from "redux-saga/effects";
 
 import {
+  SESSION_SETUP,
+  SESSION_BUCKETS_REQUEST,
   SESSION_SERVERINFO_SUCCESS,
   BUCKET_CREATE_REQUEST,
   BUCKET_UPDATE_REQUEST,
@@ -22,10 +24,11 @@ import * as collectionSagas from "./collection";
 export default function* rootSaga(getState) {
   yield [
     // session
-    fork(sessionSagas.watchSessionSetup),
-    fork(sessionSagas.watchSessionSetupComplete),
-    fork(sessionSagas.watchSessionLogout),
-    fork(sessionSagas.watchSessionBuckets),
+    takeEvery(SESSION_SETUP, sessionSagas.setupSession, getState),
+    takeEvery(SESSION_BUCKETS_REQUEST, sessionSagas.listBuckets, getState),
+    // fork(sessionSagas.watchSessionSetupComplete),
+    // fork(sessionSagas.watchSessionLogout),
+    // fork(sessionSagas.watchSessionBuckets),
     // route
     fork(routeSagas.watchRouteUpdated),
     // bucket/collections

--- a/scripts/sagas/session.js
+++ b/scripts/sagas/session.js
@@ -1,12 +1,6 @@
 import { push as updatePath } from "react-router-redux";
-import { call, take, fork, put } from "redux-saga/effects";
+import { call, put } from "redux-saga/effects";
 
-import {
-  SESSION_SETUP,
-  SESSION_SETUP_COMPLETE,
-  SESSION_BUCKETS_REQUEST,
-  SESSION_LOGOUT,
-} from "../constants";
 import * as notificationActions from "../actions/notifications";
 import * as sessionActions from "../actions/session";
 import { getClient, setupClient, resetClient } from "../client";
@@ -29,9 +23,8 @@ export function* setupSession(getState, action) {
 
 export function* handleSessionRedirect(getState, action) {
   const {session} = action;
-  const {redirectURL} = session;
-  if (redirectURL) {
-    yield put(updatePath(redirectURL));
+  if (session.redirectURL) {
+    yield put(updatePath(session.redirectURL));
     yield put(sessionActions.storeRedirectURL(null));
   }
 }

--- a/test/sagas/index_test.js
+++ b/test/sagas/index_test.js
@@ -1,86 +1,53 @@
 import { expect } from "chai";
 import sinon from "sinon";
-import { fork } from "redux-saga/effects";
 
 import { SESSION_SERVERINFO_SUCCESS } from "../../scripts/constants";
-const routeSagas = require("../../scripts/sagas/route");
+// const routeSagas = require("../../scripts/sagas/route");
 const sessionSagas = require("../../scripts/sagas/session");
 const bucketSagas = require("../../scripts/sagas/bucket");
 const collectionSagas = require("../../scripts/sagas/collection");
-import rootSaga from "../../scripts/sagas";
 import configureStore from "../../scripts/store/configureStore";
 
+import * as sessionActions from "../../scripts/actions/session";
 import * as bucketActions from "../../scripts/actions/bucket";
 
 
+function expectSagaCalled(saga, action) {
+  // Note: the rootSaga function is called by configureStore
+  configureStore().dispatch(action);
+
+  expect(saga.firstCall.args[0].name).eql("bound getState");
+  expect(saga.firstCall.args[1]).eql(action);
+}
+
 describe("root saga", () => {
-  let sandbox, getState;
+  let sandbox;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    getState = () => {};
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  describe("Watchers registration", function() {
-    let registered;
+  describe("Session watchers registration", () => {
+    it("should watch for the setup action", () => {
+      const saga = sandbox.stub(sessionSagas, "setupSession");
+      const action = sessionActions.setup();
 
-    beforeEach(() => {
-      registered = rootSaga(getState).next().value;
+      expectSagaCalled(saga, action);
     });
 
-    it("should register the watchRecordDelete watcher", () => {
-      expect(registered).to.include(fork(sessionSagas.watchSessionSetup));
-    });
+    it("should watch for the listBuckets action", () => {
+      const saga = sandbox.stub(sessionSagas, "listBuckets");
+      const action = sessionActions.listBuckets();
 
-    it("should register the watchRecordDelete watcher", () => {
-      expect(registered).to.include(fork(sessionSagas.watchSessionSetupComplete));
-    });
-
-    it("should register the watchRecordDelete watcher", () => {
-      expect(registered).to.include(fork(sessionSagas.watchSessionLogout));
-    });
-
-    it("should register the watchRecordDelete watcher", () => {
-      expect(registered).to.include(fork(sessionSagas.watchSessionBuckets));
-    });
-
-    it("should register the watchRouteUpdated watcher", () => {
-      expect(registered).to.include(fork(routeSagas.watchRouteUpdated));
-    });
-
-    it("should register the watchListRecords watcher", () => {
-      expect(registered).to.include(fork(collectionSagas.watchListRecords));
-    });
-
-    it("should register the watchRecordUpdate watcher", () => {
-      expect(registered).to.include(fork(collectionSagas.watchRecordUpdate, getState));
-    });
-
-    it("should register the watchRecordDelete watcher", () => {
-      expect(registered).to.include(fork(collectionSagas.watchRecordDelete));
-    });
-
-    it("should register the watchBulkCreateRecords watcher", () => {
-      expect(registered).to.include(fork(collectionSagas.watchBulkCreateRecords));
-    });
-
-    it("should register the watchAttachmentDelete watcher", () => {
-      expect(registered).to.include(fork(collectionSagas.watchAttachmentDelete));
+      expectSagaCalled(saga, action);
     });
   });
 
   describe("Bucket watchers registration", () => {
-    function expectSagaCalled(saga, action) {
-      configureStore().dispatch(action);
-
-      expect(saga.firstCall.args[0].name).eql("bound getState");
-      expect(saga.firstCall.args[1]).eql(action);
-    }
-
     it("should watch for the createBucket action", () => {
       const saga = sandbox.stub(bucketSagas, "createBucket");
       const action = bucketActions.createBucket();

--- a/test/sagas/index_test.js
+++ b/test/sagas/index_test.js
@@ -45,6 +45,13 @@ describe("root saga", () => {
 
       expectSagaCalled(saga, action);
     });
+
+    it("should watch for the setupComplete action", () => {
+      const saga = sandbox.stub(sessionSagas, "handleSessionRedirect");
+      const action = sessionActions.setupComplete();
+
+      expectSagaCalled(saga, action);
+    });
   });
 
   describe("Bucket watchers registration", () => {

--- a/test/sagas/session_test.js
+++ b/test/sagas/session_test.js
@@ -1,13 +1,7 @@
 import { expect } from "chai";
 import { push as updatePath } from "react-router-redux";
-import { take, fork, put, call } from "redux-saga/effects";
+import { put, call } from "redux-saga/effects";
 
-import {
-  SESSION_SETUP,
-  SESSION_SETUP_COMPLETE,
-  SESSION_BUCKETS_REQUEST,
-  SESSION_LOGOUT,
-} from "../../scripts/constants";
 import { notifyError } from "../../scripts/actions/notifications";
 import * as actions from "../../scripts/actions/session";
 import * as saga from "../../scripts/sagas/session";
@@ -26,7 +20,8 @@ describe("session sagas", () => {
 
     before(() => {
       resetClient();
-      setupSession = saga.setupSession(session);
+      const action = actions.setup(session);
+      setupSession = saga.setupSession(() => {}, action);
       setupSession.next();
     });
 
@@ -55,24 +50,6 @@ describe("session sagas", () => {
     });
   });
 
-  describe("sessionLogout()", () => {
-    let sessionLogout;
-
-    before(() => {
-      setClient({fake: true});
-      sessionLogout = saga.sessionLogout();
-    });
-
-    it("should redirect to the homepage", () => {
-      expect(sessionLogout.next().value)
-        .eql(put(updatePath("/")));
-    });
-
-    it("should reset the client", () => {
-      expect(() => getClient()).to.throw(Error, /not configured/);
-    });
-  });
-
   describe("listBuckets()", () => {
     describe("Success", () => {
       let client, listBuckets;
@@ -89,7 +66,8 @@ describe("session sagas", () => {
           fetchServerInfo() {},
           listBuckets() {}
         });
-        listBuckets = saga.listBuckets();
+        const action = actions.listBuckets();
+        listBuckets = saga.listBuckets(() => {}, action);
       });
 
       it("should fetch server information", () => {
@@ -150,7 +128,8 @@ describe("session sagas", () => {
     let handleSessionRedirect;
 
     before(() => {
-      handleSessionRedirect = saga.handleSessionRedirect({redirectURL: "/blah"});
+      const action = actions.
+      handleSessionRedirect = saga.handleSessionRedirect(() =>  {}, action);
     });
 
     it("should redirect to redirectURL", () => {
@@ -164,55 +143,22 @@ describe("session sagas", () => {
     });
   });
 
-  // Watchers
+  describe("sessionLogout()", () => {
+    let sessionLogout;
 
-  describe("Watchers", () => {
-    describe("watchSessionSetup()", () => {
-      it("should watch for the setup action", () => {
-        const watchSessionSetup = saga.watchSessionSetup();
-
-        expect(watchSessionSetup.next().value)
-          .eql(take(SESSION_SETUP));
-
-        expect(watchSessionSetup.next(actions.setup(session)).value)
-          .eql(fork(saga.setupSession, session));
-      });
+    before(() => {
+      setClient({fake: true});
+      const action = actions.logout();
+      sessionLogout = saga.sessionLogout(() => {}, action);
     });
 
-    describe("watchSessionSetupComplete()", () => {
-      it("should watch for the setupComplete action", () => {
-        const watchSessionSetupComplete = saga.watchSessionSetupComplete();
-
-        expect(watchSessionSetupComplete.next().value)
-          .eql(take(SESSION_SETUP_COMPLETE));
-
-        expect(watchSessionSetupComplete.next({session: {}}).value)
-          .eql(fork(saga.handleSessionRedirect, {}));
-      });
+    it("should redirect to the homepage", () => {
+      expect(sessionLogout.next().value)
+        .eql(put(updatePath("/")));
     });
 
-    describe("watchSessionBuckets()", () => {
-      it("should watch for the listBuckets action", () => {
-        const watchSessionBuckets = saga.watchSessionBuckets();
-
-        expect(watchSessionBuckets.next().value)
-          .eql(take(SESSION_BUCKETS_REQUEST));
-
-        expect(watchSessionBuckets.next(actions.listBuckets()).value)
-          .eql(fork(saga.listBuckets));
-      });
-    });
-
-    describe("watchSessionLogout()", () => {
-      it("should watch for the logout action", () => {
-        const watchSessionLogout = saga.watchSessionLogout();
-
-        expect(watchSessionLogout.next().value)
-          .eql(take(SESSION_LOGOUT));
-
-        expect(watchSessionLogout.next(actions.logout()).value)
-          .eql(fork(saga.sessionLogout));
-      });
+    it("should reset the client", () => {
+      expect(() => getClient()).to.throw(Error, /not configured/);
     });
   });
 });

--- a/test/sagas/session_test.js
+++ b/test/sagas/session_test.js
@@ -128,7 +128,7 @@ describe("session sagas", () => {
     let handleSessionRedirect;
 
     before(() => {
-      const action = actions.
+      const action = actions.setupComplete({redirectURL: "/blah"});
       handleSessionRedirect = saga.handleSessionRedirect(() =>  {}, action);
     });
 


### PR DESCRIPTION
This is pursuing the work started with #156 and #157, moves the session saga watchers to the root saga and update the saga signatures to receive `getState` and the full action payload.

r=? @glasserc @Natim 