### PR TITLE
Add safety check for list of collections

### DIFF
--- a/src/sagas/session.js
+++ b/src/sagas/session.js
@@ -76,7 +76,7 @@ export function* listBuckets(getState, action) {
       }
     });
     let buckets = data.map((bucket, index) => {
-      const collections = responses[index].body.data;
+      const {data: collections=[]} = responses[index].body;
       return {id: bucket.id, collections};
     });
 


### PR DESCRIPTION
@n1k0 r?

Seems to be a bug from server though:
```
$ http :8888/v1/buckets --auth test:test
HTTP/1.1 200 OK
Access-Control-Expose-Headers: Content-Length, Expires, Alert, Retry-After, Last-Modified, Total-Records, ETag, Pragma, Cache-Control, Backoff, Next-Page
Cache-Control: no-cache, no-store
Content-Length: 107
Content-Type: application/json; charset=UTF-8
Date: Tue, 25 Oct 2016 10:01:42 GMT
Etag: "1477306958028"
Last-Modified: Mon, 24 Oct 2016 11:02:38 GMT
Server: waitress
Total-Records: 2

{
    "data": [
        {
            "id": "source", 
            "last_modified": 1477306958028
        }, 
        {
            "id": "destination", 
            "last_modified": 1476717932394
        }
    ]
}

```



```
$ http :8888/v1/buckets/source/collections --auth test:test 
HTTP/1.1 403 Forbidden
Access-Control-Expose-Headers: Content-Length, Expires, Alert, Retry-After, Last-Modified, ETag, Pragma, Cache-Control, Backoff
Content-Length: 95
Content-Type: application/json; charset=UTF-8
Date: Tue, 25 Oct 2016 10:02:10 GMT
Server: waitress

{
    "code": 403, 
    "errno": 121, 
    "error": "Forbidden", 
    "message": "This user cannot access this resource."
}

```