### PR TITLE
Fix broken signoff plugin.

### DIFF
--- a/plugins/signoff/index.js
+++ b/plugins/signoff/index.js
@@ -28,7 +28,7 @@ function* handleSignoffRequest(getState, action) {
     yield call([coll, coll.setData], {status: "to-sign"}, {patch: true});
     yield put(notifySuccess("Signature requested."));
   } catch (e) {
-    yield put(notifyError(e));
+    yield put(notifyError("Couldn't sign collection.", e));
   }
 }
 
@@ -72,7 +72,7 @@ export const reducers = {};
 
 export function register(store) {
   const hooks = {
-    CollectionList: {
+    CollectionRecords: {
       ListActions: [
         <SignoffButton key="request-signoff-btn"
                        getState={store.getState.bind(store)}

--- a/scripts/actions/notifications.js
+++ b/scripts/actions/notifications.js
@@ -9,7 +9,10 @@ import {
 } from "../constants";
 
 
-function getErrorDetails(error: Error | ClientError): string[] {
+function getErrorDetails(error: ?(Error | ClientError)): string[] {
+  if (!error) {
+    return [];
+  }
   const {message} = error;
   let details = [message];
   if (!error.data) {
@@ -61,7 +64,7 @@ export function notifySuccess(message: string, options: Object={}): Action {
 
 export function notifyError(
   message: string,
-  error:   Error | ClientError,
+  error:   ?(Error | ClientError),
   options: Object={}
 ): Action {
   console.error(error);

--- a/scripts/types.js
+++ b/scripts/types.js
@@ -22,9 +22,9 @@ export type Bucket = {
   permissions: BucketPermissions,
   history: Object[],
   historyLoaded: boolean,
-  collections: Object[],
+  collections: CollectionData[],
   collectionsLoaded: boolean,
-  groups: Object[],
+  groups: GroupData[],
   groupsLoaded: boolean,
 };
 


### PR DESCRIPTION
This fixes the signoff plugin, broken after #219 has landed.

This also updates the error notification API so the Error object argument is not required anymore.