### PR TITLE
Fix #428: Fix signoff plugin membership checks.

### DIFF
--- a/src/plugins/signoff/components.js
+++ b/src/plugins/signoff/components.js
@@ -16,7 +16,7 @@ import { ProgressBar, ProgressStep } from "./ProgressBar.js";
 
 function isMember(groupKey, source, sessionState, bucketState) {
   const { serverInfo: { user = {}, capabilities } } = sessionState;
-  if (!user.id) {
+  if (!source || !user.id) {
     return false;
   }
   const { signer = {} } = capabilities;
@@ -103,7 +103,11 @@ export default class SignoffToolBar extends React.Component {
     if (!collections) {
       return null;
     }
-    const { source, destination, preview } = collections;
+    const {
+      sourceInfo: source,
+      destinationinfo: destination,
+      previewInfo: preview,
+    } = collections;
 
     const canRequestReview =
       canEdit && isEditor(source, sessionState, bucketState);

--- a/src/plugins/signoff/components.js
+++ b/src/plugins/signoff/components.js
@@ -103,11 +103,7 @@ export default class SignoffToolBar extends React.Component {
     if (!collections) {
       return null;
     }
-    const {
-      sourceInfo: source,
-      destinationinfo: destination,
-      previewInfo: preview,
-    } = collections;
+    const { source, destination, preview } = collections;
 
     const canRequestReview =
       canEdit && isEditor(source, sessionState, bucketState);
@@ -218,6 +214,7 @@ function WorkInProgress(props: WorkInProgressProps) {
     confirmRequestReview,
     source,
   } = props;
+
   const active = step == currentStep;
   const { lastAuthor, lastReviewerComment, changes = {} } = source;
   const { lastUpdated } = changes;

--- a/src/plugins/signoff/sagas.js
+++ b/src/plugins/signoff/sagas.js
@@ -63,7 +63,11 @@ export function* onCollectionRecordsRequest(getState, action) {
     lastSigned: destinationAttributes.last_modified,
   };
   yield put(
-    SignoffActions.workflowInfo({ sourceInfo, previewInfo, destinationInfo })
+    SignoffActions.workflowInfo({
+      source: sourceInfo,
+      preview: previewInfo,
+      destination: destinationInfo,
+    })
   );
 }
 


### PR DESCRIPTION
Deployed to gh-pages. Note: needs enabling the Moz VPN and checks the `https://kinto-writer.stage.mozaws.net/v1/` server.