### PR TITLE
Upgrade kinto-http.js to v2.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "codemirror": "^5.13.2",
     "express": "^4.14.0",
     "filesize": "^3.3.0",
-    "kinto-http": "^2.1.1",
+    "kinto-http": "^2.2.0",
     "node-fs-extra": "^0.8.1",
     "react": "^15.2.0",
     "react-codemirror": "^0.2.3",

--- a/scripts/client.js
+++ b/scripts/client.js
@@ -3,7 +3,6 @@
 import type { AuthData } from "./types";
 
 import KintoClient from "kinto-http";
-import { isHTTPok } from "./utils";
 
 
 let client: ?KintoClient;
@@ -45,29 +44,4 @@ export function setClient(_client: KintoClient): KintoClient {
 
 export function resetClient(): void {
   client = null;
-}
-
-export function requestPermissions(): Promise {
-  const client: KintoClient = getClient();
-  if (!client) {
-    throw new Error("Client is not configured.");
-  }
-  const {remote, defaultReqOptions}: {
-    remote: string,
-    defaultReqOptions: {
-      headers: Object
-    }
-  } = client;
-  return fetch(`${remote}/permissions`, {
-    headers: defaultReqOptions.headers,
-  })
-    .then((res) => {
-      if (!isHTTPok(res.status)) {
-        throw new Error("HTTP ${status}");
-      }
-      return res.json();
-    })
-    .catch(({message}) => {
-      throw new Error(`Unable to request the permissions endpoint: ${message}`);
-    });
 }

--- a/scripts/sagas/session.js
+++ b/scripts/sagas/session.js
@@ -5,7 +5,7 @@ import * as notificationActions from "../actions/notifications";
 import * as sessionActions from "../actions/session";
 import * as historyActions from "../actions/history";
 import { clone } from "../utils";
-import { getClient, setupClient, resetClient, requestPermissions } from "../client";
+import { getClient, setupClient, resetClient } from "../client";
 
 
 export function* setupSession(getState, action) {
@@ -43,7 +43,7 @@ function handlePermissions(buckets, permissions) {
 
   // Augment the list of bucket and collections with the ones retrieved from
   // the /permissions endpoint
-  for (const permission of permissions.data) {
+  for (const permission of permissions) {
     // Add any missing bucket to the current list
     let bucket = bucketsCopy.find(x => x.id === permission.bucket_id);
     if (!bucket) {
@@ -86,7 +86,7 @@ export function* listBuckets(getState, action) {
 
     // If the Kinto API version allows it, retrieves all permissions
     if ("permissions_endpoint" in serverInfo.capabilities) {
-      const permissions = yield call(requestPermissions);
+      const {data: permissions} = yield call([client, client.listPermissions]);
       buckets = handlePermissions(buckets, permissions);
     }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -27,10 +27,6 @@ export function validJSON(string: string): boolean {
   }
 }
 
-export function isHTTPok(status: number): boolean {
-  return [1, 2, 3].some((c: number) => String(status).startsWith(String(c)));
-}
-
 export function validateSchema(jsonSchema: string) {
   let schema: Object;
   try {

--- a/test/sagas/session_test.js
+++ b/test/sagas/session_test.js
@@ -6,12 +6,7 @@ import { notifyError } from "../../scripts/actions/notifications";
 import * as actions from "../../scripts/actions/session";
 import * as historyActions from "../../scripts/actions/history";
 import * as saga from "../../scripts/sagas/session";
-import {
-  getClient,
-  setClient,
-  resetClient,
-  requestPermissions
-} from "../../scripts/client";
+import { getClient, setClient, resetClient } from "../../scripts/client";
 
 
 const session = {
@@ -73,7 +68,8 @@ describe("session sagas", () => {
         client = setClient({
           batch() {},
           fetchServerInfo() {},
-          listBuckets() {}
+          listBuckets() {},
+          listPermissions() {},
         });
         const getState = () => ({
           session: {
@@ -119,7 +115,7 @@ describe("session sagas", () => {
         ];
 
         expect(listBuckets.next(responses).value)
-          .eql(call(requestPermissions));
+          .eql(call([client, client.listPermissions]));
       });
 
       it("should dispatch the list of buckets", () => {


### PR DESCRIPTION
This upgrades kinto-http.js to [v2.2.0](https://github.com/Kinto/kinto-http.js/releases/tag/v2.2.0) and leverages the new `listPermissions()` method.

r=? @leplatrem 
