### PR TITLE
Add a .prettierrc file so editors can make use of it

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "jsxBracketSameLine": true,
+  "trailingComma": "es5",
+  "semi": true,
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "build": "rimraf build && NODE_ENV=production node_modules/.bin/webpack --progress --config webpack.prod.js && cp html/prod.html build/index.html",
     "build:lib": "rimraf lib && NODE_ENV=production babel -d lib/ src/",
     "build:readme": "toctoc README.md -w",
-    "cs-check": "prettier -l $npm_package_prettierOptions '{src,test,test-browser}/**/*.js'",
-    "cs-format": "prettier $npm_package_prettierOptions '{src,test,test-browser}/**/*.js' --write",
+    "cs-check": "prettier -l '{src,test,test-browser}/**/*.js'",
+    "cs-format": "prettier '{src,test,test-browser}/**/*.js' --write",
     "flow-check": "node_modules/.bin/flow check",
     "lint": "node_modules/.bin/eslint src test test-browser",
     "publish-to-gh-pages": "npm run build && gh-pages --add --dist build/",
@@ -19,7 +19,6 @@
     "test-browser": "NODE_ENV=test node_modules/.bin/babel-node node_modules/.bin/_mocha 'test-browser/**/*_test.js'",
     "test-all": "npm run lint && npm run flow-check && npm run test"
   },
-  "prettierOptions": "--jsx-bracket-same-line --trailing-comma es5 --semi",
   "main": "lib/index.js",
   "files": [
     "css",


### PR DESCRIPTION
With prettier options in the package.json, it wasn't possible to have editors automatically use the same settings, or even running `prettier` manually (without the `cs-*` scripts in the package.json).

Another way would have been to add those options in a `prettier` entry in the package.json, which might have also worked, but I believe having a .prettierrc file is more common?

What do you think @glasserc @peterbe ?