### PR TITLE
Implement a signoff request button in the builtin signoff plugin

### DIFF
--- a/interfaces/external-modules/react-jsonschema-form.d.js
+++ b/interfaces/external-modules/react-jsonschema-form.d.js
@@ -1,0 +1,4 @@
+declare module "react-jsonschema-form/lib/utils" {
+  declare function mergeObjects(): Object;
+  declare var exports: mergeObjects;
+}

--- a/plugins/example/index.js
+++ b/plugins/example/index.js
@@ -49,8 +49,12 @@ function* testSaga(getState, action) {
 }
 
 // Plugin exports
-export const routes = [
+const routes = [
   {path: "/test/plugin", components: {content: TestPluginContainer}}
+];
+
+const sagas = [
+  [takeEvery, PLUGIN_ACTION_REQUEST, testSaga]
 ];
 
 export const reducers = {
@@ -66,6 +70,10 @@ export const reducers = {
   }
 };
 
-export const sagas = [
-  [takeEvery, PLUGIN_ACTION_REQUEST, testSaga]
-];
+export function register(store) {
+  return {
+    routes,
+    reducers,
+    sagas,
+  };
+}

--- a/plugins/example/index.js
+++ b/plugins/example/index.js
@@ -53,7 +53,7 @@ const routes = [
   {path: "/test/plugin", components: {content: TestPluginContainer}}
 ];
 
-const sagas = [
+export const sagas = [
   [takeEvery, PLUGIN_ACTION_REQUEST, testSaga]
 ];
 
@@ -72,8 +72,6 @@ export const reducers = {
 
 export function register(store) {
   return {
-    routes,
-    reducers,
-    sagas,
+    routes
   };
 }

--- a/plugins/signoff/index.js
+++ b/plugins/signoff/index.js
@@ -21,7 +21,7 @@ class Signoff extends React.Component {
   }
 }
 
-export const routes = [
+const routes = [
   {
     path: "/buckets/:bid/collections/:cid/signoff",
     components: {
@@ -30,14 +30,28 @@ export const routes = [
   }
 ];
 
-export const hooks = {
-  CollectionList: {
-    ListActions: [
-      <a key="request-signoff-btn" className="btn btn-info" href="#">Request signoff</a>
-    ]
-  }
-};
-
-export const sagas = [];
+const sagas = [];
 
 export const reducers = {};
+
+export function register(store) {
+  const hooks = {
+    CollectionList: {
+      ListActions: [
+        <a key="request-signoff-btn"
+           className="btn btn-info"
+           href="#"
+           onClick={(event) => {
+             event.preventDefault();
+             store.dispatch(requestSignoff());
+           }}>Request signoff</a>
+      ]
+    }
+  };
+
+  return {
+    routes,
+    sagas,
+    hooks,
+  };
+}

--- a/plugins/signoff/index.js
+++ b/plugins/signoff/index.js
@@ -1,7 +1,13 @@
 import React from "react";
 
 
-// Plugin view root container component
+const PLUGIN_SIGNOFF_REQUEST = "PLUGIN_SIGNOFF_REQUEST";
+
+// Actions
+function requestSignoff() {
+  return {type: PLUGIN_SIGNOFF_REQUEST};
+}
+
 class Signoff extends React.Component {
   render() {
     const {params} = this.props;
@@ -23,6 +29,14 @@ export const routes = [
     }
   }
 ];
+
+export const hooks = {
+  CollectionList: {
+    ListActions: [
+      <a key="request-signoff-btn" className="btn btn-info" href="#">Request signoff</a>
+    ]
+  }
+};
 
 export const sagas = [];
 

--- a/plugins/signoff/index.js
+++ b/plugins/signoff/index.js
@@ -1,4 +1,9 @@
 import React from "react";
+import { takeEvery } from "redux-saga";
+import { call, put } from "redux-saga/effects";
+
+import { getClient } from "../../scripts/client";
+import { notifySuccess, notifyError } from "../../scripts/actions/notifications";
 
 
 const PLUGIN_SIGNOFF_REQUEST = "PLUGIN_SIGNOFF_REQUEST";
@@ -8,29 +13,60 @@ function requestSignoff() {
   return {type: PLUGIN_SIGNOFF_REQUEST};
 }
 
-class Signoff extends React.Component {
+
+function* handleSignoffRequest(getState, action) {
+  // Obtain current bucket and collection ids from state.
+  const {collection:collectionState} = getState();
+  const {bucket: bid, name: cid} = collectionState;
+
+  // XXX: Currently the signoff feature does not exist on the server.
+  // Meanwhile we will just trigger a signature.
+  const client = getClient();
+  // Set "status" metadata to trigger the signature.
+  const coll = client.bucket(bid).collection(cid);
+  try {
+    yield call([coll, coll.setData], {status: "to-sign"}, {patch: true});
+    yield put(notifySuccess("Signature requested."));
+  } catch (e) {
+    yield put(notifyError(e));
+  }
+}
+
+
+class SignoffButton extends React.Component {
   render() {
-    const {params} = this.props;
-    const {bid, cid} = params;
+    const {getState, dispatch} = this.props;
+    const {collection:collectionState, session: sessionState} = getState();
+    const {serverInfo} = sessionState;
+    const {bucket: bid, name: cid} = collectionState;
+
+    // Hide button if server does not support signoff.
+    const capability = serverInfo.capabilities.signer;
+    if (!capability) {
+      return null;
+    }
+
+    // Hide button if this collection is not configured to be signed.
+    const sources = capability.resources.map((r) => `${r.source.bucket}/${r.source.collection}`);
+    if (!sources.includes(`${bid}/${cid}`)) {
+      return null;
+    }
+
     return (
-      <div>
-        <h1>Signoff the <b>{bid}/{cid}</b> collection</h1>
-        <p>In the future, you'll be able to sign off this collection here.</p>
-      </div>
+      <a className="btn btn-info"
+         href="#"
+         onClick={(event) => {
+           event.preventDefault();
+           dispatch(requestSignoff());
+         }}>Request signoff</a>
     );
   }
 }
 
-const routes = [
-  {
-    path: "/buckets/:bid/collections/:cid/signoff",
-    components: {
-      content: Signoff
-    }
-  }
-];
 
-const sagas = [];
+export const sagas = [
+  [takeEvery, PLUGIN_SIGNOFF_REQUEST, handleSignoffRequest]
+];
 
 export const reducers = {};
 
@@ -38,20 +74,14 @@ export function register(store) {
   const hooks = {
     CollectionList: {
       ListActions: [
-        <a key="request-signoff-btn"
-           className="btn btn-info"
-           href="#"
-           onClick={(event) => {
-             event.preventDefault();
-             store.dispatch(requestSignoff());
-           }}>Request signoff</a>
+        <SignoffButton key="request-signoff-btn"
+                       getState={store.getState.bind(store)}
+                       dispatch={store.dispatch.bind(store)} />
       ]
     }
   };
 
   return {
-    routes,
-    sagas,
     hooks,
   };
 }

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -15,6 +15,8 @@ import "../css/styles.css";
 export function createAdmin(plugins=[]) {
   const store = configureStore({}, plugins);
 
+  const registerPlugins = plugins.map(plugin => plugin.register(store));
+
   syncHistoryWithStore(hashHistory, store);
 
   function onRouteUpdate() {
@@ -25,7 +27,7 @@ export function createAdmin(plugins=[]) {
   const component = (
     <Provider store={store}>
       <Router history={hashHistory} onUpdate={onRouteUpdate}>
-        {getRoutes(store, plugins)}
+        {getRoutes(store, registerPlugins)}
       </Router>
     </Provider>
   );

--- a/scripts/components/CollectionList.js
+++ b/scripts/components/CollectionList.js
@@ -11,7 +11,7 @@ class Row extends Component {
     schema: {},
     displayFields: ["__json"],
     record: {},
-  }
+  };
 
   get lastModified() {
     const lastModified = this.props.record.last_modified;
@@ -229,6 +229,10 @@ function ListActions(props) {
 }
 
 export default class CollectionList extends Component {
+  // This is useful to identify wrapped component for plugin hooks when code is
+  // minified; see https://github.com/facebook/react/issues/4915
+  static displayName = "CollectionList";
+
   updateSort = (sort) => {
     const {params, listRecords} = this.props;
     const {bid, cid} = params;

--- a/scripts/components/CollectionList.js
+++ b/scripts/components/CollectionList.js
@@ -201,20 +201,21 @@ class Table extends Component {
 }
 
 function ListActions(props) {
-  const {bid, cid, session, collection} = props;
+  const {bid, cid, session, collection, hooks=[]} = props;
   if (session.busy || collection.busy) {
     return null;
   }
+  const defaultButtons = [
+    <Link key="__1" to={`/buckets/${bid}/collections/${cid}/add`}
+          className="btn btn-info btn-record-add">Add</Link>,
+    <Link key="__2" to={`/buckets/${bid}/collections/${cid}/bulk`}
+          className="btn btn-info btn-record-bulk-add">Bulk add</Link>,
+  ];
   return (
     <div className="row list-actions">
       <div className="col-xs-8">
         {canCreateRecord(session, collection) ?
-          <div>
-            <Link to={`/buckets/${bid}/collections/${cid}/add`}
-              className="btn btn-info btn-record-add">Add</Link>
-            <Link to={`/buckets/${bid}/collections/${cid}/bulk`}
-              className="btn btn-info btn-record-bulk-add">Bulk add</Link>
-          </div> : null}
+          [...defaultButtons, ...hooks] : null}
       </div>
       <div className="edit-coll-props col-xs-4 text-right">
         <Link to={`/buckets/${bid}/collections/${cid}/edit`}
@@ -241,6 +242,7 @@ export default class CollectionList extends Component {
       collection,
       deleteRecord,
       updatePath,
+      pluginHooks,
     } = this.props;
     const {bid, cid} = params;
     const {
@@ -258,7 +260,8 @@ export default class CollectionList extends Component {
         bid={bid}
         cid={cid}
         session={session}
-        collection={collection} />
+        collection={collection}
+        hooks={pluginHooks.ListActions} />
     );
 
     return (

--- a/scripts/components/Notifications.js
+++ b/scripts/components/Notifications.js
@@ -52,6 +52,10 @@ export class Notification extends Component {
 }
 
 export default class Notifications extends Component {
+  // This is useful to identify wrapped component for plugin hooks when code is
+  // minified; see https://github.com/facebook/react/issues/4915
+  static displayName = "Notifications";
+
   render() {
     const {notifications, removeNotification} = this.props;
     if (!notifications.length) {

--- a/scripts/components/Sidebar.js
+++ b/scripts/components/Sidebar.js
@@ -87,6 +87,10 @@ function BucketsMenu(props) {
 }
 
 export default class Sidebar extends Component {
+  // This is useful to identify wrapped component for plugin hooks when code is
+  // minified; see https://github.com/facebook/react/issues/4915
+  static displayName = "Sidebar";
+
   render() {
     const {session, params, location} = this.props;
     const {bid, cid} = params;

--- a/scripts/containers/CollectionListPage.js
+++ b/scripts/containers/CollectionListPage.js
@@ -5,6 +5,7 @@ import * as CollectionActions from "../actions/collection";
 import * as NotificationsActions from "../actions/notifications";
 import { push as updatePath } from "react-router-redux";
 
+
 function mapStateToProps(state) {
   return {
     collection: state.collection,

--- a/scripts/plugin.js
+++ b/scripts/plugin.js
@@ -26,14 +26,14 @@ export function flattenPluginsRoutes(
 }
 
 export function flattenPluginsSagas(
-  plugins: Object[],
+  pluginsSagas: Array<Array<any>>,
   getState: Function
 ): Object[] {
-  return plugins.reduce((acc, {sagas:sagaDefs = []}) => {
+  return pluginsSagas.reduce((acc, sagaDefs = []) => {
     // Create the saga watchers for this plugin, passing them the getState
     // function
-    const sagas = sagaDefs.map(([fn, ...args]) => fn(...args, getState));
-    return [...acc, ...sagas];
+    const pluginSagas = sagaDefs.map(([fn, ...args]) => fn(...args, getState));
+    return [...acc, ...pluginSagas];
   }, []);
 }
 
@@ -62,13 +62,13 @@ function extendReducers(pluginReducers, standardReducers) {
 }
 
 export function flattenPluginsReducers(
-  plugins: Object[],
+  pluginsReducers: Object[],
   standardReducers: Object
 ): Object {
   // standardReducers contain the kinto-admin core reducers; each plugin
   // will extend their reducers against these, so a plugin will never extend
   // another plugin reducer.
-  return plugins.reduce((acc, {reducers: pluginReducers = {}}) => ({
+  return pluginsReducers.reduce((acc, pluginReducers = {}) => ({
     ...acc,
     ...extendReducers(pluginReducers, standardReducers)
   }), {});

--- a/scripts/plugin.js
+++ b/scripts/plugin.js
@@ -12,8 +12,8 @@ export function flattenPluginsRoutes(
   plugins: Object[],
   defaultComponents: Object
 ): Object[] {
-  return plugins.reduce((routes, plugin) => {
-    const pluginRoutes = plugin.routes.map((route, key) => {
+  return plugins.reduce((acc, {routes=[]}) => {
+    const pluginRoutes = routes.map((route, key) => {
       const {components, ...props} = route;
       return (
         <Route key={key}
@@ -21,7 +21,7 @@ export function flattenPluginsRoutes(
                {...props} />
       );
     });
-    return [...routes, ...pluginRoutes];
+    return [...acc, ...pluginRoutes];
   }, []);
 }
 

--- a/scripts/reducers/index.js
+++ b/scripts/reducers/index.js
@@ -22,9 +22,9 @@ const standardReducers = {
   history,
 };
 
-export default function createRootReducer(plugins: Object[] = []) {
+export default function createRootReducer(pluginsReducers: Object[] = []) {
   return combineReducers({
     ...standardReducers,
-    ...flattenPluginsReducers(plugins, standardReducers),
+    ...flattenPluginsReducers(pluginsReducers, standardReducers),
   });
 }

--- a/scripts/sagas/index.js
+++ b/scripts/sagas/index.js
@@ -11,9 +11,9 @@ import * as collectionSagas from "./collection";
  * Registers saga watchers.
  *
  * @param {Function} getState Function to obtain the current store state.
- * @param {Array}    plugins  The list of plugins.
+ * @param {Array}    sagas  The list of plugin sagas.
  */
-export default function* rootSaga(getState, plugins=[]) {
+export default function* rootSaga(getState, pluginsSagas=[]) {
   const standardSagas = [
     // session
     takeEvery(c.SESSION_SETUP, sessionSagas.setupSession, getState),
@@ -39,5 +39,5 @@ export default function* rootSaga(getState, plugins=[]) {
     takeEvery(c.ATTACHMENT_DELETE_REQUEST, collectionSagas.deleteAttachment, getState),
   ];
 
-  yield [...standardSagas, ...flattenPluginsSagas(plugins, getState)];
+  yield [...standardSagas, ...flattenPluginsSagas(pluginsSagas, getState)];
 }

--- a/scripts/store/configureStore.js
+++ b/scripts/store/configureStore.js
@@ -14,8 +14,11 @@ const finalCreateStore = compose(
 )(createStore);
 
 export default function configureStore(initialState, plugins=[]) {
+  // Each plugin exports a `reducers` attribute.
   const pluginReducers = plugins.map(({reducers={}}) => reducers);
+  // Each plugin exports a `sagas` attribute.
   const pluginSagas = plugins.map(({sagas=[]}) => sagas);
+
   const store = finalCreateStore(createRootReducer(pluginReducers), initialState);
   // Every saga will receive the store getState() function as first argument
   // by default; this allows sagas to share the same signature and access the

--- a/scripts/store/configureStore.js
+++ b/scripts/store/configureStore.js
@@ -14,10 +14,12 @@ const finalCreateStore = compose(
 )(createStore);
 
 export default function configureStore(initialState, plugins=[]) {
-  const store = finalCreateStore(createRootReducer(plugins), initialState);
+  const pluginReducers = plugins.map(({reducers={}}) => reducers);
+  const pluginSagas = plugins.map(({sagas=[]}) => sagas);
+  const store = finalCreateStore(createRootReducer(pluginReducers), initialState);
   // Every saga will receive the store getState() function as first argument
   // by default; this allows sagas to share the same signature and access the
   // state consistently.
-  sagaMiddleware.run(rootSaga, store.getState.bind(store), plugins);
+  sagaMiddleware.run(rootSaga, store.getState.bind(store), pluginSagas);
   return store;
 }

--- a/test/components/CollectionList_test.js
+++ b/test/components/CollectionList_test.js
@@ -42,6 +42,7 @@ describe("CollectionList component", () => {
       node = createComponent(CollectionList, {
         params: {bid: "bucket", cid: "collection"},
         session: {authenticated: true, serverInfo: {user: {id: "plop"}}},
+        pluginHooks: {},
         collection,
       });
     });
@@ -80,6 +81,7 @@ describe("CollectionList component", () => {
       node = createComponent(CollectionList, {
         params: {bid: "bucket", cid: "collection"},
         session: {authenticated: true, serverInfo: {user: {id: "plop"}}},
+        pluginHooks: {},
         collection,
       });
     });
@@ -123,6 +125,7 @@ describe("CollectionList component", () => {
         node = createComponent(CollectionList, {
           params: {bid: "bucket", cid: "collection"},
           session: {authenticated: true, serverInfo: {user: {id: "basicauth:plop"}}},
+          pluginHooks: {},
           collection,
         });
       });
@@ -156,6 +159,7 @@ describe("CollectionList component", () => {
         node = createComponent(CollectionList, {
           params: {bid: "bucket", cid: "collection"},
           session: {authenticated: true, serverInfo: {user: {id: "basicauth:plop"}}},
+          pluginHooks: {},
           collection,
         });
       });

--- a/test/plugin_test.js
+++ b/test/plugin_test.js
@@ -67,17 +67,13 @@ describe("Plugin API", () => {
     function* saga2() { yield 2; }
     function* saga3() { yield 3; }
     const plugins = [
-      {
-        sagas: [
-          [takeEvery, "ACTION_1", saga1],
-          [takeEvery, "ACTION_2", saga2],
-        ]
-      },
-      {
-        sagas: [
-          [takeEvery, "ACTION_3", saga3],
-        ]
-      },
+      [
+        [takeEvery, "ACTION_1", saga1],
+        [takeEvery, "ACTION_2", saga2],
+      ],
+      [
+        [takeEvery, "ACTION_3", saga3],
+      ],
     ];
 
     it("should append the plugins sagas to the standard watchers", () => {
@@ -93,16 +89,12 @@ describe("Plugin API", () => {
   describe("flattenPluginsReducers()", () => {
     const plugins = [
       {
-        reducers: {
-          foo() {},
-          bar() {},
-        }
+        foo() {},
+        bar() {},
       },
       {
-        reducers: {
-          baz() {},
-        }
-      }
+        baz() {},
+      },
     ];
 
     it("should flatten reducers", () => {


### PR DESCRIPTION
This is WiP. This enhances the plugin API to allow:

- Registering plugins, so the plugin can be aware of the store (and so of the `dispatch` function, useful to dispatch actions)
- Registering plugin component hooks, allowing to augment pieces of UI for a given page container component.