### PR TITLE
Fix broken post-auth redirections.

### DIFF
--- a/src/sagas/route.js
+++ b/src/sagas/route.js
@@ -103,8 +103,8 @@ export function* routeUpdated(getState: GetStateFn, action: ActionType<typeof ac
   // Clear notifications on each route update
   yield put(clearNotifications());
 
-  // Check for an authenticated session; if we're requesting anything other
-  // than the homepage, redirect to the homepage with a notification.
+  // Check for a non-authenticated session; if we're requesting anything other
+  // than the homepage, proceed with a redirection.
   if (!authenticated && location.pathname !== "/") {
     if (token && payload) {
       // We've just been redirected with an auth token and payload
@@ -114,6 +114,8 @@ export function* routeUpdated(getState: GetStateFn, action: ActionType<typeof ac
       // Redirect to the initially requested URL
       yield put(updatePath(redirectURL));
     } else {
+      // We're requesting an app URL requiring authentication while we're not;
+      // Store current requested URL, wait for user authentication then redirect
       yield put(storeRedirectURL(location.pathname));
       yield put(updatePath(""));
       yield put(notifyInfo("Authentication required.", {persistent: true}));

--- a/test/sagas/route_test.js
+++ b/test/sagas/route_test.js
@@ -383,6 +383,34 @@ describe("route sagas", () => {
       });
     });
 
+    describe("Pending authentication", () => {
+      let routeUpdated;
+
+      before(() => {
+        const getState = () => ({session: {authenticated: false}});
+        const action = actions.routeUpdated({
+          token: "token",
+          payload: btoa(JSON.stringify({redirectURL: "/blah"}))
+        }, {});
+        routeUpdated = saga.routeUpdated(getState, action);
+      });
+
+      it("should clear notification", () => {
+        expect(routeUpdated.next().value)
+          .eql(put(notificationActions.clearNotifications()));
+      });
+
+      it("should wait for the SESSION_AUTHENTICATED event", () => {
+        expect(routeUpdated.next().value)
+          .eql(take(SESSION_AUTHENTICATED));
+      });
+
+      it("should redirect to the initially requested URL", () => {
+        expect(routeUpdated.next().value)
+          .eql(put(updatePath("/blah")));
+      });
+    });
+
     describe("Authenticated", () => {
       let routeUpdated;
       const params = {bid: "bucket", cid: "collection", rid: "record"};


### PR DESCRIPTION
We recently switched from localStorage to sessionStorage for volatile session data persistence, which introduced a regression with redirect URL storage; navigating to external auth sites like fxa and portier clears the sessionStorage, so we were loosing the stored redirectURL. 

This patch reads the redirectURL from the authentication payload we receive as an URL parameters and fixes this issue.