### PR TITLE
Fix broken listBuckets operations.

### DIFF
--- a/scripts/sagas/bucket.js
+++ b/scripts/sagas/bucket.js
@@ -3,10 +3,9 @@ import { call, put } from "redux-saga/effects";
 
 import { getClient } from "../client";
 import { notifySuccess, notifyError } from "../actions/notifications";
-import { sessionBusy } from "../actions/session";
+import { sessionBusy, listBuckets } from "../actions/session";
 import { bucketLoadSuccess } from "../actions/bucket";
 import { collectionLoadSuccess } from "../actions/collection";
-import { listBuckets } from "./session";
 
 
 function getBucket(bid) {
@@ -23,7 +22,7 @@ export function* createBucket(getState, action) {
     const client = getClient();
     yield put(sessionBusy(true));
     yield call([client, client.createBucket], bid, {data});
-    yield call(listBuckets);
+    yield put(listBuckets());
     yield put(updatePath(`/buckets/${bid}/edit`));
     yield put(notifySuccess("Bucket created."));
   } catch(error) {
@@ -54,7 +53,7 @@ export function* deleteBucket(getState, action) {
     const client = getClient();
     yield put(sessionBusy(true));
     yield call([client, client.deleteBucket], bid);
-    yield call(listBuckets);
+    yield put(listBuckets());
     yield put(updatePath("/"));
     yield put(notifySuccess("Bucket deleted."));
   } catch(error) {
@@ -81,7 +80,7 @@ export function* createCollection(getState, action) {
     });
     yield put(updatePath(`/buckets/${bid}/collections/${name}`));
     yield put(notifySuccess("Collection created."));
-    yield call(listBuckets);
+    yield put(listBuckets());
   } catch(error) {
     yield put(notifyError(error));
   }
@@ -107,7 +106,7 @@ export function* deleteCollection(getState, action) {
     yield call([bucket, bucket.deleteCollection], cid);
     yield put(updatePath(""));
     yield put(notifySuccess("Collection deleted."));
-    yield call(listBuckets);
+    yield put(listBuckets());
   } catch(error) {
     yield put(notifyError(error));
   }

--- a/test/sagas/bucket_test.js
+++ b/test/sagas/bucket_test.js
@@ -6,7 +6,6 @@ import { notifyError, notifySuccess } from "../../scripts/actions/notifications"
 import * as sessionActions from "../../scripts/actions/session";
 import * as collectionActions from "../../scripts/actions/collection";
 import * as actions from "../../scripts/actions/bucket";
-import { listBuckets } from "../../scripts/sagas/session";
 import * as saga from "../../scripts/sagas/bucket";
 import { setClient } from "../../scripts/client";
 
@@ -42,7 +41,7 @@ describe("bucket sagas", () => {
 
       it("should reload the list of buckets/collections", () => {
         expect(createBucket.next().value)
-          .eql(call(listBuckets));
+          .eql(put(sessionActions.listBuckets()));
       });
 
       it("should update the route path", () => {
@@ -170,7 +169,7 @@ describe("bucket sagas", () => {
 
       it("should reload the list of buckets/collections", () => {
         expect(deleteBucket.next().value)
-          .eql(call(listBuckets));
+          .eql(put(sessionActions.listBuckets()));
       });
 
       it("should update the route path", () => {
@@ -243,7 +242,7 @@ describe("bucket sagas", () => {
 
       it("should reload the list of buckets/collections", () => {
         expect(createCollection.next().value)
-          .eql(call(listBuckets));
+          .eql(put(sessionActions.listBuckets()));
       });
     });
 
@@ -345,7 +344,7 @@ describe("bucket sagas", () => {
 
       it("should reload the list of buckets/collections", () => {
         expect(deleteCollection.next().value)
-          .eql(call(listBuckets));
+          .eql(put(sessionActions.listBuckets()));
       });
     });
 


### PR DESCRIPTION
This fixes a breakage on current master where the list of buckets and collections are not properly refreshed after a transactional operation is performed. This has been introduced by #174.