### PR TITLE
Don't request records as part of the permissions

### DIFF
--- a/src/sagas/session.js
+++ b/src/sagas/session.js
@@ -229,7 +229,7 @@ export function* listBuckets(
     if ("permissions_endpoint" in serverCapabilities) {
       const { data: permissions } = yield call(
         [client, client.listPermissions],
-        { pages: Infinity }
+        { pages: Infinity, filters: { exclude_resource_name: "record" } }
       );
       buckets = expandBucketsCollections(buckets, permissions);
       yield put(actions.permissionsListSuccess(permissions));

--- a/test/sagas/session_test.js
+++ b/test/sagas/session_test.js
@@ -283,7 +283,10 @@ describe("session sagas", () => {
         ];
 
         expect(listBuckets.next(responses).value).eql(
-          call([client, client.listPermissions], { pages: Infinity })
+          call([client, client.listPermissions], {
+            pages: Infinity,
+            filters: { exclude_resource_name: "record" },
+          })
         );
       });
 


### PR DESCRIPTION
It's normal for a user to have a ton of records. We only actually need
the buckets and collections here to build the sidebar, but build this
as a blacklist instead of a whitelist on the off-chance that someday
we add groups to the sidebar too.

Fixes #533.