### PR TITLE
Introduce a TagsField component.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-breadcrumbs": "^1.3.16",
     "react-codemirror": "^0.2.3",
     "react-dom": "^15.2.0",
-    "react-jsonschema-form": "^0.39.0",
+    "react-jsonschema-form": "^0.41.2",
     "react-redux": "^4.0.0",
     "react-router": "^2.7.0",
     "react-router-redux": "4.0.5",

--- a/src/components/AuthForm.js
+++ b/src/components/AuthForm.js
@@ -1,11 +1,10 @@
 /* @flow */
 import type { SessionState, SettingsState } from "../types";
 
-import { omit } from "../utils";
-
 import React, { Component } from "react";
 
-import Form from "react-jsonschema-form";
+import BaseForm from "./BaseForm";
+import { omit } from "../utils";
 
 
 class ServerHistory extends Component {
@@ -238,10 +237,8 @@ function extendUiSchemaWithHistory(uiSchema, history, clearHistory, singleServer
     ...uiSchema,
     server: {
       ...uiSchema.server,
-      "ui:widget": {
-        component: ServerHistory,
-        options: {history, clearHistory}
-      }
+      "ui:widget": ServerHistory,
+      "ui:options": {history, clearHistory},
     }
   };
 }
@@ -315,7 +312,7 @@ export default class AuthForm extends Component {
     return (
       <div className="panel panel-default">
         <div className="panel-body">
-          <Form
+          <BaseForm
             schema={extendSchemaWithHistory(schema, history, authMethods, singleServer)}
             uiSchema={extendUiSchemaWithHistory(uiSchema, history, clearHistory, singleServer)}
             formData={formData}
@@ -324,7 +321,7 @@ export default class AuthForm extends Component {
             <button type="submit" className="btn btn-info">
               {"Sign in using "}{authLabels[formData.authType]}
             </button>
-          </Form>
+          </BaseForm>
         </div>
       </div>
     );

--- a/src/components/BaseForm.js
+++ b/src/components/BaseForm.js
@@ -1,0 +1,13 @@
+import React, { Component } from "react";
+import Form from "react-jsonschema-form";
+
+import TagsField from "./TagsField";
+
+
+const adminFields = {tags: TagsField};
+
+export default class BaseForm extends Component {
+  render() {
+    return <Form {...this.props} fields={adminFields} />;
+  }
+}

--- a/src/components/BaseForm.js
+++ b/src/components/BaseForm.js
@@ -1,3 +1,4 @@
+/* @flow */
 import React, { Component } from "react";
 import Form from "react-jsonschema-form";
 

--- a/src/components/JSONRecordForm.js
+++ b/src/components/JSONRecordForm.js
@@ -1,7 +1,7 @@
 /* @flow */
 import React, { Component } from "react";
-import Form from "react-jsonschema-form";
 
+import BaseForm from "./BaseForm";
 import JSONEditor from "./JSONEditor";
 import { validJSON } from "./../utils";
 
@@ -40,14 +40,14 @@ export default class JSONRecordForm extends Component {
     const {record, disabled, children} = this.props;
     return (
       <div>
-        <Form
+        <BaseForm
           schema={schema}
           formData={record}
           uiSchema={disabled ? {...uiSchema, "ui:disabled": true} : uiSchema}
           validate={validate}
           onSubmit={this.onSubmit}>
           {children}
-        </Form>
+        </BaseForm>
       </div>
     );
   }

--- a/src/components/PermissionsForm.js
+++ b/src/components/PermissionsForm.js
@@ -3,8 +3,8 @@
 import type { Permissions, GroupData } from "../types";
 
 import React, { Component } from "react";
-import Form from "react-jsonschema-form";
 
+import BaseForm from "./BaseForm";
 import {
   permissionsToFormData,
   formDataToPermissions,
@@ -40,7 +40,7 @@ export default class PermissionsForm extends Component {
     const formData = permissionsToFormData(bid, permissions);
     const {schema, uiSchema} = preparePermissionsForm(acls, groups);
     return (
-      <Form className="permissions-form"
+      <BaseForm className="permissions-form"
             schema={schema}
             uiSchema={uiSchema}
             formData={formData}

--- a/src/components/TagsField.js
+++ b/src/components/TagsField.js
@@ -1,17 +1,37 @@
+/* @flow */
 import React, { Component } from "react";
 
 
+type Props = {
+  schema: Object,
+  uiSchema: Object,
+  formData: string[],
+  onChange: (value: string[]) => void,
+  required: bool,
+  readonly: bool,
+};
+
+type State = {
+  tagsString: string,
+}
+
 export default class TagsField extends Component {
+  props: Props;
+  state: State;
+
   static defaultProps = {
     formData: [],
+    required: false,
+    readonly: false,
   };
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
+    console.log(props);
     this.state = {tagsString: props.formData.join(", ")};
   }
 
-  onChange = ({target: {value: tagsString}}) => {
+  onChange = ({target: {value: tagsString}}: {target: {value: string}}) => {
     const tags = tagsString.split(",")
       .map(tag => tag.trim())
       .filter(tag => tag !== "");
@@ -20,7 +40,26 @@ export default class TagsField extends Component {
   }
 
   render() {
+    const {uiSchema, required, readonly} = this.props;
     const {tagsString} = this.state;
-    return <input type="text" value={tagsString} onChange={this.onChange} />;
+    return (
+      <div className="form-group field field-string">
+        <label className="control-label">
+          {this.props.schema.title || this.props.name || "Tags"}
+          {required ? "*" : ""}
+        </label>
+        <input
+          type="text"
+          className="form-control"
+          value={tagsString}
+          placeholder={uiSchema["ui:placeholder"] || "tag1, tag2, tag3"}
+          onChange={this.onChange}
+          required={required}
+          readOnly={readonly} />
+        <p className="help-block">
+          {uiSchema["ui:help"] || "Comma-separated strings"}
+        </p>
+      </div>
+    );
   }
 }

--- a/src/components/TagsField.js
+++ b/src/components/TagsField.js
@@ -2,6 +2,14 @@
 import React, { Component } from "react";
 
 
+function toTagList(tagsString: string, unique: bool = false): string[] {
+  const list = tagsString.split(",")
+    .map(tag => tag.trim())
+    .filter(tag => tag !== "");
+  // we want unique values
+  return unique ? Array.from(new Set(list)) : list;
+}
+
 type Props = {
   schema: Object,
   uiSchema: Object,
@@ -27,14 +35,11 @@ export default class TagsField extends Component {
 
   constructor(props: Props) {
     super(props);
-    console.log(props);
     this.state = {tagsString: props.formData.join(", ")};
   }
 
   onChange = ({target: {value: tagsString}}: {target: {value: string}}) => {
-    const tags = tagsString.split(",")
-      .map(tag => tag.trim())
-      .filter(tag => tag !== "");
+    const tags = toTagList(tagsString, this.props.schema.uniqueItems);
     this.setState({tagsString});
     setImmediate(() => this.props.onChange(tags));
   }

--- a/src/components/TagsField.js
+++ b/src/components/TagsField.js
@@ -1,0 +1,26 @@
+import React, { Component } from "react";
+
+
+export default class TagsField extends Component {
+  static defaultProps = {
+    formData: [],
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {tagsString: props.formData.join(", ")};
+  }
+
+  onChange = ({target: {value: tagsString}}) => {
+    const tags = tagsString.split(",")
+      .map(tag => tag.trim())
+      .filter(tag => tag !== "");
+    this.setState({tagsString});
+    setImmediate(() => this.props.onChange(tags));
+  }
+
+  render() {
+    const {tagsString} = this.state;
+    return <input type="text" value={tagsString} onChange={this.onChange} />;
+  }
+}

--- a/src/components/TagsField.js
+++ b/src/components/TagsField.js
@@ -15,6 +15,10 @@ function toTagList(
   return unique ? Array.from(new Set(list)) : list;
 }
 
+function toTagsString(tags: string[], separator: string = ","): string {
+  return tags.join(separator += separator !== " " ? " " : "");
+}
+
 type Props = {
   schema: Object,
   uiSchema: Object,
@@ -48,7 +52,7 @@ export default class TagsField extends Component {
 
   constructor(props: Props) {
     super(props);
-    this.state = {tagsString: props.formData.join(this.separator + " ")};
+    this.state = {tagsString: toTagsString(props.formData, this.separator)};
   }
 
   onChange = ({target: {value: tagsString}}: {target: {value: string}}) => {
@@ -71,7 +75,8 @@ export default class TagsField extends Component {
           type="text"
           className="form-control"
           value={tagsString}
-          placeholder={uiSchema["ui:placeholder"] || ["tag1", "tag2", "tag3"].join(this.separator)}
+          placeholder={uiSchema["ui:placeholder"] ||
+                       toTagsString(["tag1", "tag2", "tag3"], this.separator)}
           onChange={this.onChange}
           required={required}
           readOnly={readonly} />

--- a/src/components/bucket/BucketForm.js
+++ b/src/components/bucket/BucketForm.js
@@ -7,8 +7,8 @@ import type {
 
 import React, { Component } from "react";
 import { Link } from "react-router";
-import Form from "react-jsonschema-form";
 
+import BaseForm from "../BaseForm";
 import JSONEditor from "../JSONEditor";
 import Spinner from "../Spinner";
 import { canEditBucket } from "../../permission";
@@ -67,7 +67,7 @@ function DeleteForm({bid, onSubmit}) {
           Delete the <b>{bid}</b> bucket and all the collections and
           records it contains.
         </p>
-        <Form
+        <BaseForm
           schema={deleteSchema}
           validate={validate}
           onSubmit={({formData}) => {
@@ -78,7 +78,7 @@ function DeleteForm({bid, onSubmit}) {
           <button type="submit" className="btn btn-danger">
             <i className="glyphicon glyphicon-trash"/>{" "}Delete bucket
           </button>
-        </Form>
+        </BaseForm>
       </div>
     </div>
   );
@@ -147,7 +147,7 @@ export default class BucketForm extends Component {
         {alert}
         {bucket.busy ?
           <Spinner /> :
-          <Form
+          <BaseForm
             schema={schema}
             uiSchema={formIsEditable ? _uiSchema :
                         {..._uiSchema, "ui:readonly": true}}
@@ -155,7 +155,7 @@ export default class BucketForm extends Component {
             validate={validate}
             onSubmit={this.onSubmit}>
             {buttons}
-          </Form>
+          </BaseForm>
         }
         {showDeleteForm ?
           <DeleteForm

--- a/src/components/collection/CollectionForm.js
+++ b/src/components/collection/CollectionForm.js
@@ -8,8 +8,8 @@ import type {
 
 import React, { Component } from "react";
 import { Link } from "react-router";
-import Form from "react-jsonschema-form";
 
+import BaseForm from "../BaseForm";
 import JSONEditor from "../JSONEditor";
 import { canCreateCollection, canEditCollection } from "../../permission";
 import { validateSchema, validateUiSchema } from "../../utils";
@@ -68,7 +68,7 @@ function DeleteForm({cid, onSubmit}) {
         <p>
           Delete the <b>{cid}</b> collection and all the records it contains.
         </p>
-        <Form
+        <BaseForm
           schema={deleteSchema}
           validate={validate}
           onSubmit={({formData}) => {
@@ -80,7 +80,7 @@ function DeleteForm({cid, onSubmit}) {
             <i className="glyphicon glyphicon-trash"/>{" "}
             Delete collection
           </button>
-        </Form>
+        </BaseForm>
       </div>
     </div>
   );
@@ -316,7 +316,7 @@ export default class CollectionForm extends Component {
     return (
       <div>
         {alert}
-        <Form
+        <BaseForm
           schema={schema}
           formData={formDataSerialized}
           uiSchema={this.allowEditing ? _uiSchema :
@@ -324,7 +324,7 @@ export default class CollectionForm extends Component {
           validate={validate}
           onSubmit={this.onSubmit}>
           {buttons}
-        </Form>
+        </BaseForm>
         {showDeleteForm ?
           <DeleteForm
             cid={cid}

--- a/src/components/collection/CollectionRecords.js
+++ b/src/components/collection/CollectionRecords.js
@@ -52,36 +52,38 @@ class Row extends Component {
     const {bid, cid, record, displayFields, capabilities} = this.props;
     const {id: rid} = record;
     const attachmentUrl = buildAttachmentUrl(record, capabilities);
-    return <tr onDoubleClick={this.onDoubleClick.bind(this)}>
-      {
-        displayFields.map((displayField, index) => {
-          return <td key={index}>{renderDisplayField(record, displayField)}</td>;
-        })
-      }
-      <td className="lastmod">{this.lastModified}</td>
-      <td className="actions text-right">
-        <div className="btn-group">
-          {attachmentUrl ?
-            <a href={attachmentUrl} className="btn btn-sm btn-default"
-              title="The record has an attachment"
-              target="_blank">
-              <i className="glyphicon glyphicon-paperclip" />
-            </a> : null}
-          <AdminLink name="record:attributes" params={{bid, cid, rid}}
-            className="btn btn-sm btn-info" title="Edit record">
-            <i className="glyphicon glyphicon-pencil"/>
-          </AdminLink>
-          <AdminLink name="record:permissions" params={{bid, cid, rid}}
-            className="btn btn-sm btn-warning" title="Record permissions">
-            <i className="glyphicon glyphicon-lock"/>
-          </AdminLink>
-          <button type="button" className="btn btn-sm btn-danger"
-            onClick={this.onDeleteClick.bind(this)} title="Delete record">
-            <i className="glyphicon glyphicon-trash"/>
-          </button>
-        </div>
-      </td>
-    </tr>;
+    return (
+      <tr onDoubleClick={this.onDoubleClick.bind(this)}>
+        {
+          displayFields.map((displayField, index) => {
+            return <td key={index}>{renderDisplayField(record, displayField)}</td>;
+          })
+        }
+        <td className="lastmod">{this.lastModified}</td>
+        <td className="actions text-right">
+          <div className="btn-group">
+            {attachmentUrl ?
+              <a href={attachmentUrl} className="btn btn-sm btn-default"
+                title="The record has an attachment"
+                target="_blank">
+                <i className="glyphicon glyphicon-paperclip" />
+              </a> : null}
+            <AdminLink name="record:attributes" params={{bid, cid, rid}}
+              className="btn btn-sm btn-info" title="Edit record">
+              <i className="glyphicon glyphicon-pencil"/>
+            </AdminLink>
+            <AdminLink name="record:permissions" params={{bid, cid, rid}}
+              className="btn btn-sm btn-warning" title="Record permissions">
+              <i className="glyphicon glyphicon-lock"/>
+            </AdminLink>
+            <button type="button" className="btn btn-sm btn-danger"
+              onClick={this.onDeleteClick.bind(this)} title="Delete record">
+              <i className="glyphicon glyphicon-trash"/>
+            </button>
+          </div>
+        </td>
+      </tr>
+    );
   }
 }
 

--- a/src/components/group/GroupForm.js
+++ b/src/components/group/GroupForm.js
@@ -7,8 +7,8 @@ import type {
 } from "../../types";
 
 import React, { Component } from "react";
-import Form from "react-jsonschema-form";
 
+import BaseForm from "../BaseForm";
 import AdminLink from "../AdminLink";
 import JSONEditor from "../JSONEditor";
 import { canCreateGroup, canEditGroup } from "../../permission";
@@ -73,7 +73,7 @@ function DeleteForm({gid, onSubmit}) {
         <p>
           Delete the <b>{gid}</b> group.
         </p>
-        <Form
+        <BaseForm
           schema={deleteSchema}
           validate={validate}
           onSubmit={({formData}) => {
@@ -85,7 +85,7 @@ function DeleteForm({gid, onSubmit}) {
             <i className="glyphicon glyphicon-trash"/>{" "}
             Delete group
           </button>
-        </Form>
+        </BaseForm>
       </div>
     </div>
   );
@@ -161,7 +161,7 @@ export default class GroupForm extends Component {
         {alert}
         {group.busy ?
           <Spinner/> :
-          <Form
+          <BaseForm
             schema={schema}
             uiSchema={formIsEditable ? _uiSchema :
                         {..._uiSchema, "ui:readonly": true}}
@@ -169,7 +169,7 @@ export default class GroupForm extends Component {
             validate={validate}
             onSubmit={this.onSubmit}>
             {buttons}
-          </Form>
+          </BaseForm>
             }
         {showDeleteForm ?
           <DeleteForm

--- a/src/components/record/RecordBulk.js
+++ b/src/components/record/RecordBulk.js
@@ -6,8 +6,8 @@ import type {
 } from "../../types";
 
 import React, { Component } from "react";
-import Form from "react-jsonschema-form";
 
+import BaseForm from "../BaseForm";
 import AdminLink from "../AdminLink";
 import Spinner from "../Spinner";
 import JSONEditor from "../JSONEditor";
@@ -81,7 +81,7 @@ export default class RecordBulk extends Component {
         {busy ? <Spinner /> :
           <div className="panel panel-default">
             <div className="panel-body">
-            <Form
+            <BaseForm
               schema={bulkSchema}
               uiSchema={bulkUiSchema}
               formData={bulkFormData}
@@ -90,7 +90,7 @@ export default class RecordBulk extends Component {
                 value="Bulk create" />
               {" or "}
               <AdminLink name="collection:records" params={{bid, cid}}>Cancel</AdminLink>
-            </Form>
+            </BaseForm>
           </div>
         </div>}
       </div>

--- a/src/components/record/RecordForm.js
+++ b/src/components/record/RecordForm.js
@@ -9,9 +9,9 @@ import type {
 } from "../../types";
 
 import React, { Component } from "react";
-import Form from "react-jsonschema-form";
 import filesize from "filesize";
 
+import BaseForm from "./../BaseForm";
 import AdminLink from "../AdminLink";
 import Spinner from "../Spinner";
 import JSONRecordForm from "../JSONRecordForm";
@@ -248,13 +248,13 @@ export default class RecordForm extends Component {
     _uiSchema = extendUiSchemaWhenDisabled(_uiSchema, !this.allowEditing);
 
     return (
-      <Form
+      <BaseForm
         schema={_schema}
         uiSchema={_uiSchema}
         formData={cleanRecord(recordData)}
         onSubmit={this.onSubmit}>
         {buttons}
-      </Form>
+      </BaseForm>
     );
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -179,6 +179,8 @@ export function renderDisplayField(record: Object, displayField: string): any {
     const field = record[displayField];
     if (typeof field === "string") {
       return linkify(field);
+    } else if (Array.isArray(field) && field.every(x => typeof x === "string")) {
+      return field.join(", ");
     } else if (typeof field === "object") {
       return JSON.stringify(field);
     } else {

--- a/test/components/TagsField_test.js
+++ b/test/components/TagsField_test.js
@@ -40,6 +40,19 @@ describe("TagsField component", () => {
       expect(node.querySelector("input").value)
         .eql("a: b: c");
     });
+
+    it("should special case the space separator", () => {
+      const node = createComponent(TagsField, {
+        schema: {},
+        formData: ["a", "b", "c"],
+        uiSchema: {
+          "ui:options": {separator: " "}
+        }
+      });
+
+      expect(node.querySelector("input").value)
+        .eql("a b c");
+    });
   });
 
   describe("Unique items", () => {

--- a/test/components/TagsField_test.js
+++ b/test/components/TagsField_test.js
@@ -1,0 +1,74 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import { Simulate } from "react-addons-test-utils";
+
+import { createSandbox, createComponent } from "../test_utils";
+import TagsField from "../../src/components/TagsField";
+
+
+describe("TagsField component", () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("Separator", () => {
+    it("should use \",\" as a default separator", () => {
+      const node = createComponent(TagsField, {
+        schema: {},
+        formData: ["a", "b", "c"],
+      });
+
+      expect(node.querySelector("input").value)
+        .eql("a, b, c");
+    });
+
+    it("should accept and use a custom separator", () => {
+      const node = createComponent(TagsField, {
+        schema: {},
+        formData: ["a", "b", "c"],
+        uiSchema: {
+          "ui:options": {separator: ":"}
+        }
+      });
+
+      expect(node.querySelector("input").value)
+        .eql("a: b: c");
+    });
+  });
+
+  describe("Unique items", () => {
+    it("should accept duplicates by default", () => {
+      const node = createComponent(TagsField, {
+        schema: {},
+        formData: ["a", "b", "a"],
+      });
+
+      expect(node.querySelector("input").value)
+        .eql("a, b, a");
+    });
+
+    it("should drop duplicates with an uniqueItems enabled schema", (done) => {
+      const onChange = sinon.spy();
+      const node = createComponent(TagsField, {
+        schema: {uniqueItems: true},
+        formData: ["a", "b"],
+        onChange
+      });
+
+      Simulate.change(node.querySelector("input"), {
+        target: {value: "a, b, a"}
+      });
+
+      setImmediate(() => {
+        sinon.assert.calledWithExactly(onChange, ["a", "b"]);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
WiP. This allows entering a comma-separated list of strings in a text input in order to fill a jsonschema array field.

### Usage

For a given json schema declaring an array of strings, set its `ui:field` uiSchema to `tags`:

```js
const schema = {
  "type": "object",
  "properties": {
    "tags": {
      "type": "array",
      "uniqueItems": true,
      "items": {
        "type": "string"
      }
    }
  }
}

const uiSchema = {
  "tags": {
    "ui:field": "tags"
  }
}
```

![](http://i.imgur.com/RI0LIEd.png)

![](http://i.imgur.com/avW1cdJ.png)

### Todo

- [x] Initial implementation
- [x] Label support
- [x] Unique values
- [x] Custom separator