### PR TITLE
Use en-US for the humanDate util

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -209,7 +209,7 @@ export function renderDisplayField(record: Object, displayField: string): any {
 
 export function humanDate(since: string | number): string {
   return (
-    new Date(parseInt(since, 10)).toLocaleDateString("en-GB", {
+    new Date(parseInt(since, 10)).toLocaleDateString("en-US", {
       timeZone: "UTC",
       weekday: "long",
       year: "numeric",


### PR DESCRIPTION
It seems travis is falling back to en-US (it might not have en-GB by default), which is the format that was present in the tests.

en-GB gives: `Thursday, 1 January 1970, 12:00:00 am UTC`
en-US gives: `Thursday, January 1, 1970, 12:00:00 AM UTC`