### PR TITLE
Fix #407: Order history entry target permissions consistently.

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -214,7 +214,10 @@ export type ResourceHistoryEntry = {
   id: string,
   last_modified: number,
   resource_name: string,
-  target: Object,
+  target: {
+    data: Object,
+    permissions: Object,
+  },
   timestamp: number,
   uri: string,
   user_id: string,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type { RecordData, Capabilities } from "./types";
+import type { RecordData, ResourceHistoryEntry, Capabilities } from "./types";
 import React from "react";
 import _timeago from "timeago.js";
 
@@ -238,4 +238,25 @@ export function scrollToTop(): Promise<void> {
 export function scrollToBottom(): Promise<void> {
   window.scrollTo(0, window.document.body.scrollHeight);
   return Promise.resolve();
+}
+
+export function sortHistoryEntryPermissions(
+  entry: ResourceHistoryEntry
+): ResourceHistoryEntry {
+  const currentPermissions = entry.target.permissions;
+  return entry.action === "delete"
+    ? entry
+    : {
+        ...entry,
+        target: {
+          ...entry.target,
+          permissions: Object.keys(currentPermissions).reduce(
+            (acc, type) => {
+              const permissions = currentPermissions[type];
+              return { ...acc, [type]: permissions.sort() };
+            },
+            {}
+          ),
+        },
+      };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -243,10 +243,10 @@ export function scrollToBottom(): Promise<void> {
 export function sortHistoryEntryPermissions(
   entry: ResourceHistoryEntry
 ): ResourceHistoryEntry {
-  if (entry.action === "delete") {
+  const { permissions } = entry.target;
+  if (!permissions) {
     return entry;
   }
-  const { permissions } = entry.target;
   return {
     ...entry,
     target: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -243,20 +243,18 @@ export function scrollToBottom(): Promise<void> {
 export function sortHistoryEntryPermissions(
   entry: ResourceHistoryEntry
 ): ResourceHistoryEntry {
-  const currentPermissions = entry.target.permissions;
-  return entry.action === "delete"
-    ? entry
-    : {
-        ...entry,
-        target: {
-          ...entry.target,
-          permissions: Object.keys(currentPermissions).reduce(
-            (acc, type) => {
-              const permissions = currentPermissions[type];
-              return { ...acc, [type]: permissions.sort() };
-            },
-            {}
-          ),
-        },
-      };
+  if (entry.action === "delete") {
+    return entry;
+  }
+  const { permissions } = entry.target;
+  return {
+    ...entry,
+    target: {
+      ...entry.target,
+      permissions: Object.keys(permissions).reduce(
+        (acc, type) => ({ ...acc, [type]: permissions[type].sort() }),
+        {}
+      ),
+    },
+  };
 }

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -8,6 +8,7 @@ import {
   humanDate,
   buildAttachmentUrl,
   timeago,
+  sortHistoryEntryPermissions,
 } from "../src/utils";
 
 describe("cleanRecord", () => {
@@ -246,5 +247,39 @@ describe("timeago", function() {
   it("should prevent rendering future events", () => {
     const now = new Date().getTime();
     expect(timeago(now + 86400000, now)).eql("just now");
+  });
+});
+
+describe("sortHistoryEntryPermissions()", () => {
+  it("should sort permissions", () => {
+    const entry = {
+      action: "update",
+      target: {
+        permissions: {
+          write: ["b", "c", "a"],
+          read: ["c", "a", "b"],
+        },
+      },
+    };
+    expect(sortHistoryEntryPermissions(entry)).eql({
+      action: "update",
+      target: {
+        permissions: {
+          write: ["a", "b", "c"],
+          read: ["a", "b", "c"],
+        },
+      },
+    });
+  });
+
+  it("should not process tombstones", () => {
+    const entry = {
+      action: "delete",
+      target: {
+        id: "x",
+        deleted: true,
+      },
+    };
+    expect(sortHistoryEntryPermissions(entry)).eql(entry);
   });
 });


### PR DESCRIPTION
Refs #407, ensure sorting history entry permissions list before rendering a diff.

![](http://i.imgur.com/S8Jhtbq.png)