### PR TITLE
Missing whitespace before link

### DIFF
--- a/src/components/collection/CollectionForm.js
+++ b/src/components/collection/CollectionForm.js
@@ -280,7 +280,7 @@ function FormInstructions({ onSchemalessLinkClick }) {
         <li>Decide if you want to enable attaching a file to records.</li>
       </ol>
       <p>
-        Alternatively, you can create a
+        Alternatively, you can create a{" "}
         <a href="" onClick={onSchemalessLinkClick}>
           schemaless collection
         </a>


### PR DESCRIPTION
This is a solution taken from https://stackoverflow.com/a/41142436

The issue is visible when creating a new collection:
<img width="196" alt="screen shot 2018-10-12 at 15 28 06" src="https://user-images.githubusercontent.com/167767/46872103-8ed86380-ce33-11e8-8e95-993650871ff8.png">

Disclaimer: I haven't tested this.