### PR TITLE
Fix #459: bucket readonly filter with writable collection

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -161,7 +161,12 @@ function filterBuckets(buckets, filters): BucketEntry[] {
         return acc;
       }
     }, [])
-    .filter(bucket => !(hideReadOnly && bucket.readonly));
+    .filter(
+      bucket =>
+        !hideReadOnly ||
+        !bucket.readonly ||
+        bucket.collections.some(c => !c.readonly)
+    );
 }
 
 type BucketsMenuState = {

--- a/src/sagas/session.js
+++ b/src/sagas/session.js
@@ -186,10 +186,6 @@ export function expandBucketsCollections(
           return ["write", "record:create"].includes(cp);
         });
       }
-      // If this collection is writable, mark its parent bucket writable
-      if (!collection.readonly) {
-        bucket.readonly = false;
-      }
     }
   }
 

--- a/test/sagas/session_test.js
+++ b/test/sagas/session_test.js
@@ -505,8 +505,8 @@ describe("session sagas", () => {
 
 describe("expandBucketsCollections()", () => {
   const buckets = [
-    { id: "b1", permissions: [], collections: [], readonly: true },
-    { id: "b2", permissions: [], collections: [], readonly: true },
+    { id: "b1", permissions: [], collections: [], readonly: undefined },
+    { id: "b2", permissions: [], collections: [], readonly: undefined },
   ];
 
   function bucketPerm(bucket_id, permissions) {
@@ -525,6 +525,7 @@ describe("expandBucketsCollections()", () => {
   const permissions = [
     bucketPerm("b1", ["read"]),
     bucketPerm("b2", ["read"]),
+    bucketPerm("b4", ["write"]),
     collectionPerm("b1", "b1c1", ["read", "write"]),
     collectionPerm("b2", "b2c1", ["read"]),
     collectionPerm("b3", "b3c1", ["read", "write"]),
@@ -535,7 +536,7 @@ describe("expandBucketsCollections()", () => {
   const tree = saga.expandBucketsCollections(buckets, permissions, 2);
 
   it("should denote a bucket as writable", () => {
-    expect(tree.find(b => b.id === "b1").readonly).to.be.false;
+    expect(tree.find(b => b.id === "b4").readonly).to.be.false;
   });
 
   it("should denote a bucket as readonly", () => {
@@ -557,7 +558,7 @@ describe("expandBucketsCollections()", () => {
   });
 
   it("should infer an implicit bucket", () => {
-    expect(tree.find(b => b.id === "b3").readonly).to.be.false;
+    expect(tree.find(b => b.id === "b3").readonly).to.be.true;
   });
 
   it("should distinguish resource ids", () => {


### PR DESCRIPTION
Fix #459 

![screenshot from 2018-09-28 10-38-57](https://user-images.githubusercontent.com/546692/46197665-bd6e1e80-c30a-11e8-8a3c-f1122e9179a2.png)
