### PR TITLE
Fix #118: order buckets alphabetically

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -220,6 +220,7 @@ class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
       sidebarMaxListedCollections,
     } = this.props;
     const filteredBuckets = filterBuckets(buckets, this.state);
+    const sortedBuckets = filteredBuckets.sort((a, b) => (a.id > b.id ? 1 : -1));
     return (
       <div>
         {canCreateBucket && (
@@ -269,7 +270,7 @@ class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
         {busy ? (
           <Spinner />
         ) : (
-          filteredBuckets.map((bucket, i) => {
+          sortedBuckets.map((bucket, i) => {
             const { id, collections } = bucket;
             const current = bid === id;
             return (

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -220,7 +220,9 @@ class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
       sidebarMaxListedCollections,
     } = this.props;
     const filteredBuckets = filterBuckets(buckets, this.state);
-    const sortedBuckets = filteredBuckets.sort((a, b) => (a.id > b.id ? 1 : -1));
+    const sortedBuckets = filteredBuckets.sort(
+      (a, b) => (a.id > b.id ? 1 : -1)
+    );
     return (
       <div>
         {canCreateBucket && (


### PR DESCRIPTION
Fix #118 

(Done at the component level so that the default bucket is sorted by its name and not its real ID)