### PR TITLE
Fix #353: show changes in review step even if no perm to approve

### DIFF
--- a/src/plugins/signoff/components.js
+++ b/src/plugins/signoff/components.js
@@ -222,7 +222,7 @@ function Review(props: ReviewProps) {
     source,
     preview,
   } = props;
-  const active = step == currentStep && canEdit;
+  const active = step == currentStep;
 
   // If preview disabled, the preview object is empty.
   // We use the source last status change as review request datetime.
@@ -238,7 +238,7 @@ function Review(props: ReviewProps) {
   return (
     <ProgressStep {...{label, currentStep, step}}>
       {lastEditor ? <ReviewInfos {...{active, source, lastRequested, link, hasHistory}}/> : null}
-      {active ? <ReviewButtons onApprove={approveChanges} onDecline={declineChanges}/> : null}
+      {active  && canEdit ? <ReviewButtons onApprove={approveChanges} onDecline={declineChanges}/> : null}
     </ProgressStep>
   );
 }


### PR DESCRIPTION
Fix #353 

![screenshot from 2017-01-20 11-43-17](https://cloud.githubusercontent.com/assets/546692/22146710/da3a2e54-df05-11e6-852d-e9cadfcf0a93.png)
