### PR TITLE
Renames "Signed" to "Approved"

### DIFF
--- a/src/plugins/signoff/components.js
+++ b/src/plugins/signoff/components.js
@@ -150,8 +150,8 @@ export default class SignoffToolBar extends React.Component<
             source={source}
             preview={preview}
           />
-          <Signed
-            label="Signed"
+          <Approved
+            label="Approved"
             step={2}
             currentStep={step}
             canEdit={canSign}


### PR DESCRIPTION
Fixes #683

If this is just a change for user experience, this should be adequate. But if it's regarding terminology, there are lots of references to "Signed" within the code such as in sagas.js ` const lastSigned = String(destinationAttributes.last_modified || 0);`

It may be worth updating those too depending on what the intention is