### PR TITLE
Fix #619: fix display of attachment info

### DIFF
--- a/src/components/record/RecordForm.js
+++ b/src/components/record/RecordForm.js
@@ -310,20 +310,20 @@ export default class RecordForm extends PureComponent<Props, State> {
       data: { attachment: attachmentConfig },
     } = collection;
     const attachmentRequired = attachmentConfig && attachmentConfig.required;
-    const creation = !record;
+    const isUpdate = !!record;
 
     const alert =
       this.allowEditing || collection.busy ? null : (
         <div className="alert alert-warning">
           You don't have the required permission to
-          {creation ? " create a" : " edit this"} record.
+          {isUpdate ? " edit this" : " create a"} record.
         </div>
       );
 
     return (
       <div>
         {alert}
-        {creation && (
+        {isUpdate && (
           <AttachmentInfo
             capabilities={capabilities}
             record={record}

--- a/test/components/RecordAttributes_test.js
+++ b/test/components/RecordAttributes_test.js
@@ -54,7 +54,11 @@ describe("RecordAttributes component", () => {
       data: {
         id: "abc",
         foo: "bar",
-        attachment: { location: "path/file.png" },
+        attachment: {
+          location: "path/file.png",
+          mimetype: "image/png",
+          size: 12345,
+        },
       },
       permissions: {},
     };
@@ -78,7 +82,7 @@ describe("RecordAttributes component", () => {
     });
 
     it("should show a delete attachment button", () => {
-      expect(node.querySelector(".attachment-action btn.btn-danger")).to.exist;
+      expect(node.querySelector(".attachment-action .btn.btn-danger")).to.exist;
     });
   });
 });

--- a/test/components/RecordAttributes_test.js
+++ b/test/components/RecordAttributes_test.js
@@ -1,0 +1,84 @@
+import { expect } from "chai";
+
+import { createSandbox, createComponent } from "../test_utils";
+
+import RecordAttributes from "../../src/components/record/RecordAttributes";
+
+describe("RecordAttributes component", () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const bucket = {
+    id: "bucket",
+    data: {},
+    permissions: {
+      read: [],
+      write: [],
+    },
+  };
+
+  const collection = {
+    data: {
+      schema: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+          },
+          foo: {
+            type: "string",
+          },
+        },
+      },
+      attachment: {
+        enabled: true,
+        required: false,
+      },
+    },
+    permissions: {
+      write: [],
+    },
+  };
+
+  describe("Attachment info shown", () => {
+    let node;
+
+    const record = {
+      data: {
+        id: "abc",
+        foo: "bar",
+        attachment: { location: "path/file.png" },
+      },
+      permissions: {},
+    };
+
+    beforeEach(() => {
+      node = createComponent(RecordAttributes, {
+        match: { params: { bid: "bucket", cid: "collection", rid: "abc" } },
+        session: { authenticated: true, serverInfo: { user: "plop" } },
+        capabilities: { attachments: { base_url: "" } },
+        bucket,
+        collection,
+        record,
+        deleteRecord: () => {},
+        deleteAttachment: () => {},
+        updateRecord: () => {},
+      });
+    });
+
+    it("should render the attachment info", () => {
+      expect(node.querySelector(".attachment-info")).to.exist;
+    });
+
+    it("should show a delete attachment button", () => {
+      expect(node.querySelector(".attachment-action btn.btn-danger")).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
Fix #619 

![screenshot from 2018-09-27 17-35-53](https://user-images.githubusercontent.com/546692/46157876-f95aa280-c27c-11e8-9e62-93e93ca63038.png)

or when attachment is not required:
![screenshot from 2018-09-27 17-41-25](https://user-images.githubusercontent.com/546692/46157881-fbbcfc80-c27c-11e8-8212-0ef11fb6e081.png)
