### PR TITLE
Fix bulk creation error when no attachment is provided.

### DIFF
--- a/scripts/sagas/collection.js
+++ b/scripts/sagas/collection.js
@@ -114,8 +114,12 @@ export function* bulkCreateRecords(getState, action) {
       // XXX We should perform a batch request here
       for (const rawRecord of records) {
         // Note: data urls are attached to the __attachment__ record property
-        const {__attachment__: dataURL, ...record} = rawRecord;
-        yield call([coll, coll.addAttachment], dataURL, record);
+        const {__attachment__: attachement, ...record} = rawRecord;
+        if (attachement) {
+          yield call([coll, coll.addAttachment], attachement, record);
+        } else {
+          yield call([coll, coll.createRecord], record);
+        }
       }
       yield put(updatePath(`/buckets/${bid}/collections/${cid}`));
       yield put(notifySuccess(`${records.length} records created.`));

--- a/test/sagas/collection_test.js
+++ b/test/sagas/collection_test.js
@@ -15,9 +15,10 @@ const records = [
   record,
   record2,
 ];
-const recordsWithAttachment = records.map((record, i) => {
-  return {...record, __attachment__: {n: i + 1}};
-});
+const recordsWithAttachment = [
+  {...record, __attachment__: "fake-attachment"},
+  record2,
+];
 
 describe("collection sagas", () => {
   describe("listRecords()", () => {
@@ -467,6 +468,7 @@ describe("collection sagas", () => {
       collection = {
         batch() {},
         addAttachment() {},
+        createRecord() {},
       };
       const bucket = {collection() {return collection;}};
       setClient({bucket() {return bucket;}});
@@ -545,10 +547,9 @@ describe("collection sagas", () => {
                     record));
       });
 
-      it("should send the second attachment", () => {
+      it("should send the second record with no attachment", () => {
         expect(bulkCreateRecords.next().value)
-          .eql(call([collection, collection.addAttachment],
-                    recordsWithAttachment[1].__attachment__,
+          .eql(call([collection, collection.createRecord],
                     record2));
       });
 


### PR DESCRIPTION
This fixes an issue where when bulk creating records when the attachments capability is enabled on the server, records without any attachment specified would make the whole operation fail.

Here we ensure that an attachment exists for each record, falling back to the standard API if none is provided.

r=? @Natim @leplatrem @glasserc 