### PR TITLE
Fixes #213: Fix redirect URL handling after successful authentication.

### DIFF
--- a/scripts/reducers/session.js
+++ b/scripts/reducers/session.js
@@ -14,6 +14,7 @@ import {
 const DEFAULT: Session = {
   busy: false,
   authenticated: false,
+  authPending: false,
   server: null,
   credentials: {},
   buckets: [],
@@ -35,7 +36,7 @@ export default function session(
     }
     case SESSION_SETUP_COMPLETE: {
       const {session}: {session: Session} = action;
-      return {...state, ...session};
+      return {...state, ...session, authPending: true};
     }
     case SESSION_STORE_REDIRECT_URL: {
       const {redirectURL}: {redirectURL: string} = action;
@@ -47,6 +48,7 @@ export default function session(
       return {
         ...state,
         authenticated: true,
+        authPending: false,
         buckets: action.buckets.map((bucket) => {
           return {
             ...bucket,

--- a/scripts/routes.js
+++ b/scripts/routes.js
@@ -56,7 +56,7 @@ function onAuthEnter(store: Object, {params}) {
 function onCollectionListEnter(store: Object, {params}) {
   const {bid, cid} = params;
   const {session, collection} = store.getState();
-  if (!session.authenticated) {
+  if (!session.authenticated && !session.authPending) {
     // We're not authenticated, skip requesting the list of records. This likely
     // occurs when users refresh the page and lose their session.
     return;
@@ -68,7 +68,7 @@ function onCollectionListEnter(store: Object, {params}) {
 function onCollectionHistoryEnter(store: Object, {params}) {
   const {bid, cid} = params;
   const {session} = store.getState();
-  if (!session.authenticated) {
+  if (!session.authenticated && !session.authPending) {
     // We're not authenticated, skip requesting the list of records. This likely
     // occurs when users refresh the page and lose their session.
     return;
@@ -79,7 +79,7 @@ function onCollectionHistoryEnter(store: Object, {params}) {
 function onBucketPageEnter(store: Object, action: Function, {params}) {
   const {bid} = params;
   const {session} = store.getState();
-  if (!session.authenticated) {
+  if (!session.authenticated && !session.authPending) {
     // We're not authenticated, skip requesting the list of records. This likely
     // occurs when users refresh the page and lose their session.
     return;
@@ -90,7 +90,7 @@ function onBucketPageEnter(store: Object, action: Function, {params}) {
 function onGroupHistoryEnter(store: Object, {params}) {
   const {bid, gid} = params;
   const {session} = store.getState();
-  if (!session.authenticated) {
+  if (!session.authenticated && !session.authPending) {
     // We're not authenticated, skip requesting the list of records. This likely
     // occurs when users refresh the page and lose their session.
     return;

--- a/scripts/sagas/route.js
+++ b/scripts/sagas/route.js
@@ -105,6 +105,7 @@ export function* loadRoute(bid, cid, gid, rid) {
 
 export function* routeUpdated(getState, action) {
   const {session} = getState();
+  const {authenticated, authPending} = session;
   const {params, location} = action;
   const {bid, cid, rid, gid, token} = params;
 
@@ -113,7 +114,7 @@ export function* routeUpdated(getState, action) {
 
   // Check for an authenticated session; if we're requesting anything other
   // than the homepage, redirect to the homepage with a notification.
-  if (!session.authenticated && !token && location.pathname !== "/") {
+  if (!authPending && !authenticated && !token && location.pathname !== "/") {
     yield put(storeRedirectURL(location.pathname));
     yield put(updatePath(""));
     yield put(notifyInfo("Authentication required.", {persistent: true}));

--- a/scripts/types.js
+++ b/scripts/types.js
@@ -129,6 +129,7 @@ export type RecordPermissions = {
 export type Session = {
   busy: boolean,
   authenticated: boolean,
+  authPending: boolean,
   server: ?string,
   credentials: Object,
   buckets: Object[],

--- a/test/reducers/sessions_test.js
+++ b/test/reducers/sessions_test.js
@@ -30,10 +30,12 @@ describe("session reducer", () => {
 
     expect(session(undefined, {
       type: SESSION_SETUP_COMPLETE,
-      session: setup
+      session: setup,
+      authPending: false,
     })).eql({
       busy: false,
       authenticated: false,
+      authPending: true,
       server: setup.server,
       authType: setup.authType,
       credentials: setup.credentials,
@@ -74,6 +76,7 @@ describe("session reducer", () => {
 
     expect(state).to.have.property("buckets").eql(buckets);
     expect(state).to.have.property("authenticated").eql(true);
+    expect(state).to.have.property("authPending").eql(false);
   });
 
   it("SESSION_LOGOUT", () => {


### PR DESCRIPTION
This restores the expected behavior when loading an route requiring being authenticated when you're currently not. That also fixes the issue described in #213 where the *Authentication required* notification wouldn't go away after successfully authenticating.

Deployed to gh-pages.

QA:

1. Head to https://kinto.github.io/kinto-admin/#/buckets/Foo/collections/Bar
1.  You should be redirected to the authentication form with an *Authentication required* notification displayed
1. Authenticate using test:test (use the default dev kinto server url)
1. You should be redirected to the collection list view, and the notification should be gone. 

r=? @Natim @glasserc 