### PR TITLE
Fix #326: Use server info in server infos bar

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,13 +5,20 @@ import React, { Component } from "react";
 import Breadcrumbs from "react-breadcrumbs";
 
 
+function UserInfo({session}) {
+  const {serverInfo: {user={}}} = session;
+  if (!user.id) {
+    return <strong>Anonymous</strong>;
+  }
+  return <span>Connected as <strong>{user.id}</strong></span>;
+}
+
+
 function SessionInfoBar({session, logout}) {
-  const {server, credentials={}} = session;
-  const {username} = credentials;
-  const userInfo = username ? <span>as <strong>{username}</strong></span> : "";
+  const {serverInfo: {url}} = session;
   return (
     <div className="session-info-bar text-right">
-      Connected {userInfo} on <strong>{server}</strong>
+      <UserInfo session={session}/> on <strong>{url}</strong>
       <a href="" className="btn btn-xs btn-success btn-logout"
         onClick={(event) => event.preventDefault() || logout()}>logout</a>
     </div>

--- a/src/reducers/session.js
+++ b/src/reducers/session.js
@@ -21,6 +21,7 @@ const DEFAULT: SessionState = {
   credentials: {},
   buckets: [],
   serverInfo: {
+    url: "",
     capabilities: {},
   },
   redirectURL: null,

--- a/src/sagas/session.js
+++ b/src/sagas/session.js
@@ -64,7 +64,7 @@ export function* listBuckets(getState, action) {
     const serverInfo = yield call([client, client.fetchServerInfo]);
     // We got a valid response; officially declare current user authenticated
     // XXX: authenticated here means that we have setup the client, not
-    // that then credentials are valid :/
+    // that the credentials are valid :/
     yield put(sessionActions.setAuthenticated());
     // Store this valid server url in the history
     yield put(historyActions.addHistory(getState().session.server));

--- a/src/sagas/session.js
+++ b/src/sagas/session.js
@@ -63,6 +63,8 @@ export function* listBuckets(getState, action) {
     // Fetch server information
     const serverInfo = yield call([client, client.fetchServerInfo]);
     // We got a valid response; officially declare current user authenticated
+    // XXX: authenticated here means that we have setup the client, not
+    // that then credentials are valid :/
     yield put(sessionActions.setAuthenticated());
     // Store this valid server url in the history
     yield put(historyActions.addHistory(getState().session.server));

--- a/src/types.js
+++ b/src/types.js
@@ -271,6 +271,7 @@ export type SessionState = {
 };
 
 export type ServerInfo = {
+  url: string,
   capabilities: Capabilities,
   user?: {
     id: string,

--- a/test/components/App_test.js
+++ b/test/components/App_test.js
@@ -29,6 +29,26 @@ describe("App component", () => {
       expect(node.querySelector(".session-info-bar")).to.not.exist;
     });
 
+    it("should render a session top bar when anonymous", () => {
+      const session = {
+        authenticated: true,
+        serverInfo: {
+          url: "http://test.server/v1/"
+        }
+      };
+      const node = createComponent(App, {
+        session,
+        logout: {},
+        notificationList: [],
+        routes: [{name: "Home"}],
+      });
+      const infoBar = node.querySelector(".session-info-bar");
+      const content = infoBar.textContent;
+
+      expect(content).to.contain("Anonymous");
+      expect(content).to.contain(session.serverInfo.url);
+    });
+
     it("should render a session top bar when authenticated", () => {
       const session = {
         authenticated: true,

--- a/test/components/App_test.js
+++ b/test/components/App_test.js
@@ -32,7 +32,12 @@ describe("App component", () => {
     it("should render a session top bar when authenticated", () => {
       const session = {
         authenticated: true,
-        server: "http://test.server/v1",
+        serverInfo: {
+          url: "http://test.server/v1/",
+          user: {
+            id: "fxa:1234"
+          }
+        },
         credentials: {
           username: "user",
           password: "pass",
@@ -50,8 +55,8 @@ describe("App component", () => {
       expect(infoBar).to.exist;
 
       const content = infoBar.textContent;
-      expect(content).to.contain(session.server);
-      expect(content).to.contain(session.credentials.username);
+      expect(content).to.contain(session.serverInfo.url);
+      expect(content).to.contain(session.serverInfo.user.id);
       expect(content).to.not.contain(session.credentials.password);
 
       Simulate.click(node.querySelector(".btn-logout"));

--- a/test/reducers/sessions_test.js
+++ b/test/reducers/sessions_test.js
@@ -43,6 +43,7 @@ describe("session reducer", () => {
       permissions: null,
       redirectURL: null,
       serverInfo: {
+        url: "",
         capabilities: {},
       },
     });


### PR DESCRIPTION
IMO the current approach was wrong. We should rely as much as possible on what the server returns.