### PR TITLE
Fix redux-saga deprecated imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
   - npm install
+  - npm ls
   - npm run build
 env:
   - ACTION="build:lib"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-router": "^2.7.0",
     "react-router-redux": "4.0.5",
     "redux": "^3.0.4",
-    "redux-saga": "^1.0.0-beta.0",
+    "redux-saga": "github:redux-saga/redux-saga#v1.0.0-beta.0",
     "rimraf": "^2.4.4",
     "timeago.js": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-router": "^2.7.0",
     "react-router-redux": "4.0.5",
     "redux": "^3.0.4",
-    "redux-saga": "^0.15.3",
+    "redux-saga": "^1.0.0-beta.0",
     "rimraf": "^2.4.4",
     "timeago.js": "^3.0.1"
   },

--- a/src/plugins/example/index.js
+++ b/src/plugins/example/index.js
@@ -1,6 +1,5 @@
 import React from "react";
-import { takeEvery } from "redux-saga";
-import { put } from "redux-saga/effects";
+import { put, takeEvery } from "redux-saga/effects";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 

--- a/src/plugins/signoff/index.js
+++ b/src/plugins/signoff/index.js
@@ -1,8 +1,8 @@
 import type { Store } from "redux";
 
 import React from "react";
-import { takeEvery } from "redux-saga";
 import { connect } from "react-redux";
+import { takeEvery } from "redux-saga/effects";
 import { bindActionCreators } from "redux";
 
 import * as adminConstants from "../../constants";

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,7 +1,7 @@
 /* @flow */
 import type { GetStateFn, PluginSagas, SagaGen } from "../types";
 
-import { takeEvery } from "redux-saga/effects";
+import { takeEvery, all } from "redux-saga/effects";
 
 import { flattenPluginsSagas } from "../plugin";
 import * as c from "../constants";
@@ -119,5 +119,5 @@ export default function* rootSaga(
     ),
   ];
 
-  yield [...standardSagas, ...flattenPluginsSagas(pluginsSagas, getState)];
+  yield all([...standardSagas, ...flattenPluginsSagas(pluginsSagas, getState)]);
 }

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,7 +1,7 @@
 /* @flow */
 import type { GetStateFn, PluginSagas, SagaGen } from "../types";
 
-import { takeEvery } from "redux-saga";
+import { takeEvery } from "redux-saga/effects";
 
 import { flattenPluginsSagas } from "../plugin";
 import * as c from "../constants";

--- a/test/plugin_test.js
+++ b/test/plugin_test.js
@@ -77,9 +77,12 @@ describe("Plugin API", () => {
       const sagas = flattenPluginsSagas(plugins, getState);
 
       expect(sagas).to.have.length.of(3);
-      expect(sagas[0].name).eql("takeEvery(ACTION_1, saga1)");
-      expect(sagas[1].name).eql("takeEvery(ACTION_2, saga2)");
-      expect(sagas[2].name).eql("takeEvery(ACTION_3, saga3)");
+      expect(sagas[0].FORK.fn.name).eql("takeEvery");
+      expect(sagas[1].FORK.fn.name).eql("takeEvery");
+      expect(sagas[2].FORK.fn.name).eql("takeEvery");
+      expect(sagas[0].FORK.args).eql(["ACTION_1", saga1, getState]);
+      expect(sagas[1].FORK.args).eql(["ACTION_2", saga2, getState]);
+      expect(sagas[2].FORK.args).eql(["ACTION_3", saga3, getState]);
     });
   });
 

--- a/test/plugin_test.js
+++ b/test/plugin_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { expect } from "chai";
-import { takeEvery } from "redux-saga";
+import { takeEvery } from "redux-saga/effects";
 
 import {
   flattenPluginsRoutes,


### PR DESCRIPTION
I first wanted to fix every deprecation warnings, but it seems we are running behind in terms of dependencies, and `git grep` does not give anything relevant :) 

```
Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs

Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class
```