### PR TITLE
Fix list permissions if anonymous

### DIFF
--- a/src/sagas/session.js
+++ b/src/sagas/session.js
@@ -130,7 +130,7 @@ export function* listBuckets(
     } catch (error) {
       // If the user is not allowed to list the buckets, we want
       // to show an empty list.
-      if (!/HTTP 403/.test(error.message)) {
+      if (!/HTTP 40[13]/.test(error.message)) {
         throw error;
       }
       data = [];

--- a/test/sagas/session_test.js
+++ b/test/sagas/session_test.js
@@ -196,7 +196,7 @@ describe("session sagas", () => {
       });
 
       describe("Forbidden list of buckets", () => {
-        before(() => {
+        beforeEach(() => {
           const action = actions.listBuckets();
           const getState = () => ({
             session: sessionState,
@@ -214,6 +214,16 @@ describe("session sagas", () => {
         it("should support 403 errors when fetching list of buckets", () => {
           // listBucket fails with unauthorized error.
           listBuckets.throw(new Error("HTTP 403"));
+          // Saga continues without failing.
+          expect(listBuckets.next().value)
+            .to.have.property("CALL")
+            .to.have.property("fn")
+            .eql(client.listPermissions);
+        });
+
+        it("should support 401 errors when fetching list of buckets", () => {
+          // listBucket fails with unauthorized error.
+          listBuckets.throw(new Error("HTTP 401"));
           // Saga continues without failing.
           expect(listBuckets.next().value)
             .to.have.property("CALL")


### PR DESCRIPTION
1. Enter as anonymous
1. Anonymous has permissions to create records somewhere
1. The permissions endpoint returns some values
1. Anonymous has no permission to list buckets on server
1. Kinto returns a 401 on listing bucket because anonymous has no authorization header
1. The UI should still show the collections where anonymous is allowed.

This fixes it.

