### PR TITLE
Upgrade kinto-http to v4.3.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "diff": "^3.2.0",
     "express": "^4.14.0",
     "filesize": "^3.3.0",
-    "kinto-http": "^4.3.0",
+    "kinto-http": "^4.3.1",
     "react": "^15.4.2",
     "react-breadcrumbs": "^1.3.16",
     "react-codemirror": "^0.2.3",


### PR DESCRIPTION
This fixes an issue with Chrome not being able to execute HTTP CORS preflight requests.