### PR TITLE
Fix #248: Prevent crash on uiSchema validation when JSON schema is invalid

### DIFF
--- a/src/components/collection/CollectionForm.js
+++ b/src/components/collection/CollectionForm.js
@@ -235,11 +235,12 @@ function validate({schema, uiSchema, displayFields}, errors) {
     validateSchema(schema);
   } catch(error) {
     errors.schema.addError(error);
+    return errors;
   }
   try {
     validateUiSchema(uiSchema, schema);
   } catch(error) {
-    errors.schema.addError(error);
+    errors.uiSchema.addError(error);
   }
   return errors;
 }


### PR DESCRIPTION
Fix #248