### PR TITLE
sagas/route: redirectURL can sometimes be null

### DIFF
--- a/src/sagas/route.js
+++ b/src/sagas/route.js
@@ -133,8 +133,10 @@ export function* routeUpdated(
       const { redirectURL } = JSON.parse(atob(payload));
       // Wait until we're actually authenticated
       yield take(SESSION_AUTHENTICATED);
-      // Redirect to the initially requested URL
-      yield put(updatePath(redirectURL));
+      // Redirect to the initially requested URL (if any)
+      if (redirectURL) {
+        yield put(updatePath(redirectURL));
+      }
     } else {
       // We're requesting an app URL requiring authentication while we're not;
       // Store current requested URL, wait for user authentication then redirect


### PR DESCRIPTION
redirectURL starts out as null and is only updated if a user happens to
be viewing an authenticated page when they aren't logged in.

If a user tries to log in from the home page, no redirectURL will be
present and this updatePath call will fail.