### PR TITLE
Fix #225: Ensure reauth on session restore.

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -6,6 +6,7 @@ import { syncHistoryWithStore } from "react-router-redux";
 import getRoutes from "./routes";
 import configureStore from "./store/configureStore";
 import * as routeActions from "./actions/route";
+import * as sessionActions from "./actions/session";
 
 import { loadSession } from "./store/localStore";
 
@@ -15,7 +16,7 @@ import "../css/styles.css";
 
 
 export function createAdmin(plugins=[]) {
-  const store = configureStore(loadSession(), plugins);
+  const store = configureStore({}, plugins);
 
   const registerPlugins = plugins.map(plugin => plugin.register(store));
 
@@ -33,6 +34,12 @@ export function createAdmin(plugins=[]) {
       </Router>
     </Provider>
   );
+
+  // Load any previously saved session, trigger reauth against it
+  const session = loadSession();
+  if (session) {
+    store.dispatch(sessionActions.setup(session));
+  }
 
   return {store, component};
 }

--- a/scripts/store/localStore.js
+++ b/scripts/store/localStore.js
@@ -1,8 +1,6 @@
 /* @flow */
 import type { Session } from "../types";
 
-import { setupClient } from "../client";
-
 
 const HISTORY_KEY = "kinto-admin-server-history";
 const SESSION_KEY = "kinto-admin-session";
@@ -34,20 +32,11 @@ export function clearHistory(): string[] {
   return saveHistory([]);
 }
 
-export function loadSession(): Object {
-  const jsonSession = localStorage.getItem(SESSION_KEY);
-  if (!jsonSession) {
-    return {};
-  }
+export function loadSession(): ?Object {
   try {
-    const session = JSON.parse(jsonSession);
-    if (!session) {
-      return {};
-    }
-    setupClient(session);
-    return {session};
+    return JSON.parse(localStorage.getItem(SESSION_KEY) || "null");
   } catch(err) {
-    return {};
+    return null;
   }
 }
 

--- a/test/store/localStore_test.js
+++ b/test/store/localStore_test.js
@@ -38,19 +38,19 @@ describe("localStore", () => {
     });
 
     it("should load initial session", () => {
-      expect(localStore.loadSession()).eql({});
+      expect(localStore.loadSession()).eql(null);
     });
 
     it("should save and load session", () => {
       localStore.saveSession(session);
 
-      expect(localStore.loadSession()).eql({session});
+      expect(localStore.loadSession()).eql(session);
     });
 
     it("should clear session", () => {
       localStore.clearSession();
 
-      expect(localStore.loadSession()).eql({});
+      expect(localStore.loadSession()).eql(null);
     });
   });
 });


### PR DESCRIPTION
Refs #225.

> We shouldn't blindly reuse data stored in a saved session, eg. the list of buckets as they might have been heavily updated meanwhile.
>
> We should ensure fully reauthenticating when loading previsouly saved session data.