### PR TITLE
Fix #316: minor relative time fixes

### DIFF
--- a/interfaces/external-modules/timeago.d.js
+++ b/interfaces/external-modules/timeago.d.js
@@ -1,6 +1,6 @@
 declare module "timeago.js" {
   declare class timeagoApi {
-    format(date: Date): string;
+    format(date: Date | number | string): string;
   }
   declare function timeago(): timeagoApi
 

--- a/src/plugins/signoff/components.js
+++ b/src/plugins/signoff/components.js
@@ -121,11 +121,7 @@ function WorkInProgress({label, canEdit, currentStep, step, requestReview, sourc
 
 function WorkInProgressInfos({lastAuthor, lastUpdated}) {
   if (!lastUpdated) {
-    return (
-      <ul>
-        <li>Never updated</li>
-      </ul>
-    );
+    return <ul><li>Never updated</li></ul>;
   }
   return (
     <ul>

--- a/src/plugins/signoff/components.js
+++ b/src/plugins/signoff/components.js
@@ -120,6 +120,13 @@ function WorkInProgress({label, canEdit, currentStep, step, requestReview, sourc
 }
 
 function WorkInProgressInfos({lastAuthor, lastUpdated}) {
+  if (!lastUpdated) {
+    return (
+      <ul>
+        <li>Never updated</li>
+      </ul>
+    );
+  }
   return (
     <ul>
       <li><strong>Updated: </strong><HumanDate timestamp={lastUpdated}/></li>

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,11 +22,11 @@ export function isObject(thing: any): boolean {
 export function timeago(date: string | number): string {
   // Show relative time according to current timezone.
   const nowUTC = (new Date()).getTime();
+  const timestamp = parseInt(date, 10);
   // In our use case, we should never show relative time in the future.
   // For example, if local computer is late, the server timestamp will appear
   // to be in the future. Hence use "now" as a maximum.
-  const timestamp = nowUTC < date ? nowUTC : date;
-  return _timeago().format(timestamp);
+  return _timeago().format(Math.min(nowUTC, timestamp));
 }
 
 export function validJSON(string: string): boolean {

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,7 +21,12 @@ export function isObject(thing: any): boolean {
 
 export function timeago(date: string | number): string {
   // Show relative time according to current timezone.
-  return _timeago().format(new Date(date));
+  const nowUTC = (new Date()).getTime();
+  // In our use case, we should never show relative time in the future.
+  // For example, if local computer is late, the server timestamp will appear
+  // to be in the future. Hence use "now" as a maximum.
+  const timestamp = nowUTC < date ? nowUTC : date;
+  return _timeago().format(timestamp);
 }
 
 export function validJSON(string: string): boolean {


### PR DESCRIPTION
I'm not super enthusiastic about the fix I made for relative time in the future. The correct way to go would be to query the server to get a clock diff and then shift timestamps. 
Since our use case consists in showing timestamps in the past, and that we are responsible engineers with NTP, it should not be a problem to keep the current behaviour. I just added a very simple safety to make sure we don't have string like `In 1 minute` when what we expect is `Just now`.

@n1k0 r?