### PR TITLE
Fix workflow info parameter types

### DIFF
--- a/src/plugins/signoff/sagas.js
+++ b/src/plugins/signoff/sagas.js
@@ -12,16 +12,25 @@ export function* onCollectionRecordsRequest(getState, action) {
   // described in server info capabilities.
   const resource = _pickSignoffResource(serverInfo, bid, cid);
 
-  // Refresh the signoff toolbar (either empty or basic infos about current)
-  yield put(SignoffActions.workflowInfo(resource));
-
   // Current collection is not configured, no need to proceed.
   if (!resource) {
+    yield put(SignoffActions.workflowInfo(null));
     return;
   }
 
-  // Obtain information for workflow (last update, authors, etc).
   const { source, preview = {}, destination } = resource;
+
+  // Show basic infos for this collection while fetching more details.
+  const basicInfos = resource
+    ? {
+        source: { bid: source.bucket, cid: source.collection },
+        destination: { bid: destination.bucket, cid: destination.collection },
+        preview: { bid: preview.bucket, cid: preview.collection },
+      }
+    : null;
+  yield put(SignoffActions.workflowInfo(basicInfos));
+
+  // Obtain information for workflow (last update, authors, etc).
   const {
     sourceAttributes,
     previewAttributes,

--- a/test/plugins/signoff/components_test.js
+++ b/test/plugins/signoff/components_test.js
@@ -45,14 +45,14 @@ describe("SignoffToolBar component", () => {
       collections: {
         source: {
           bid: "stage",
-          cid: null,
+          cid: "certs",
           changes: {
             lastUpdated: 42,
           },
         },
         destination: {
           bid: "prod",
-          cid: null,
+          cid: "certs",
         },
       },
     },

--- a/test/plugins/signoff/sagas_test.js
+++ b/test/plugins/signoff/sagas_test.js
@@ -56,7 +56,7 @@ describe("Signoff plugin sagas", () => {
       it("should do nothing if current collection is not configured", () => {
         const action = collection_actions.listRecords("bid", "cid", "");
         const result = saga.onCollectionRecordsRequest(getState, action);
-        expect(result.next().value).eql(put(actions.workflowInfo(undefined)));
+        expect(result.next().value).eql(put(actions.workflowInfo(null)));
       });
 
       it("should pick resource for current collection if source matches", () => {
@@ -70,16 +70,16 @@ describe("Signoff plugin sagas", () => {
           put(
             actions.workflowInfo({
               source: {
-                bucket: "stage",
-                collection: "source-plugins",
+                bid: "stage",
+                cid: "source-plugins",
               },
               preview: {
-                bucket: "preview",
-                collection: "preview-plugins",
+                bid: "preview",
+                cid: "preview-plugins",
               },
               destination: {
-                bucket: "prod",
-                collection: "dest-plugins",
+                bid: "prod",
+                cid: "dest-plugins",
               },
             })
           )
@@ -93,16 +93,16 @@ describe("Signoff plugin sagas", () => {
           put(
             actions.workflowInfo({
               source: {
-                bucket: "stage",
-                collection: "cid",
+                bid: "stage",
+                cid: "cid",
               },
               preview: {
-                bucket: "preview",
-                collection: "cid",
+                bid: "preview",
+                cid: "cid",
               },
               destination: {
-                bucket: "prod",
-                collection: "cid",
+                bid: "prod",
+                cid: "cid",
               },
             })
           )


### PR DESCRIPTION
The `signoff.workflowInfo(...)` was called with an item of the resources listed in the signer capability. 
But this item does not match the type expected by `workflowInfo()`.
This PR does not change the UI behaviour, but fixes the consistency of parameters types.