### PR TITLE
Reactivate and fix flow typechecking

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,9 +1,8 @@
 [ignore]
 .*/node_modules/*
 .*/test/.*
-.*/src/components/.*
-.*/src/containers/.*
-.*/src/plugins/.*
+.*/src/components/Sidebar.js
+.*/src/containers/Sidebar.js
 .*/src/routes.js
 .*/src/index.js
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -14,4 +14,3 @@ esproposal.class_static_fields=enable
 unsafe.enable_getters_and_setters=true
 module.name_mapper='.*\(.css\)' -> 'CSSModule'
 module.system=haste
-strip_root=true

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,10 +1,6 @@
 [ignore]
 .*/node_modules/*
 .*/test/.*
-.*/src/components/Sidebar.js
-.*/src/containers/Sidebar.js
-.*/src/routes.js
-.*/src/index.js
 
 [include]
 ./node_modules/

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,11 @@
 [ignore]
 .*/node_modules/*
 .*/test/.*
+.*/src/components/.*
+.*/src/containers/.*
+.*/src/plugins/.*
+.*/src/routes.js
+.*/src/index.js
 
 [include]
 ./node_modules/

--- a/interfaces/external-modules/kinto-http.d.js
+++ b/interfaces/external-modules/kinto-http.d.js
@@ -46,8 +46,8 @@ declare module "kinto-http" {
     defaultReqOptions: {
       headers: Object
     };
-    constructor(): void;
-    bucket(): Bucket;
+    constructor(remote: string, options: Options): void;
+    bucket(bucketId: string): Bucket;
     createBucket(id: ?string, options?: Options): Promise<ObjectResponseBody<Resource>>;
     deleteBucket(id: string, options?: Options): Promise<ObjectResponseBody<Resource>>;
     batch(): Promise<BatchResponse[]>;
@@ -58,7 +58,7 @@ declare module "kinto-http" {
 
   declare class Bucket {
     constructor(): void;
-    collection(): Collection;
+    collection(collectionId: string): Collection;
     setData(): Promise<*>;
     setPermissions(permissions: Permissions): Promise<ObjectResponseBody<Resource>>;
     createCollection(id: ?string, options?: Options): Promise<ObjectResponseBody<Resource>>;

--- a/interfaces/external-modules/kinto-http.d.js
+++ b/interfaces/external-modules/kinto-http.d.js
@@ -65,7 +65,7 @@ declare module "kinto-http" {
     deleteCollection(id: string, options?: Options): Promise<ObjectResponseBody<Resource>>;
     listCollections(options?: Options): Promise<ListResponseBody<Resource>>;
     setData(data: Object, options?: Options): Promise<Object>,
-    listHistory(): Promise<ListResponseBody<Object>>;
+    listHistory(options: Object): Promise<ListResponseBody<Object>>;
     createGroup(id: ?string, members: string[], options?: Options): Promise<ObjectResponseBody<Resource>>;
     updateGroup(group: Object, options?: Options): Promise<ObjectResponseBody<Resource>>;
     deleteGroup(id: string, options?: Options): Promise<ObjectResponseBody<Resource>>;
@@ -76,7 +76,7 @@ declare module "kinto-http" {
     setData(data: Object, options?: Options): Promise<Object>;
     setPermissions(permissions: Permissions): Promise<ObjectResponseBody<Resource>>;
     removeAttachment(): Promise<ObjectResponseBody<Resource>>;
-    listRecords(): Promise<ListResponseBody<Resource>>;
+    listRecords(options: Object): Promise<ListResponseBody<Resource>>;
     addAttachment(attachment: string, record: Object, options?: Options): Promise<ObjectResponseBody<Resource>>;
     createRecord(record: Object, options?: Options): Promise<ObjectResponseBody<Resource>>;
     updateRecord(record: Object, options?: Options): Promise<ObjectResponseBody<Resource>>;

--- a/interfaces/external-modules/react-redux.d.js
+++ b/interfaces/external-modules/react-redux.d.js
@@ -1,39 +1,50 @@
-import type { Dispatch, Store } from 'redux'
+import type { Dispatch, Store } from "redux";
 
-declare module 'react-redux' {
-
+declare module "react-redux" {
   /*
+
     S = State
     A = Action
     OP = OwnProps
     SP = StateProps
     DP = DispatchProps
+
   */
 
-  declare type MapStateToProps<S, OP: Object, SP: Object> = (state: S, ownProps: OP) => SP | MapStateToProps<S, OP, SP>;
+  declare type MapStateToProps<S, OP: Object, SP: Object> = (
+    state: S,
+    ownProps: OP
+  ) => SP;
 
-  declare type MapDispatchToProps<A, OP: Object, DP: Object> = ((dispatch: Dispatch<A>, ownProps: OP) => DP) | DP;
+  declare type MapDispatchToProps<A, OP: Object, DP: Object> =
+    | ((dispatch: Dispatch<A>, ownProps: OP) => DP)
+    | DP;
 
-  declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (stateProps: SP, dispatchProps: DP, ownProps: OP) => P;
+  declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (
+    stateProps: SP,
+    dispatchProps: DP,
+    ownProps: OP
+  ) => P;
 
-  declare type StatelessComponent<P> = (props: P) => ?React$Element<any>;
-
-  declare class ConnectedComponent<OP, P, Def, St> extends React$Component<void, OP, void> {
-    static WrappedComponent: Class<React$Component<Def, P, St>>;
-    getWrappedInstance(): React$Component<Def, P, St>;
-    static defaultProps: void;
-    props: OP;
-    state: void;
+  declare class ConnectedComponent<OP, P> extends React$Component<OP> {
+    static WrappedComponent: Class<React$Component<P>>,
+    getWrappedInstance(): React$Component<P>,
+    props: OP,
+    state: void
   }
 
-  declare type ConnectedComponentClass<OP, P, Def, St> = Class<ConnectedComponent<OP, P, Def, St>>;
+  declare type ConnectedComponentClass<OP, P> = Class<
+    ConnectedComponent<OP, P>
+  >;
 
-  declare type Connector<OP, P> = {
-    (component: StatelessComponent<P>): ConnectedComponentClass<OP, P, void, void>;
-    <Def, St>(component: Class<React$Component<Def, P, St>>): ConnectedComponentClass<OP, P, Def, St>;
-  };
+  declare type Connector<OP, P> = (
+    component: React$ComponentType<P>
+  ) => ConnectedComponentClass<OP, P>;
 
-  declare class Provider<S, A> extends React$Component<void, { store: Store<S, A>, children?: any }, void> { }
+  declare class Provider<S, A> extends React$Component<{
+    store: Store<S, A>,
+    children?: any
+  }> {}
 
   declare type ConnectOptions = {
     pure?: boolean,
@@ -80,5 +91,4 @@ declare module 'react-redux' {
     mergeProps: MergeProps<SP, DP, OP, P>,
     options?: ConnectOptions
   ): Connector<OP, P>;
-
 }

--- a/interfaces/external-modules/react-redux.d.js
+++ b/interfaces/external-modules/react-redux.d.js
@@ -29,8 +29,6 @@ declare module "react-redux" {
   declare class ConnectedComponent<OP, P> extends React$Component<OP> {
     static WrappedComponent: Class<React$Component<P>>,
     getWrappedInstance(): React$Component<P>,
-    props: OP,
-    state: void
   }
 
   declare type ConnectedComponentClass<OP, P> = Class<

--- a/interfaces/external-modules/redux-saga.d.js
+++ b/interfaces/external-modules/redux-saga.d.js
@@ -101,7 +101,7 @@ declare module 'redux-saga' {
 
   declare type TakeXFn =
      // Kinto specific
-     & (<Y, R, N, Fn: KintoAdminSaga<Y, R, N>>(pattern: Pattern, saga: Fn) => TakeXRet)
+     & (<Y, R, N, T1, Fn: KintoAdminSaga<Y, R, N>>(pattern: Pattern, saga: Fn, t1: T1) => TakeXRet)
      // end
      & (<Y, R, N, Fn: Saga0<Y, R, N>>(pattern: Pattern, saga: Fn) => TakeXRet)
      & (<T1, Y, R, N, Fn: Saga1<Y, R, N, T1>>(pattern: Pattern, saga: Fn, t1: T1) => TakeXRet)

--- a/interfaces/external-modules/timeago.d.js
+++ b/interfaces/external-modules/timeago.d.js
@@ -2,7 +2,7 @@ declare module "timeago.js" {
   declare class timeagoApi {
     format(date: Date | number | string): string;
   }
-  declare function timeago(): timeagoApi
+  declare function timeago(now: ?Date | number): timeagoApi
 
   declare var exports: typeof timeago
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-react": "^7.0.1",
     "extract-text-webpack-plugin": "^2.1.1",
     "file-loader": "^0.11.1",
-    "flow-bin": "^0.46.0",
+    "flow-bin": "^0.57.3",
     "gh-pages": "^1.0.0",
     "html": "1.0.0",
     "ignore-styles": "^5.0.1",

--- a/src/components/AdminLink.js
+++ b/src/components/AdminLink.js
@@ -11,7 +11,7 @@ import url from "../url";
 type Props = {
   name: string,
   params: RouteParams,
-  children?: React.Element<*>,
+  children?: React.Node,
 };
 
 export default class AdminLink extends PureComponent<Props> {

--- a/src/components/AdminLink.js
+++ b/src/components/AdminLink.js
@@ -2,7 +2,8 @@
 
 import type { RouteParams } from "../types";
 
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
+import * as React from "react";
 import { Link } from "react-router";
 
 import url from "../url";

--- a/src/components/AdminLink.js
+++ b/src/components/AdminLink.js
@@ -13,9 +13,7 @@ type Props = {
   children?: React.Element<*>,
 };
 
-export default class AdminLink extends PureComponent {
-  props: Props;
-
+export default class AdminLink extends PureComponent<Props> {
   render() {
     const { children, name, params, ...linkProps } = this.props;
     return (

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,6 @@
 /* @flow */
 import type { SessionState, RouteParams, Notifications } from "../types";
+import type { Element } from "react";
 
 import React, { PureComponent } from "react";
 import Breadcrumbs from "react-breadcrumbs";
@@ -35,11 +36,11 @@ type Props = {
   session: SessionState,
   logout: () => void,
   notificationList: Notifications,
-  routes: Element[],
+  routes: Element<*>[],
   params: RouteParams,
-  sidebar: Element,
-  notifications: Element,
-  content: Element,
+  sidebar: Element<*>,
+  notifications: Element<*>,
+  content: Element<*>,
 };
 
 export default class App extends PureComponent<Props> {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -31,18 +31,18 @@ function SessionInfoBar({ session, logout }) {
   );
 }
 
-export default class App extends PureComponent {
-  props: {
-    session: SessionState,
-    logout: () => void,
-    notificationList: Notifications,
-    routes: Element[],
-    params: RouteParams,
-    sidebar: Element,
-    notifications: Element,
-    content: Element,
-  };
+type Props = {
+  session: SessionState,
+  logout: () => void,
+  notificationList: Notifications,
+  routes: Element[],
+  params: RouteParams,
+  sidebar: Element,
+  notifications: Element,
+  content: Element,
+};
 
+export default class App extends PureComponent<Props> {
   render() {
     const {
       sidebar,

--- a/src/components/AuthForm.js
+++ b/src/components/AuthForm.js
@@ -6,11 +6,22 @@ import React, { PureComponent } from "react";
 import BaseForm from "./BaseForm";
 import { omit } from "../utils";
 
-class ServerHistory extends PureComponent {
-  state: {
-    menuOpened: boolean,
-  };
+type ServerHistoryProps = {
+  id: string,
+  value: string,
+  placeholder: string,
+  options: Object,
+  onChange: string => void,
+};
 
+type ServerHistoryState = {
+  menuOpened: boolean,
+};
+
+class ServerHistory extends PureComponent<
+  ServerHistoryProps,
+  ServerHistoryState
+> {
   constructor(props) {
     super(props);
     this.state = { menuOpened: false };
@@ -327,22 +338,25 @@ function extendUiSchemaWithHistory(
   };
 }
 
-export default class AuthForm extends PureComponent {
-  props: {
-    session: SessionState,
-    history: string[],
-    settings: SettingsState,
-    setup: (session: Object) => void,
-    navigateToExternalAuth: (authFormData: Object) => void,
-    clearHistory: () => void,
-  };
+type AuthFormProps = {
+  session: SessionState,
+  history: string[],
+  settings: SettingsState,
+  setup: (session: Object) => void,
+  navigateToExternalAuth: (authFormData: Object) => void,
+  clearHistory: () => void,
+};
 
-  state: {
-    schema: Object,
-    uiSchema: Object,
-    formData: Object,
-  };
+type AuthFormState = {
+  schema: Object,
+  uiSchema: Object,
+  formData: Object,
+};
 
+export default class AuthForm extends PureComponent<
+  AuthFormProps,
+  AuthFormState
+> {
   defaultProps = {
     history: [],
   };

--- a/src/components/BaseForm.js
+++ b/src/components/BaseForm.js
@@ -6,7 +6,10 @@ import TagsField from "./TagsField";
 
 const adminFields = { tags: TagsField };
 
-export default class BaseForm extends PureComponent {
+export default class BaseForm<Props, State = void> extends PureComponent<
+  Props,
+  State
+> {
   render() {
     return <Form {...this.props} fields={adminFields} />;
   }

--- a/src/components/HistoryTable.js
+++ b/src/components/HistoryTable.js
@@ -365,17 +365,21 @@ export default class HistoryTable extends PureComponent<Props, State> {
       </thead>
     );
 
-    const tbody = history.map((entry, index) => {
-      return (
-        <HistoryRow
-          key={index}
-          pos={index}
-          enableDiffOverview={enableDiffOverview}
-          bid={bid}
-          entry={entry}
-        />
-      );
-    });
+    const tbody = (
+      <tbody>
+        {history.map((entry, index) => {
+          return (
+            <HistoryRow
+              key={index}
+              pos={index}
+              enableDiffOverview={enableDiffOverview}
+              bid={bid}
+              entry={entry}
+            />
+          );
+        })}
+      </tbody>
+    );
 
     return (
       <div>

--- a/src/components/HistoryTable.js
+++ b/src/components/HistoryTable.js
@@ -200,7 +200,7 @@ class HistoryRow extends PureComponent<HistoryRowProps, HistoryRowState> {
             ) : previous ? (
               <Diff source={entry.target} target={previous.target} />
             ) : error ? (
-              <p className="alert alert-danger">{error}</p>
+              <p className="alert alert-danger">{error.toString()}</p>
             ) : (
               <pre>{JSON.stringify(entry.target, null, 2)}</pre>
             )}

--- a/src/components/HistoryTable.js
+++ b/src/components/HistoryTable.js
@@ -69,23 +69,23 @@ function fetchCollectionStateAt(
   });
 }
 
-class HistoryRow extends PureComponent {
-  props: {
-    bid: string,
-    entry: ResourceHistoryEntry,
-    pos: number,
-    enableDiffOverview: boolean,
-  };
+type HistoryRowProps = {
+  bid: string,
+  entry: ResourceHistoryEntry,
+  pos: number,
+  enableDiffOverview: boolean,
+};
 
+type HistoryRowState = {
+  open: boolean,
+  busy: boolean,
+  previous: ?ResourceHistoryEntry,
+  error: ?Error,
+};
+
+class HistoryRow extends PureComponent<HistoryRowProps, HistoryRowState> {
   static defaultProps = {
     enableDiffOverview: false,
-  };
-
-  state: {
-    open: boolean,
-    busy: boolean,
-    previous: ?ResourceHistoryEntry,
-    error: ?Error,
   };
 
   constructor(props) {
@@ -286,18 +286,16 @@ type Props = {
   notifyError: (message: string, error: Error) => void,
 };
 
-export default class HistoryTable extends PureComponent {
-  props: Props;
+type State = {
+  diffOverview: boolean,
+  busy: boolean,
+  current: ?(RecordData[]),
+  previous: ?(RecordData[]),
+};
 
+export default class HistoryTable extends PureComponent<Props, State> {
   static defaultProps = {
     enableDiffOverview: false,
-  };
-
-  state: {
-    diffOverview: boolean,
-    busy: boolean,
-    current: ?(RecordData[]),
-    previous: ?(RecordData[]),
   };
 
   constructor(props: Props) {

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -57,16 +57,16 @@ function SessionInfo({ session: { busy, serverInfo } }) {
   );
 }
 
-export default class HomePage extends PureComponent {
-  props: {
-    session: SessionState,
-    settings: SettingsState,
-    history: string[],
-    clearHistory: () => void,
-    setup: (session: Object) => void,
-    navigateToExternalAuth: (authFormData: Object) => void,
-  };
+type Props = {
+  session: SessionState,
+  settings: SettingsState,
+  history: string[],
+  clearHistory: () => void,
+  setup: (session: Object) => void,
+  navigateToExternalAuth: (authFormData: Object) => void,
+};
 
+export default class HomePage extends PureComponent<Props> {
   render() {
     const {
       session,

--- a/src/components/JSONEditor.js
+++ b/src/components/JSONEditor.js
@@ -18,14 +18,14 @@ const cmOptions = {
   tabSize: 2,
 };
 
-export default class JSONEditor extends PureComponent {
-  props: {
-    readonly: boolean,
-    disabled: boolean,
-    value: any,
-    onChange: (code: string) => void,
-  };
+type Props = {
+  readonly: boolean,
+  disabled: boolean,
+  value: any,
+  onChange: (code: string) => void,
+};
 
+export default class JSONEditor extends PureComponent<Props> {
   onCodeChange = (editor: Object, metadata: any, code: string) => {
     this.props.onChange(code);
   };

--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -3,7 +3,7 @@ import type { Notifications } from "../types";
 
 import React, { PureComponent } from "react";
 
-class ErrorDetails extends PureComponent {
+class ErrorDetails extends PureComponent<{ details: Array<string> }> {
   render() {
     const { details } = this.props;
     if (details.length === 0) {
@@ -19,21 +19,24 @@ class ErrorDetails extends PureComponent {
   }
 }
 
-export class Notification extends PureComponent {
+type NotificationProps = {
+  type: string,
+  message: string,
+  details: string[],
+  close: () => void,
+};
+
+type NotificationState = {
+  expanded: boolean,
+};
+
+export class Notification extends PureComponent<
+  NotificationProps,
+  NotificationState
+> {
   static defaultProps = {
     type: "info",
     details: [],
-  };
-
-  props: {
-    type: string,
-    message: string,
-    details: string[],
-    close: () => void,
-  };
-
-  state: {
-    expanded: boolean,
   };
 
   constructor(props: Object) {
@@ -93,15 +96,15 @@ export class Notification extends PureComponent {
   }
 }
 
-export default class Notifications_ extends PureComponent {
+type Props = {
+  notifications: Notifications,
+  removeNotification: (index: number) => void,
+};
+
+export default class Notifications_ extends PureComponent<Props> {
   // This is useful to identify wrapped component for plugin hooks when code is
   // minified; see https://github.com/facebook/react/issues/4915
   static displayName = "Notifications";
-
-  props: {
-    notifications: Notifications,
-    removeNotification: (index: number) => void,
-  };
 
   render() {
     const { notifications, removeNotification } = this.props;

--- a/src/components/PaginatedTable.js
+++ b/src/components/PaginatedTable.js
@@ -1,10 +1,20 @@
 /* @flow */
 
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
+import * as React from "react";
 
 import Spinner from "./Spinner";
 
-export default class PaginatedTable extends PureComponent {
+type Props = {
+  thead: React.Element<React.ElementType>,
+  tbody: React.Element<React.ElementType>,
+  dataLoaded: boolean,
+  colSpan: number,
+  hasNextPage: boolean,
+  listNextPage: ?() => void,
+};
+
+export default class PaginatedTable extends PureComponent<Props> {
   render() {
     const {
       thead,
@@ -30,7 +40,11 @@ export default class PaginatedTable extends PureComponent {
                     key="__3"
                     onClick={event => {
                       event.preventDefault();
-                      listNextPage();
+                      // FIXME: we should always have listNextPage if
+                      // we have hasNextPage
+                      if (listNextPage) {
+                        listNextPage();
+                      }
                     }}>
                     Load more
                   </a>

--- a/src/components/PermissionsForm.js
+++ b/src/components/PermissionsForm.js
@@ -11,16 +11,16 @@ import {
   preparePermissionsForm,
 } from "../permission";
 
-export default class PermissionsForm extends PureComponent {
-  props: {
-    bid: string,
-    readonly: boolean,
-    permissions: Permissions,
-    groups: GroupData[],
-    acls: string[],
-    onSubmit: (data: { formData: Object }) => void,
-  };
+type Props = {
+  bid: string,
+  readonly: boolean,
+  permissions: Permissions,
+  groups: GroupData[],
+  acls: string[],
+  onSubmit: (data: { formData: Object }) => void,
+};
 
+export default class PermissionsForm extends PureComponent<Props> {
   onSubmit = ({ formData }: { formData: Object }) => {
     const { bid, onSubmit } = this.props;
     onSubmit({ formData: formDataToPermissions(bid, formData) });

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -7,13 +7,22 @@ import type {
   BucketEntry,
 } from "../types";
 
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
+import * as React from "react";
 
 import Spinner from "./Spinner";
 import AdminLink from "./AdminLink";
 import url from "../url";
 
-function SideBarLink(props) {
+type SideBarLinkProps = {
+  currentPath: string,
+  name: string,
+  params: RouteParams,
+  children: React.Node,
+  className?: string,
+};
+
+function SideBarLink(props: SideBarLinkProps) {
   const {
     currentPath,
     name,
@@ -150,14 +159,12 @@ function filterBuckets(buckets, filters): BucketEntry[] {
     .filter(bucket => !(hideReadOnly && bucket.readonly));
 }
 
-class BucketsMenu extends PureComponent {
-  props: BucketsMenuProps;
+type BucketsMenuState = {
+  hideReadOnly: boolean,
+  search: ?string,
+};
 
-  state: {
-    hideReadOnly: boolean,
-    search: ?string,
-  };
-
+class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
   constructor(props: BucketsMenuProps) {
     super(props);
     this.state = { hideReadOnly: false, search: null };
@@ -276,22 +283,28 @@ class BucketsMenu extends PureComponent {
   }
 }
 
-export default class Sidebar extends PureComponent {
+type SidebarProps = {
+  session: SessionState,
+  settings: SettingsState,
+  params: RouteParams,
+  location: RouteLocation,
+};
+
+export default class Sidebar extends PureComponent<SidebarProps> {
   // This is useful to identify wrapped component for plugin hooks when code is
   // minified; see https://github.com/facebook/react/issues/4915
   static displayName = "Sidebar";
-
-  props: {
-    session: SessionState,
-    settings: SettingsState,
-    params: RouteParams,
-    location: RouteLocation,
-  };
 
   render() {
     const { session, settings, params, location } = this.props;
     const { pathname: currentPath } = location;
     const { bid, cid } = params;
+    if (!bid) {
+      throw new Error("can't happen -- bid missing from params");
+    }
+    if (!cid) {
+      throw new Error("can't happen -- cid missing from params");
+    }
     const { busy, authenticated, buckets = [] } = session;
     const { sidebarMaxListedCollections } = settings;
     return (

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -197,7 +197,10 @@ class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
       <div>
         <div className="panel panel-default">
           <div className="list-group">
-            <SideBarLink name="bucket:create" currentPath={currentPath}>
+            <SideBarLink
+              name="bucket:create"
+              currentPath={currentPath}
+              params={{}}>
               <i className="glyphicon glyphicon-plus" />
               Create bucket
             </SideBarLink>
@@ -311,7 +314,7 @@ export default class Sidebar extends PureComponent<SidebarProps> {
       <div>
         <div className="panel panel-default">
           <div className="list-group">
-            <SideBarLink name="home" currentPath={currentPath}>
+            <SideBarLink name="home" currentPath={currentPath} params={{}}>
               Home
             </SideBarLink>
           </div>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -7,6 +7,7 @@ import type {
   BucketEntry,
 } from "../types";
 
+import type { Element } from "react";
 import React, { PureComponent } from "react";
 
 import Spinner from "./Spinner";
@@ -128,7 +129,7 @@ type BucketsMenuProps = {
   sidebarMaxListedCollections: ?number,
 };
 
-function filterBuckets(buckets, filters) {
+function filterBuckets(buckets, filters): BucketEntry[] {
   const { hideReadOnly, search } = filters;
   return buckets
     .slice(0)

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -132,8 +132,8 @@ type BucketsMenuProps = {
   currentPath: string,
   busy: boolean,
   buckets: BucketEntry[],
-  bid: string,
-  cid: string,
+  bid: ?string,
+  cid: ?string,
   sidebarMaxListedCollections: ?number,
 };
 
@@ -302,12 +302,6 @@ export default class Sidebar extends PureComponent<SidebarProps> {
     const { session, settings, params, location } = this.props;
     const { pathname: currentPath } = location;
     const { bid, cid } = params;
-    if (!bid) {
-      throw new Error("can't happen -- bid missing from params");
-    }
-    if (!cid) {
-      throw new Error("can't happen -- cid missing from params");
-    }
     const { busy, authenticated, buckets = [] } = session;
     const { sidebarMaxListedCollections } = settings;
     return (

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -7,7 +7,6 @@ import type {
   BucketEntry,
 } from "../types";
 
-import type { Element } from "react";
 import React, { PureComponent } from "react";
 
 import Spinner from "./Spinner";

--- a/src/components/TagsField.js
+++ b/src/components/TagsField.js
@@ -33,10 +33,7 @@ type State = {
   tagsString: string,
 };
 
-export default class TagsField extends PureComponent {
-  props: Props;
-  state: State;
-
+export default class TagsField extends PureComponent<Props, State> {
   static defaultProps = {
     formData: [],
     uiSchema: {},

--- a/src/components/bucket/BucketAttributes.js
+++ b/src/components/bucket/BucketAttributes.js
@@ -13,16 +13,16 @@ import Spinner from "../Spinner";
 import BucketForm from "./BucketForm";
 import BucketTabs from "./BucketTabs";
 
-export default class BucketAttributes extends PureComponent {
-  props: {
-    params: BucketRouteParams,
-    session: SessionState,
-    bucket: BucketState,
-    capabilities: Capabilities,
-    updateBucket: (bid: string, data: BucketData) => void,
-    deleteBucket: (bid: string) => void,
-  };
+type Props = {
+  params: BucketRouteParams,
+  session: SessionState,
+  bucket: BucketState,
+  capabilities: Capabilities,
+  updateBucket: (bid: string, data: BucketData) => void,
+  deleteBucket: (bid: string) => void,
+};
 
+export default class BucketAttributes extends PureComponent<Props> {
   deleteBucket = (bid: string) => {
     const { deleteBucket } = this.props;
     const message = [

--- a/src/components/bucket/BucketCollections.js
+++ b/src/components/bucket/BucketCollections.js
@@ -103,15 +103,15 @@ function ListActions(props) {
   );
 }
 
-export default class BucketCollections extends PureComponent {
-  props: {
-    params: BucketRouteParams,
-    session: SessionState,
-    bucket: BucketState,
-    capabilities: Capabilities,
-    listBucketNextCollections: () => void,
-  };
+type Props = {
+  params: BucketRouteParams,
+  session: SessionState,
+  bucket: BucketState,
+  capabilities: Capabilities,
+  listBucketNextCollections: () => void,
+};
 
+export default class BucketCollections extends PureComponent<Props> {
   render() {
     const {
       params,

--- a/src/components/bucket/BucketCollections.js
+++ b/src/components/bucket/BucketCollections.js
@@ -32,14 +32,17 @@ function DataList(props) {
     <tbody className={!loaded ? "loading" : ""}>
       {entries.map((collection, index) => {
         const { id: cid, schema, cache_expires, last_modified } = collection;
-        const date = new Date(last_modified);
+        // FIXME: last_modified should always be here, but the types
+        // don't express that
+        const date = last_modified && new Date(last_modified);
+        const ageString = date && timeago(date.getTime());
         return (
           <tr key={index}>
             <td>{cid}</td>
             <td>{schema ? "Yes" : "No"}</td>
             <td>{cache_expires ? `${cache_expires} seconds` : "No"}</td>
             <td>
-              <span title={date.toISOString()}>{timeago(date.getTime())}</span>
+              <span title={date ? date.toISOString() : ""}>{ageString}</span>
             </td>
             <td className="actions">
               <div className="btn-group">

--- a/src/components/bucket/BucketCreate.js
+++ b/src/components/bucket/BucketCreate.js
@@ -6,13 +6,13 @@ import React, { PureComponent } from "react";
 import BucketForm from "./BucketForm";
 import Spinner from "../Spinner";
 
-export default class BucketCreate extends PureComponent {
-  props: {
-    session: SessionState,
-    bucket: BucketState,
-    createBucket: (bid: string, data: BucketData) => void,
-  };
+type Props = {
+  session: SessionState,
+  bucket: BucketState,
+  createBucket: (bid: string, data: BucketData) => void,
+};
 
+export default class BucketCreate extends PureComponent<Props> {
   render() {
     const { session, bucket, createBucket } = this.props;
     const { busy } = session;

--- a/src/components/bucket/BucketForm.js
+++ b/src/components/bucket/BucketForm.js
@@ -79,16 +79,16 @@ function DeleteForm({ bid, onSubmit }) {
   );
 }
 
-export default class BucketForm extends PureComponent {
-  props: {
-    bid?: string,
-    session: SessionState,
-    bucket: BucketState,
-    formData?: BucketData,
-    deleteBucket?: (bid: string) => void,
-    onSubmit: (data: Object) => void,
-  };
+type Props = {
+  bid?: string,
+  session: SessionState,
+  bucket: BucketState,
+  formData?: BucketData,
+  deleteBucket?: (bid: string) => void,
+  onSubmit: (data: Object) => void,
+};
 
+export default class BucketForm extends PureComponent<Props> {
   onSubmit = ({ formData }: { formData: Object }) => {
     const { id, data } = formData;
     // Parse JSON fields so they can be sent to the server

--- a/src/components/bucket/BucketGroups.js
+++ b/src/components/bucket/BucketGroups.js
@@ -85,14 +85,14 @@ function ListActions({ bid, session, bucket }) {
   );
 }
 
-export default class BucketCollections extends PureComponent {
-  props: {
-    params: BucketRouteParams,
-    session: SessionState,
-    bucket: BucketState,
-    capabilities: Capabilities,
-  };
+type Props = {
+  params: BucketRouteParams,
+  session: SessionState,
+  bucket: BucketState,
+  capabilities: Capabilities,
+};
 
+export default class BucketCollections extends PureComponent<Props> {
   render() {
     const { params, session, bucket, capabilities } = this.props;
     const { bid } = params;

--- a/src/components/bucket/BucketHistory.js
+++ b/src/components/bucket/BucketHistory.js
@@ -11,16 +11,16 @@ import React, { PureComponent } from "react";
 import BucketTabs from "./BucketTabs";
 import HistoryTable from "../HistoryTable";
 
-export default class BucketHistory extends PureComponent {
-  props: {
-    params: BucketRouteParams,
-    bucket: BucketState,
-    capabilities: Capabilities,
-    location: RouteLocation,
-    listBucketNextHistory: () => void,
-    notifyError: (message: string, error: ?Error) => void,
-  };
+type Props = {
+  params: BucketRouteParams,
+  bucket: BucketState,
+  capabilities: Capabilities,
+  location: RouteLocation,
+  listBucketNextHistory: () => void,
+  notifyError: (message: string, error: ?Error) => void,
+};
 
+export default class BucketHistory extends PureComponent<Props> {
   render() {
     const {
       params,

--- a/src/components/bucket/BucketPermissions.js
+++ b/src/components/bucket/BucketPermissions.js
@@ -14,18 +14,15 @@ import BucketTabs from "./BucketTabs";
 import PermissionsForm from "../PermissionsForm";
 import { canEditBucket } from "../../permission";
 
-export default class BucketPermissions_ extends PureComponent {
-  props: {
-    params: BucketRouteParams,
-    session: SessionState,
-    bucket: BucketState,
-    capabilities: Capabilities,
-    updateBucket: (
-      bid: string,
-      data: { permissions: BucketPermissions }
-    ) => void,
-  };
+type Props = {
+  params: BucketRouteParams,
+  session: SessionState,
+  bucket: BucketState,
+  capabilities: Capabilities,
+  updateBucket: (bid: string, data: { permissions: BucketPermissions }) => void,
+};
 
+export default class BucketPermissions_ extends PureComponent<Props> {
   onSubmit = ({ formData }: { formData: BucketPermissions }) => {
     const { params, updateBucket } = this.props;
     const { bid } = params;

--- a/src/components/bucket/BucketTabs.js
+++ b/src/components/bucket/BucketTabs.js
@@ -1,7 +1,8 @@
 /* @flow */
 import type { Capabilities } from "../../types";
 
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
+import * as React from "react";
 
 import AdminLink from "../AdminLink";
 

--- a/src/components/bucket/BucketTabs.js
+++ b/src/components/bucket/BucketTabs.js
@@ -10,7 +10,7 @@ type Props = {
   bid: string,
   selected: "collections" | "groups" | "attributes" | "permissions" | "history",
   capabilities: Capabilities,
-  children?: React.Element<*>,
+  children?: React.Node,
 };
 
 export default class BucketTabs extends PureComponent<Props> {

--- a/src/components/bucket/BucketTabs.js
+++ b/src/components/bucket/BucketTabs.js
@@ -5,19 +5,14 @@ import React, { PureComponent } from "react";
 
 import AdminLink from "../AdminLink";
 
-export default class BucketTabs extends PureComponent {
-  props: {
-    bid: string,
-    selected:
-      | "collections"
-      | "groups"
-      | "attributes"
-      | "permissions"
-      | "history",
-    capabilities: Capabilities,
-    children?: React.Element<*>,
-  };
+type Props = {
+  bid: string,
+  selected: "collections" | "groups" | "attributes" | "permissions" | "history",
+  capabilities: Capabilities,
+  children?: React.Element<*>,
+};
 
+export default class BucketTabs extends PureComponent<Props> {
   render() {
     const { bid, selected, capabilities, children } = this.props;
 

--- a/src/components/collection/CollectionAttributes.js
+++ b/src/components/collection/CollectionAttributes.js
@@ -14,17 +14,17 @@ import Spinner from "../Spinner";
 import CollectionForm from "./CollectionForm";
 import CollectionTabs from "./CollectionTabs";
 
-export default class CollectionAttributes extends PureComponent {
-  props: {
-    session: SessionState,
-    bucket: BucketState,
-    collection: CollectionState,
-    capabilities: Capabilities,
-    params: CollectionRouteParams,
-    updateCollection: (bid: string, cid: string, data: CollectionData) => void,
-    deleteCollection: (bid: string, cid: string) => void,
-  };
+type Props = {
+  session: SessionState,
+  bucket: BucketState,
+  collection: CollectionState,
+  capabilities: Capabilities,
+  params: CollectionRouteParams,
+  updateCollection: (bid: string, cid: string, data: CollectionData) => void,
+  deleteCollection: (bid: string, cid: string) => void,
+};
 
+export default class CollectionAttributes extends PureComponent<Props> {
   onSubmit = (formData: CollectionData) => {
     const { params, updateCollection } = this.props;
     const { bid, cid } = params;

--- a/src/components/collection/CollectionCreate.js
+++ b/src/components/collection/CollectionCreate.js
@@ -13,16 +13,16 @@ import React, { PureComponent } from "react";
 import Spinner from "../Spinner";
 import CollectionForm from "./CollectionForm";
 
-export default class CollectionCreate extends PureComponent {
-  props: {
-    session: SessionState,
-    bucket: BucketState,
-    collection: CollectionState,
-    capabilities: Capabilities,
-    params: BucketRouteParams,
-    createCollection: (bid: string, data: CollectionData) => void,
-  };
+type Props = {
+  session: SessionState,
+  bucket: BucketState,
+  collection: CollectionState,
+  capabilities: Capabilities,
+  params: BucketRouteParams,
+  createCollection: (bid: string, data: CollectionData) => void,
+};
 
+export default class CollectionCreate extends PureComponent<Props> {
   render() {
     const {
       params,

--- a/src/components/collection/CollectionForm.js
+++ b/src/components/collection/CollectionForm.js
@@ -301,13 +301,11 @@ type Props = {
   formData?: CollectionData,
 };
 
-export default class CollectionForm extends PureComponent {
-  props: Props;
+type State = {
+  asJSON: boolean,
+};
 
-  state: {
-    asJSON: boolean,
-  };
-
+export default class CollectionForm extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { asJSON: false };

--- a/src/components/collection/CollectionHistory.js
+++ b/src/components/collection/CollectionHistory.js
@@ -13,18 +13,18 @@ import React, { PureComponent } from "react";
 import HistoryTable from "../HistoryTable";
 import CollectionTabs from "./CollectionTabs";
 
-export default class CollectionHistory extends PureComponent {
-  props: {
-    session: SessionState,
-    bucket: BucketState,
-    collection: CollectionState,
-    capabilities: Capabilities,
-    params: CollectionRouteParams,
-    location: RouteLocation,
-    listCollectionNextHistory: () => void,
-    notifyError: (message: string, error: ?Error) => void,
-  };
+type Props = {
+  session: SessionState,
+  bucket: BucketState,
+  collection: CollectionState,
+  capabilities: Capabilities,
+  params: CollectionRouteParams,
+  location: RouteLocation,
+  listCollectionNextHistory: () => void,
+  notifyError: (message: string, error: ?Error) => void,
+};
 
+export default class CollectionHistory extends PureComponent<Props> {
   render() {
     const {
       params,

--- a/src/components/collection/CollectionPermissions.js
+++ b/src/components/collection/CollectionPermissions.js
@@ -15,20 +15,20 @@ import CollectionTabs from "./CollectionTabs";
 import PermissionsForm from "../PermissionsForm";
 import { canEditCollection } from "../../permission";
 
-export default class CollectionPermissions_ extends PureComponent {
-  props: {
-    session: SessionState,
-    bucket: BucketState,
-    collection: CollectionState,
-    capabilities: Capabilities,
-    params: CollectionRouteParams,
-    updateCollection: (
-      bid: string,
-      cid: string,
-      data: { permissions: CollectionPermissions }
-    ) => void,
-  };
+type Props = {
+  session: SessionState,
+  bucket: BucketState,
+  collection: CollectionState,
+  capabilities: Capabilities,
+  params: CollectionRouteParams,
+  updateCollection: (
+    bid: string,
+    cid: string,
+    data: { permissions: CollectionPermissions }
+  ) => void,
+};
 
+export default class CollectionPermissions_ extends PureComponent<Props> {
   onSubmit = ({ formData }: { formData: CollectionPermissions }) => {
     const { params, updateCollection } = this.props;
     const { bid, cid } = params;

--- a/src/components/collection/CollectionRecords.js
+++ b/src/components/collection/CollectionRecords.js
@@ -5,6 +5,7 @@ import type {
   BucketState,
   CollectionState,
   Capabilities,
+  RecordData,
 } from "../../types";
 
 import React, { PureComponent } from "react";
@@ -15,7 +16,24 @@ import AdminLink from "../AdminLink";
 import CollectionTabs from "./CollectionTabs";
 import PaginatedTable from "../PaginatedTable";
 
-class Row extends PureComponent {
+type CommonProps = {
+  capabilities: Capabilities,
+  deleteRecord: (bid: string, cid: string, rid: string) => void,
+  redirectTo: (name: string, params: CollectionRouteParams) => void,
+};
+
+type RecordsViewProps = CommonProps & {
+  bid: string,
+  cid: string,
+  displayFields: string[],
+  schema: Object,
+};
+
+type RowProps = RecordsViewProps & {
+  record: RecordData,
+};
+
+class Row extends PureComponent<RowProps> {
   static defaultProps = {
     schema: {},
     record: {},
@@ -146,7 +164,16 @@ function ColumnSortLink(props) {
   );
 }
 
-class Table extends PureComponent {
+type TableProps = RecordsViewProps & {
+  currentSort: string,
+  hasNextRecords: boolean,
+  listNextRecords: () => void,
+  records: RecordData[],
+  recordsLoaded: boolean,
+  updateSort: string => void,
+};
+
+class Table extends PureComponent<TableProps> {
   getFieldTitle(displayField) {
     const { schema } = this.props;
     if (displayField === "__json") {
@@ -284,17 +311,14 @@ function ListActions(props) {
   );
 }
 
-type Props = {
-  capabilities: Capabilities,
+type Props = CommonProps & {
   pluginHooks: Object,
   params: CollectionRouteParams,
   session: SessionState,
   bucket: BucketState,
   collection: CollectionState,
-  deleteRecord: (bid: string, cid: string, rid: string) => void,
   listRecords: (bid: string, cid: string, sort: ?string) => void,
   listNextRecords: () => void,
-  redirectTo: (name: string, params: CollectionRouteParams) => void,
 };
 
 export default class CollectionRecords extends PureComponent<Props> {

--- a/src/components/collection/CollectionRecords.js
+++ b/src/components/collection/CollectionRecords.js
@@ -395,7 +395,7 @@ export default class CollectionRecords extends PureComponent<Props> {
             hasNextRecords={hasNextRecords}
             listNextRecords={listNextRecords}
             currentSort={currentSort}
-            schema={schema}
+            schema={schema || {}}
             displayFields={displayFields || ["__json"]}
             deleteRecord={deleteRecord}
             updateSort={this.updateSort}

--- a/src/components/collection/CollectionRecords.js
+++ b/src/components/collection/CollectionRecords.js
@@ -18,7 +18,13 @@ import PaginatedTable from "../PaginatedTable";
 
 type CommonProps = {
   capabilities: Capabilities,
-  deleteRecord: (bid: string, cid: string, rid: string) => void,
+  // FIXME: rid *must* be passed on calls to deleteRecord
+  deleteRecord: (
+    bid: string,
+    cid: string,
+    rid: ?string,
+    last_modified: ?number
+  ) => void,
   redirectTo: (name: string, params: CollectionRouteParams) => void,
 };
 

--- a/src/components/collection/CollectionRecords.js
+++ b/src/components/collection/CollectionRecords.js
@@ -284,23 +284,23 @@ function ListActions(props) {
   );
 }
 
-export default class CollectionRecords extends PureComponent {
+type Props = {
+  capabilities: Capabilities,
+  pluginHooks: Object,
+  params: CollectionRouteParams,
+  session: SessionState,
+  bucket: BucketState,
+  collection: CollectionState,
+  deleteRecord: (bid: string, cid: string, rid: string) => void,
+  listRecords: (bid: string, cid: string, sort: ?string) => void,
+  listNextRecords: () => void,
+  redirectTo: (name: string, params: CollectionRouteParams) => void,
+};
+
+export default class CollectionRecords extends PureComponent<Props> {
   // This is useful to identify wrapped component for plugin hooks when code is
   // minified; see https://github.com/facebook/react/issues/4915
   static displayName = "CollectionRecords";
-
-  props: {
-    capabilities: Capabilities,
-    pluginHooks: Object,
-    params: CollectionRouteParams,
-    session: SessionState,
-    bucket: BucketState,
-    collection: CollectionState,
-    deleteRecord: (bid: string, cid: string, rid: string) => void,
-    listRecords: (bid: string, cid: string, sort: ?string) => void,
-    listNextRecords: () => void,
-    redirectTo: (name: string, params: CollectionRouteParams) => void,
-  };
 
   updateSort = (sort: string) => {
     const { params, listRecords } = this.props;

--- a/src/components/collection/CollectionTabs.js
+++ b/src/components/collection/CollectionTabs.js
@@ -1,7 +1,8 @@
 /* @flow */
 import type { Capabilities } from "../../types";
 
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
+import * as React from "react";
 
 import AdminLink from "../AdminLink";
 

--- a/src/components/collection/CollectionTabs.js
+++ b/src/components/collection/CollectionTabs.js
@@ -11,7 +11,7 @@ type Props = {
   cid: string,
   selected: "records" | "attributes" | "permissions" | "history",
   capabilities: Capabilities,
-  children?: React.Element<*>,
+  children?: React.Node,
 };
 
 export default class CollectionTabs extends PureComponent<Props> {

--- a/src/components/collection/CollectionTabs.js
+++ b/src/components/collection/CollectionTabs.js
@@ -5,15 +5,15 @@ import React, { PureComponent } from "react";
 
 import AdminLink from "../AdminLink";
 
-export default class CollectionTabs extends PureComponent {
-  props: {
-    bid: string,
-    cid: string,
-    selected: "records" | "attributes" | "permissions" | "history",
-    capabilities: Capabilities,
-    children?: React.Element<*>,
-  };
+type Props = {
+  bid: string,
+  cid: string,
+  selected: "records" | "attributes" | "permissions" | "history",
+  capabilities: Capabilities,
+  children?: React.Element<*>,
+};
 
+export default class CollectionTabs extends PureComponent<Props> {
   render() {
     const { bid, cid, selected, capabilities, children } = this.props;
 

--- a/src/components/collection/JSONCollectionForm.js
+++ b/src/components/collection/JSONCollectionForm.js
@@ -1,7 +1,9 @@
 /* @flow */
 import type { CollectionData } from "../../types";
 
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
+import * as React from "react";
+
 import Form from "react-jsonschema-form";
 
 import JSONEditor from "../JSONEditor";

--- a/src/components/collection/JSONCollectionForm.js
+++ b/src/components/collection/JSONCollectionForm.js
@@ -38,14 +38,14 @@ function validate({ data }, errors) {
   return errors;
 }
 
-export default class JSONCollectionForm extends PureComponent {
-  props: {
-    children?: React.Element<*>,
-    cid: ?string,
-    formData: CollectionData,
-    onSubmit: (data: { formData: CollectionData }) => void,
-  };
+type Props = {
+  children?: React.Element<*>,
+  cid: ?string,
+  formData: CollectionData,
+  onSubmit: (data: { formData: CollectionData }) => void,
+};
 
+export default class JSONCollectionForm extends PureComponent<Props> {
   onSubmit = ({
     formData,
   }: {

--- a/src/components/group/GroupAttributes.js
+++ b/src/components/group/GroupAttributes.js
@@ -14,21 +14,17 @@ import Spinner from "../Spinner";
 import GroupForm from "./GroupForm";
 import GroupTabs from "./GroupTabs";
 
-export default class GroupAttributes extends PureComponent {
-  props: {
-    params: GroupRouteParams,
-    session: SessionState,
-    bucket: BucketState,
-    group: GroupState,
-    capabilities: Capabilities,
-    updateGroup: (
-      bid: string,
-      gid: string,
-      payload: { data: GroupData }
-    ) => void,
-    deleteGroup: (bid: string, gid: string) => void,
-  };
+type Props = {
+  params: GroupRouteParams,
+  session: SessionState,
+  bucket: BucketState,
+  group: GroupState,
+  capabilities: Capabilities,
+  updateGroup: (bid: string, gid: string, payload: { data: GroupData }) => void,
+  deleteGroup: (bid: string, gid: string) => void,
+};
 
+export default class GroupAttributes extends PureComponent<Props> {
   onSubmit = (formData: GroupData) => {
     const { params, updateGroup } = this.props;
     const { bid, gid } = params;

--- a/src/components/group/GroupCreate.js
+++ b/src/components/group/GroupCreate.js
@@ -13,16 +13,16 @@ import React, { PureComponent } from "react";
 import GroupForm from "./GroupForm";
 import Spinner from "../Spinner";
 
-export default class GroupCreate extends PureComponent {
-  props: {
-    params: BucketRouteParams,
-    session: SessionState,
-    bucket: BucketState,
-    group: GroupState,
-    capabilities: Capabilities,
-    createGroup: (bid: string, data: GroupData) => void,
-  };
+type Props = {
+  params: BucketRouteParams,
+  session: SessionState,
+  bucket: BucketState,
+  group: GroupState,
+  capabilities: Capabilities,
+  createGroup: (bid: string, data: GroupData) => void,
+};
 
+export default class GroupCreate extends PureComponent<Props> {
   render() {
     const { params, session, bucket, group, createGroup } = this.props;
     const { bid } = params;

--- a/src/components/group/GroupForm.js
+++ b/src/components/group/GroupForm.js
@@ -89,17 +89,17 @@ function DeleteForm({ gid, onSubmit }) {
   );
 }
 
-export default class GroupForm extends PureComponent {
-  props: {
-    gid?: string,
-    session: SessionState,
-    bucket: BucketState,
-    group: GroupState,
-    formData?: GroupData,
-    onSubmit: (formData: GroupData) => void,
-    deleteGroup?: (gid: string) => void,
-  };
+type Props = {
+  gid?: string,
+  session: SessionState,
+  bucket: BucketState,
+  group: GroupState,
+  formData?: GroupData,
+  onSubmit: (formData: GroupData) => void,
+  deleteGroup?: (gid: string) => void,
+};
 
+export default class GroupForm extends PureComponent<Props> {
   onSubmit = ({ formData }: { formData: { data: string } }) => {
     const { data } = formData;
     // Parse JSON fields so they can be sent to the server

--- a/src/components/group/GroupHistory.js
+++ b/src/components/group/GroupHistory.js
@@ -11,17 +11,17 @@ import React, { PureComponent } from "react";
 import HistoryTable from "../HistoryTable";
 import CollectionTabs from "./GroupTabs";
 
-export default class GroupHistory extends PureComponent {
-  props: {
-    params: GroupRouteParams,
-    group: GroupState,
-    capabilities: Capabilities,
-    location: RouteLocation,
-    hasNextHistory: boolean,
-    listGroupNextHistory: ?Function,
-    notifyError: (message: string, error: ?Error) => void,
-  };
+type Props = {
+  params: GroupRouteParams,
+  group: GroupState,
+  capabilities: Capabilities,
+  location: RouteLocation,
+  hasNextHistory: boolean,
+  listGroupNextHistory: ?Function,
+  notifyError: (message: string, error: ?Error) => void,
+};
 
+export default class GroupHistory extends PureComponent<Props> {
   render() {
     const {
       params,

--- a/src/components/group/GroupPermissions.js
+++ b/src/components/group/GroupPermissions.js
@@ -15,20 +15,20 @@ import GroupTabs from "./GroupTabs";
 import PermissionsForm from "../PermissionsForm";
 import { canEditGroup } from "../../permission";
 
-export default class GroupPermissions_ extends PureComponent {
-  props: {
-    params: GroupRouteParams,
-    session: SessionState,
-    bucket: BucketState,
-    group: GroupState,
-    capabilities: Capabilities,
-    updateGroup: (
-      bid: string,
-      gid: string,
-      data: { permissions: GroupPermissions }
-    ) => void,
-  };
+type Props = {
+  params: GroupRouteParams,
+  session: SessionState,
+  bucket: BucketState,
+  group: GroupState,
+  capabilities: Capabilities,
+  updateGroup: (
+    bid: string,
+    gid: string,
+    data: { permissions: GroupPermissions }
+  ) => void,
+};
 
+export default class GroupPermissions_ extends PureComponent<Props> {
   onSubmit = ({ formData }: { formData: GroupPermissions }) => {
     const { params, updateGroup } = this.props;
     const { bid, gid } = params;

--- a/src/components/group/GroupTabs.js
+++ b/src/components/group/GroupTabs.js
@@ -5,15 +5,15 @@ import React, { PureComponent } from "react";
 
 import AdminLink from "../AdminLink";
 
-export default class GroupTabs extends PureComponent {
-  props: {
-    bid: string,
-    gid: string,
-    selected: "attributes" | "permissions" | "history",
-    capabilities: Capabilities,
-    children?: any,
-  };
+type Props = {
+  bid: string,
+  gid: string,
+  selected: "attributes" | "permissions" | "history",
+  capabilities: Capabilities,
+  children?: any,
+};
 
+export default class GroupTabs extends PureComponent<Props> {
   render() {
     const { bid, gid, selected, capabilities, children } = this.props;
 

--- a/src/components/record/JSONRecordForm.js
+++ b/src/components/record/JSONRecordForm.js
@@ -1,5 +1,6 @@
 /* @flow */
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
+import * as React from "react";
 
 import BaseForm from "../BaseForm";
 import JSONEditor from "../JSONEditor";

--- a/src/components/record/JSONRecordForm.js
+++ b/src/components/record/JSONRecordForm.js
@@ -23,14 +23,14 @@ function validate(json, errors) {
   return errors;
 }
 
-export default class JSONRecordForm extends PureComponent {
-  props: {
-    disabled: boolean,
-    record: string, // JSON string representation of a record data
-    onSubmit: (data: Object) => void,
-    children?: React.Element<*>,
-  };
+type Props = {
+  disabled: boolean,
+  record: string, // JSON string representation of a record data
+  onSubmit: (data: Object) => void,
+  children?: React.Element<*>,
+};
 
+export default class JSONRecordForm extends PureComponent<Props> {
   onSubmit = (data: { formData: string }) => {
     this.props.onSubmit({ ...data, formData: JSON.parse(data.formData) });
   };

--- a/src/components/record/RecordAttributes.js
+++ b/src/components/record/RecordAttributes.js
@@ -14,25 +14,25 @@ import React, { PureComponent } from "react";
 import RecordForm from "./RecordForm";
 import RecordTabs from "./RecordTabs";
 
-export default class RecordAttributes extends PureComponent {
-  props: {
-    params: RecordRouteParams,
-    session: SessionState,
-    capabilities: Capabilities,
-    bucket: BucketState,
-    collection: CollectionState,
-    record: RecordState,
-    deleteRecord: (bid: string, cid: string, rid: string) => void,
-    deleteAttachment: (bid: string, cid: string, rid: string) => void,
-    updateRecord: (
-      bid: string,
-      cid: string,
-      rid: string,
-      data: RecordData,
-      attachment: ?string
-    ) => void,
-  };
+type Props = {
+  params: RecordRouteParams,
+  session: SessionState,
+  capabilities: Capabilities,
+  bucket: BucketState,
+  collection: CollectionState,
+  record: RecordState,
+  deleteRecord: (bid: string, cid: string, rid: string) => void,
+  deleteAttachment: (bid: string, cid: string, rid: string) => void,
+  updateRecord: (
+    bid: string,
+    cid: string,
+    rid: string,
+    data: RecordData,
+    attachment: ?string
+  ) => void,
+};
 
+export default class RecordAttributes extends PureComponent<Props> {
   onSubmit = ({ __attachment__: attachment, ...record }: Object) => {
     const { params, updateRecord } = this.props;
     const { bid, cid, rid } = params;

--- a/src/components/record/RecordBulk.js
+++ b/src/components/record/RecordBulk.js
@@ -16,18 +16,14 @@ import {
   extendUiSchemaWithAttachment,
 } from "./RecordForm";
 
-export default class RecordBulk extends PureComponent {
-  props: {
-    params: CollectionRouteParams,
-    collection: CollectionState,
-    bulkCreateRecords: (
-      bid: string,
-      cid: string,
-      formData: RecordData[]
-    ) => void,
-    notifyError: (msg: string, error: ?Error) => void,
-  };
+type Props = {
+  params: CollectionRouteParams,
+  collection: CollectionState,
+  bulkCreateRecords: (bid: string, cid: string, formData: RecordData[]) => void,
+  notifyError: (msg: string, error: ?Error) => void,
+};
 
+export default class RecordBulk extends PureComponent<Props> {
   onSubmit = ({ formData }: { formData: any[] }) => {
     const { params, collection, notifyError, bulkCreateRecords } = this.props;
     const { bid, cid } = params;

--- a/src/components/record/RecordCreate.js
+++ b/src/components/record/RecordCreate.js
@@ -12,21 +12,21 @@ import React, { PureComponent } from "react";
 
 import RecordForm from "./RecordForm";
 
-export default class RecordCreate extends PureComponent {
-  props: {
-    params: CollectionRouteParams,
-    session: SessionState,
-    capabilities: Capabilities,
-    bucket: BucketState,
-    collection: CollectionState,
-    createRecord: (
-      bid: string,
-      cid: string,
-      record: RecordData,
-      attachment: ?string
-    ) => void,
-  };
+type Props = {
+  params: CollectionRouteParams,
+  session: SessionState,
+  capabilities: Capabilities,
+  bucket: BucketState,
+  collection: CollectionState,
+  createRecord: (
+    bid: string,
+    cid: string,
+    record: RecordData,
+    attachment: ?string
+  ) => void,
+};
 
+export default class RecordCreate extends PureComponent<Props> {
   onSubmit = ({ __attachment__: attachment, ...record }: Object) => {
     const { params, createRecord } = this.props;
     const { bid, cid } = params;

--- a/src/components/record/RecordForm.js
+++ b/src/components/record/RecordForm.js
@@ -164,25 +164,25 @@ function AttachmentInfo(props: AttachmentInfoProps) {
   );
 }
 
-export default class RecordForm extends PureComponent {
-  props: {
-    bid: string,
-    cid: string,
-    rid?: string,
-    session: SessionState,
-    bucket: BucketState,
-    collection: CollectionState,
-    record?: RecordState,
-    deleteRecord?: (bid: string, cid: string, rid: string) => void,
-    deleteAttachment?: (bid: string, cid: string, rid: string) => void,
-    onSubmit: (data: RecordData) => void,
-    capabilities: Capabilities,
-  };
+type Props = {
+  bid: string,
+  cid: string,
+  rid?: string,
+  session: SessionState,
+  bucket: BucketState,
+  collection: CollectionState,
+  record?: RecordState,
+  deleteRecord?: (bid: string, cid: string, rid: string) => void,
+  deleteAttachment?: (bid: string, cid: string, rid: string) => void,
+  onSubmit: (data: RecordData) => void,
+  capabilities: Capabilities,
+};
 
-  state: {
-    asJSON: boolean,
-  };
+type State = {
+  asJSON: boolean,
+};
 
+export default class RecordForm extends PureComponent<Props, State> {
   constructor(props: Object) {
     super(props);
     this.state = { asJSON: false };

--- a/src/components/record/RecordHistory.js
+++ b/src/components/record/RecordHistory.js
@@ -13,18 +13,18 @@ import React, { PureComponent } from "react";
 import HistoryTable from "../HistoryTable";
 import RecordTabs from "./RecordTabs";
 
-export default class RecordHistory extends PureComponent {
-  props: {
-    params: RecordRouteParams,
-    session: SessionState,
-    capabilities: Capabilities,
-    bucket: BucketState,
-    record: RecordState,
-    location: RouteLocation,
-    listRecordNextHistory: () => void,
-    notifyError: (message: string, error: ?Error) => void,
-  };
+type Props = {
+  params: RecordRouteParams,
+  session: SessionState,
+  capabilities: Capabilities,
+  bucket: BucketState,
+  record: RecordState,
+  location: RouteLocation,
+  listRecordNextHistory: () => void,
+  notifyError: (message: string, error: ?Error) => void,
+};
 
+export default class RecordHistory extends PureComponent<Props> {
   render() {
     const {
       params,

--- a/src/components/record/RecordPermissions.js
+++ b/src/components/record/RecordPermissions.js
@@ -16,22 +16,22 @@ import RecordTabs from "./RecordTabs";
 import PermissionsForm from "../PermissionsForm";
 import { canEditRecord } from "../../permission";
 
-export default class RecordPermissions_ extends PureComponent {
-  props: {
-    params: RecordRouteParams,
-    session: SessionState,
-    capabilities: Capabilities,
-    bucket: BucketState,
-    collection: CollectionState,
-    record: RecordState,
-    updateRecord: (
-      bid: string,
-      cid: string,
-      rid: string,
-      data: { permissions: RecordPermissions }
-    ) => void,
-  };
+type Props = {
+  params: RecordRouteParams,
+  session: SessionState,
+  capabilities: Capabilities,
+  bucket: BucketState,
+  collection: CollectionState,
+  record: RecordState,
+  updateRecord: (
+    bid: string,
+    cid: string,
+    rid: string,
+    data: { permissions: RecordPermissions }
+  ) => void,
+};
 
+export default class RecordPermissions_ extends PureComponent<Props> {
   onSubmit = ({ formData }: { formData: Object }) => {
     const { params, updateRecord } = this.props;
     const { bid, cid, rid } = params;

--- a/src/components/record/RecordTabs.js
+++ b/src/components/record/RecordTabs.js
@@ -5,16 +5,16 @@ import React, { PureComponent } from "react";
 
 import AdminLink from "../AdminLink";
 
-export default class RecordTabs extends PureComponent {
-  props: {
-    bid: string,
-    cid: string,
-    rid: string,
-    selected: "attributes" | "permissions" | "history",
-    capabilities: Capabilities,
-    children?: React.Element<*>,
-  };
+type Props = {
+  bid: string,
+  cid: string,
+  rid: string,
+  selected: "attributes" | "permissions" | "history",
+  capabilities: Capabilities,
+  children?: React.Element<*>,
+};
 
+export default class RecordTabs extends PureComponent<Props> {
   render() {
     const { bid, cid, rid, selected, capabilities, children } = this.props;
 

--- a/src/components/record/RecordTabs.js
+++ b/src/components/record/RecordTabs.js
@@ -1,7 +1,8 @@
 /* @flow */
 import type { Capabilities } from "../../types";
 
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
+import * as React from "react";
 
 import AdminLink from "../AdminLink";
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,8 @@ type Props = {
   settings: Object,
 };
 
-export default class KintoAdmin extends Component {
+export default class KintoAdmin extends Component<Props> {
   store: Object;
-
-  props: Props;
 
   static defaultProps = {
     plugins: [],

--- a/src/plugins/signoff/ProgressBar.js
+++ b/src/plugins/signoff/ProgressBar.js
@@ -1,11 +1,11 @@
 /* @flow */
 import React, { Component } from "react";
 
-export class ProgressBar extends Component {
-  props: {
-    children?: any,
-  };
+type Props = {
+  children?: any,
+};
 
+export class ProgressBar extends Component<Props> {
   render() {
     const { children } = this.props;
     return (

--- a/src/plugins/signoff/components.js
+++ b/src/plugins/signoff/components.js
@@ -7,7 +7,8 @@ import type {
   DestinationInfo,
 } from "./types";
 
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
+import * as React from "react";
 
 import { canEditCollection } from "../../permission";
 import { timeago, humanDate } from "../../utils";

--- a/src/plugins/signoff/components.js
+++ b/src/plugins/signoff/components.js
@@ -51,20 +51,22 @@ function isLastEditor(source, sessionState) {
   return user.id === lastEditor;
 }
 
-export default class SignoffToolBar extends React.Component {
-  props: {
-    sessionState: SessionState,
-    bucketState: BucketState,
-    collectionState: CollectionState,
-    signoff: SignoffState,
-    requestReview: string => void,
-    confirmRequestReview: () => void,
-    approveChanges: () => void,
-    declineChanges: string => void,
-    confirmDeclineChanges: () => void,
-    cancelPendingConfirm: () => void,
-  };
+type SignoffToolBarProps = {
+  sessionState: SessionState,
+  bucketState: BucketState,
+  collectionState: CollectionState,
+  signoff: SignoffState,
+  requestReview: string => void,
+  confirmRequestReview: () => void,
+  approveChanges: () => void,
+  declineChanges: string => void,
+  confirmDeclineChanges: () => void,
+  cancelPendingConfirm: () => void,
+};
 
+export default class SignoffToolBar extends React.Component<
+  SignoffToolBarProps
+> {
   render() {
     const {
       // Global state
@@ -505,13 +507,14 @@ type CommentDialogProps = {
   onCancel: () => void,
 };
 
-class CommentDialog extends PureComponent {
-  props: CommentDialogProps;
+type CommentDialogState = {
+  comment: string,
+};
 
-  state: {
-    comment: string,
-  };
-
+class CommentDialog extends PureComponent<
+  CommentDialogProps,
+  CommentDialogState
+> {
   constructor(props: Object) {
     super(props);
     this.state = {

--- a/src/routes.js
+++ b/src/routes.js
@@ -159,7 +159,7 @@ function registerPluginsComponentHooks(PageContainer, plugins) {
     return mergeObjects(acc, hookObject, true);
   }, {});
   // Wrap the root component, augmenting its props with the plugin hooks for it.
-  return class extends Component {
+  return class extends Component<*> {
     render() {
       return (
         <PageContainer

--- a/src/routes.js
+++ b/src/routes.js
@@ -152,6 +152,9 @@ function registerPluginsComponentHooks(PageContainer, plugins) {
   const { WrappedComponent } = PageContainer;
   // By convention, the hook namespace is the wrapped component name
   const namespace = WrappedComponent.displayName;
+  if (!namespace) {
+    throw new Error("can't happen -- component with no display name");
+  }
   // Retrieve all the hooks if any
   const hooks = plugins.map(plugin => plugin.hooks).filter(isObject);
   // Merge all the hooks together, recursively grouped by namespaces


### PR DESCRIPTION
This broke in #440, apparently because of https://github.com/facebook/flow/issues/3528, because Sidebar.js uses a spread in an array without a type declaration, which as of 0.39 causes pathological behavior. The form of the breakage is that a child process of the flow typechecker starts to consume an infinite amount of memory, and when that child process dies, the parent reports an error and exits with status code zero indicating success. Thus, travis believes the build has succeeded.

Apparently the way to diagnose this sort of thing is to start marking files as ignored in .flowconfig, rerun flow and see if it terminates within a few seconds (and without consuming an unreasonable amount of memory, here defined as >10% of a Thinkpad X1 Carbon's RAM). This is basically the approach I took in this PR. We successively unignore files until we're back to where we started.

Fixing this uncovered a rat's nest of typechecking that had also been broken. In particular, some changes to the types for React meant that we had to change `Component { props: Foo }` to `Component<Foo>`. There were also a handful of other errors (some spurious, some not) that apparently a modern flow-check can catch. Fix these too.