### PR TITLE
Fix behaviour of servers history

### DIFF
--- a/src/store/localStore.js
+++ b/src/store/localStore.js
@@ -6,7 +6,7 @@ const HISTORY_KEY = "kinto-admin-server-history";
 const SESSION_KEY = "kinto-admin-session";
 
 export function loadHistory(): ServerHistoryEntry[] {
-  const jsonHistory = sessionStorage.getItem(HISTORY_KEY);
+  const jsonHistory = localStorage.getItem(HISTORY_KEY);
   if (!jsonHistory) {
     return [];
   }
@@ -28,7 +28,7 @@ export function saveHistory(
   history: ServerHistoryEntry[]
 ): ServerHistoryEntry[] {
   try {
-    sessionStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
   } catch (err) {
     // Not much to do here, let's fail silently
   }

--- a/test/store/localStore_test.js
+++ b/test/store/localStore_test.js
@@ -15,7 +15,7 @@ describe("localStore", () => {
 
     it("should load legacy history", () => {
       const HISTORY_KEY = "kinto-admin-server-history";
-      sessionStorage.setItem(
+      localStorage.setItem(
         HISTORY_KEY,
         JSON.stringify(["someServer", "otherServer"])
       );


### PR DESCRIPTION
The servers history was not working properly because the list was stored in `sessionStorage`, which is destroyed on tab/browser close.

Using `localStorage` should do the job properly.