### PR TITLE
Fix #615: fix confusing redirect/refresh for auth

### DIFF
--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -43,21 +43,17 @@ function ServerProps({ node }: { node: Object }) {
   );
 }
 
-function SessionInfo({ session: { busy, serverInfo } }) {
+function SessionInfo({ session: { serverInfo } }) {
   return (
     <div>
-      {busy ? (
-        <Spinner />
-      ) : (
-        <div className="panel server-info-panel panel-default">
-          <div className="panel-heading">
-            <b>Server information</b>
-          </div>
-          <div className="panel-body">
-            <ServerProps node={serverInfo} />
-          </div>
+      <div className="panel server-info-panel panel-default">
+        <div className="panel-heading">
+          <b>Server information</b>
         </div>
-      )}
+        <div className="panel-body">
+          <ServerProps node={serverInfo} />
+        </div>
+      </div>
     </div>
   );
 }
@@ -124,11 +120,11 @@ export default class HomePage extends PureComponent<Props> {
       navigateToExternalAuth,
       navigateToOpenID,
     } = this.props;
-    const { authenticated, busy } = session;
+    const { authenticated, authenticating } = session;
     return (
       <div>
         <h1>Kinto Web Administration Console</h1>
-        {busy ? (
+        {authenticating ? (
           <Spinner />
         ) : authenticated ? (
           <SessionInfo session={session} />

--- a/src/reducers/session.js
+++ b/src/reducers/session.js
@@ -3,6 +3,7 @@
 import type { ServerInfo, SessionState, AuthData } from "../types";
 import {
   SESSION_BUSY,
+  SESSION_SETUP,
   SESSION_SETUP_COMPLETE,
   SESSION_STORE_REDIRECT_URL,
   SESSION_SERVERINFO_SUCCESS,
@@ -20,6 +21,7 @@ export const DEFAULT_SERVERINFO: ServerInfo = {
 
 const DEFAULT: SessionState = {
   busy: false,
+  authenticating: false,
   auth: null,
   authenticated: false,
   permissions: null,
@@ -37,9 +39,12 @@ export default function session(
       const { busy }: { busy: boolean } = action;
       return { ...state, busy };
     }
+    case SESSION_SETUP: {
+      return { ...state, authenticating: true };
+    }
     case SESSION_SETUP_COMPLETE: {
       const { auth }: { auth: AuthData } = action;
-      return { ...state, auth };
+      return { ...state, auth, authenticating: false };
     }
     case SESSION_STORE_REDIRECT_URL: {
       const { redirectURL }: { redirectURL: string } = action;

--- a/src/types.js
+++ b/src/types.js
@@ -422,6 +422,7 @@ export type BucketEntry = {
 
 export type SessionState = {
   busy: boolean,
+  authenticating: boolean,
   auth: ?AuthData,
   authenticated: boolean,
   permissions: ?(PermissionsListEntry[]),

--- a/test/reducers/sessions_test.js
+++ b/test/reducers/sessions_test.js
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import session from "../../src/reducers/session";
 import {
   SESSION_BUSY,
+  SESSION_SETUP,
   SESSION_SETUP_COMPLETE,
   SESSION_SERVERINFO_SUCCESS,
   SESSION_PERMISSIONS_SUCCESS,
@@ -13,6 +14,15 @@ import {
 } from "../../src/constants";
 
 describe("session reducer", () => {
+  const auth = {
+    server: "http://test",
+    authType: "basicauth",
+    credentials: {
+      username: "user",
+      password: "pass",
+    },
+  };
+
   it("SESSION_BUSY", () => {
     expect(
       session(undefined, {
@@ -24,16 +34,18 @@ describe("session reducer", () => {
       .eql(true);
   });
 
-  it("SESSION_SETUP_COMPLETE", () => {
-    const auth = {
-      server: "http://test",
-      authType: "basicauth",
-      credentials: {
-        username: "user",
-        password: "pass",
-      },
-    };
+  it("SESSION_SETUP", () => {
+    expect(
+      session(undefined, {
+        type: SESSION_SETUP,
+        auth,
+      })
+    )
+      .to.have.property("authenticating")
+      .eql(true);
+  });
 
+  it("SESSION_SETUP_COMPLETE", () => {
     expect(
       session(undefined, {
         type: SESSION_SETUP_COMPLETE,
@@ -41,6 +53,7 @@ describe("session reducer", () => {
       })
     ).eql({
       busy: false,
+      authenticating: false,
       authenticated: false,
       auth,
       buckets: [],


### PR DESCRIPTION
Fix #615 

Basically, once authenticated, the server info will never change. So I removed the busy state for the server info, and added an additional state for when the session is being setup. 

The result is a looooooooooooooooot better :) 

### After redirect
![screencast from 23-10-2018 16_52_47](https://user-images.githubusercontent.com/546692/47369703-8cec8b00-d6e4-11e8-94b8-d5ca93ab02d5.gif)


### With refresh

![screencast from 23-10-2018 16_53_19](https://user-images.githubusercontent.com/546692/47369655-75ad9d80-d6e4-11e8-9272-65e326e6fe90.gif)
