### PR TITLE
Show details in popup in HistoryTable component

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -197,6 +197,10 @@ table.record-list td.load-more {
   line-height: 2.5em;
 }
 
+table.record-list > tbody:nth-child(odd) tr td {
+  background-color: #fff;
+}
+
 .load-more > a:hover, .load-more > a:active {
   background: #d9edf7;
   text-decoration: none;

--- a/src/components/HistoryTable.js
+++ b/src/components/HistoryTable.js
@@ -152,47 +152,53 @@ class HistoryRow extends PureComponent<HistoryRowProps, HistoryRowState> {
     } = target;
 
     return (
-      <tr>
-        <td>
-          <span title={humanDate(last_modified)}>{timeago(last_modified)}</span>
-        </td>
-        <td>{action}</td>
-        <td>{resource_name}</td>
-        <td>
-          <AdminLink
-            name={`${resource_name}:attributes`}
-            params={{ bid, cid, gid, rid }}>
-            {objectId}
-          </AdminLink>
-        </td>
-        <td>{user_id}</td>
-        <td className="text-center">
-          {resource_name === "record" &&
-            enableDiffOverview &&
-            pos !== 0 && (
-              <span>
-                <AdminLink
-                  className="btn btn-xs btn-default"
-                  title="Start history log from this point"
-                  name="collection:history"
-                  params={{ bid, cid }}
-                  query={{ since: last_modified, resource_name: "record" }}>
-                  <i className="glyphicon glyphicon-step-backward" />
-                </AdminLink>{" "}
-              </span>
-            )}
-          <a
-            href="."
-            className="btn btn-xs btn-default"
-            onClick={this.toggle}
-            title="View entry details">
-            <i
-              className={`glyphicon glyphicon-eye-${open ? "close" : "open"}`}
-            />
-          </a>
-          <div
-            className="history-row-details"
-            style={{ display: busy || open ? "table-row" : "none" }}>
+      <tbody>
+        <tr>
+          <td>
+            <span title={humanDate(last_modified)}>
+              {timeago(last_modified)}
+            </span>
+          </td>
+          <td>{action}</td>
+          <td>{resource_name}</td>
+          <td>
+            <AdminLink
+              name={`${resource_name}:attributes`}
+              params={{ bid, cid, gid, rid }}>
+              {objectId}
+            </AdminLink>
+          </td>
+          <td>{user_id}</td>
+          <td className="text-center">
+            {resource_name === "record" &&
+              enableDiffOverview &&
+              pos !== 0 && (
+                <span>
+                  <AdminLink
+                    className="btn btn-xs btn-default"
+                    title="Start history log from this point"
+                    name="collection:history"
+                    params={{ bid, cid }}
+                    query={{ since: last_modified, resource_name: "record" }}>
+                    <i className="glyphicon glyphicon-step-backward" />
+                  </AdminLink>{" "}
+                </span>
+              )}
+            <a
+              href="."
+              className="btn btn-xs btn-default"
+              onClick={this.toggle}
+              title="View entry details">
+              <i
+                className={`glyphicon glyphicon-eye-${open ? "close" : "open"}`}
+              />
+            </a>
+          </td>
+        </tr>
+        <tr
+          className="history-row-details"
+          style={{ display: busy || open ? "table-row" : "none" }}>
+          <td colSpan="6">
             {busy ? (
               <Spinner />
             ) : previous ? (
@@ -202,9 +208,9 @@ class HistoryRow extends PureComponent<HistoryRowProps, HistoryRowState> {
             ) : (
               <pre>{JSON.stringify(entry.target, null, 2)}</pre>
             )}
-          </div>
-        </td>
-      </tr>
+          </td>
+        </tr>
+      </tbody>
     );
   }
 }
@@ -366,21 +372,17 @@ export default class HistoryTable extends PureComponent<Props, State> {
       </thead>
     );
 
-    const tbody = (
-      <tbody>
-        {history.map((entry, index) => {
-          return (
-            <HistoryRow
-              key={index}
-              pos={index}
-              enableDiffOverview={enableDiffOverview}
-              bid={bid}
-              entry={entry}
-            />
-          );
-        })}
-      </tbody>
-    );
+    const tbody = history.map((entry, index) => {
+      return (
+        <HistoryRow
+          key={index}
+          pos={index}
+          enableDiffOverview={enableDiffOverview}
+          bid={bid}
+          entry={entry}
+        />
+      );
+    });
 
     return (
       <div>

--- a/src/components/PaginatedTable.js
+++ b/src/components/PaginatedTable.js
@@ -7,7 +7,7 @@ import Spinner from "./Spinner";
 
 type Props = {
   thead: React.Element<React.ElementType>,
-  tbody: React.Element<React.ElementType>,
+  tbody: React.ChildrenArray<React.Element<any>>,
   dataLoaded: boolean,
   colSpan: number,
   hasNextPage: boolean,


### PR DESCRIPTION
Fixes #492 

An element in two nested `<thead>` tags was being returned. The intention was to have a table row hide/show under the current row when details were exposed. As far as I know, with the way it's written, it is hard to do pre-fragments (React versions < 16) without some in depth rewrites.

My idea was just to take the element out of the document flow.

![screenshot-2018-4-6 kinto web administration dev](https://user-images.githubusercontent.com/24916590/38444192-3ec9c520-39a3-11e8-95bc-04c6810792ad.png)
