### PR TITLE
Fix #188: Add a delete button in the record edition view.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -124,8 +124,8 @@ table.record-list tr.conflicting {
   );
 }
 
-table.record-list td {
-  max-width: 10vw;
+table.record-list td:not(.actions) {
+  max-width: 8vw;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/scripts/components/CollectionForm.js
+++ b/scripts/components/CollectionForm.js
@@ -112,7 +112,6 @@ const schema = {
       minItems: 1,
       items: {
         type: "string",
-        description: "Enter a field name. i.e: name, attachment.filename",
         minLength: 1,
       }
     },
@@ -186,6 +185,9 @@ const uiSchema = {
     ),
   },
   displayFields: {
+    items: {
+      "ui:placeholder": "Enter a field name. i.e: name, attachment.filename"
+    },
     "ui:help": (
       <p>
         This field allows defining the record object properties to display as

--- a/scripts/components/EditForm.js
+++ b/scripts/components/EditForm.js
@@ -11,8 +11,16 @@ export default class EditForm extends Component {
   }
 
   render() {
-    const {params, session, collection, record, deleteAttachment} = this.props;
+    const {
+      params,
+      session,
+      collection,
+      record,
+      deleteRecord,
+      deleteAttachment
+    } = this.props;
     const {bid, cid, rid} = params;
+
     return (
       <div>
         <h1>Edit <b>{bid}/{cid}/{rid}</b></h1>
@@ -23,6 +31,7 @@ export default class EditForm extends Component {
           session={session}
           collection={collection}
           record={record}
+          deleteRecord={deleteRecord}
           deleteAttachment={deleteAttachment}
           onSubmit={this.onSubmit} />
       </div>

--- a/scripts/components/RecordForm.js
+++ b/scripts/components/RecordForm.js
@@ -133,6 +133,13 @@ export default class RecordForm extends Component {
     }
   }
 
+  deleteRecord = () => {
+    const {deleteRecord, bid, cid, rid} = this.props;
+    if (confirm("Are you sure?")) {
+      deleteRecord(bid, cid, rid);
+    }
+  }
+
   getForm() {
     const {asJSON} = this.state;
     const {bid, cid, collection, record} = this.props;
@@ -145,15 +152,24 @@ export default class RecordForm extends Component {
     }
 
     const buttons = (
-      <div>
-        <input type="submit" className="btn btn-primary"
-          disabled={!this.allowEditing} value={record ? "Update" : "Create"} />
-        {" or "}
-        <Link to={`/buckets/${bid}/collections/${cid}`}>Cancel</Link>
-        {" | "}
-        <a href="#" onClick={this.toggleJSON}>
-          {asJSON ? "Edit form" : "Edit raw JSON"}
-        </a>
+      <div className="row">
+        <div className="col-sm-6">
+          <input type="submit" className="btn btn-primary"
+            disabled={!this.allowEditing} value={record ? "Update" : "Create"} />
+          {" or "}
+          <Link to={`/buckets/${bid}/collections/${cid}`}>Cancel</Link>
+          {" | "}
+          <a href="#" onClick={this.toggleJSON}>
+            {asJSON ? "Edit form" : "Edit raw JSON"}
+          </a>
+        </div>
+        <div className="col-sm-6 text-right">
+          {this.allowEditing && record ?
+            <button type="button" className="btn btn-danger"
+                    onClick={this.deleteRecord}>
+              Delete record
+            </button> : null}
+        </div>
       </div>
     );
 


### PR DESCRIPTION
Refs #188. This also fixes the CSS issues on Firefox hiding the action buttons in the records list. Deployed to gh-pages.

r=? @Natim @leplatrem 