### PR TITLE
Fix #200: Reset the list of paginated records when order changes.

### DIFF
--- a/scripts/reducers/collection.js
+++ b/scripts/reducers/collection.js
@@ -79,7 +79,10 @@ export function collection(
       };
     }
     case COLLECTION_RECORDS_REQUEST: {
-      return {...state, sort: action.sort, recordsLoaded: false};
+      // If a new sort filter is used, purge the previous records list and
+      // pagination state.
+      const records = state.sort !== action.sort ? [] : state.records;
+      return {...state, sort: action.sort, records, recordsLoaded: false};
     }
     case COLLECTION_RECORDS_NEXT_REQUEST: {
       return {...state, recordsLoaded: false};

--- a/test/reducers/collection_test.js
+++ b/test/reducers/collection_test.js
@@ -24,11 +24,29 @@ describe("collection reducer", () => {
       .eql(initial);
   });
 
-  it("COLLECTION_RECORDS_REQUEST", () => {
-    expect(collection(undefined, {
-      type: COLLECTION_RECORDS_REQUEST,
-      sort: "title",
-    })).to.have.property("sort").eql("title");
+  describe("COLLECTION_RECORDS_REQUEST", () => {
+    it("should update the recordsLoaded flag", () => {
+      expect(collection({recordsLoaded: true}, {
+        type: COLLECTION_RECORDS_REQUEST,
+      })).to.have.property("recordsLoaded").eql(false);
+    });
+
+    it("should update the sort parameter", () => {
+      expect(collection(undefined, {
+        type: COLLECTION_RECORDS_REQUEST,
+        sort: "title",
+      })).to.have.property("sort").eql("title");
+    });
+
+    it("should reset records list when the sort param changes", () => {
+      expect(collection({
+        records: [1, 2, 3],
+        sort: "initial"
+      }, {
+        type: COLLECTION_RECORDS_REQUEST,
+        sort: "title",
+      })).to.have.property("records").eql([]);
+    });
   });
 
   it("COLLECTION_LOAD_SUCCESS", () => {
@@ -62,15 +80,34 @@ describe("collection reducer", () => {
     });
   });
 
-  it("COLLECTION_RECORDS_SUCCESS", () => {
+  describe("COLLECTION_RECORDS_SUCCESS", () => {
     const records = [1, 2, 3];
-    const state = collection(undefined, {
-      type: COLLECTION_RECORDS_SUCCESS,
-      records
+
+    let state;
+
+    beforeEach(() => {
+      state = collection(undefined, {
+        type: COLLECTION_RECORDS_SUCCESS,
+        records
+      });
     });
 
-    expect(state.records).eql(records);
-    expect(state.recordsLoaded).eql(true);
+    it("should assign received records to state", () => {
+      expect(state.records).eql(records);
+    });
+
+    it("should mark records as loaded", () => {
+      expect(state.recordsLoaded).eql(true);
+    });
+
+    it("should append new records received to existing list", () => {
+      const state2 = collection(state, {
+        type: COLLECTION_RECORDS_SUCCESS,
+        records: [4, 5],
+      });
+
+      expect(state2.records).eql([1, 2, 3, 4, 5]);
+    });
   });
 
   it("COLLECTION_HISTORY_SUCCESS", () => {


### PR DESCRIPTION
This fixes an issue (#200) where a paginated list of records already loaded isn't reordered when the user clicks on a new sort button.

Here I'm just resetting the list of records everytime a new sort parameter is used.

Also added a few missing test cases for pagination in the reducers. Patch deployed to gh-pages.

r=? @Natim @leplatrem @glasserc 