### PR TITLE
Ref #503: Better UI for signoff history view

### DIFF
--- a/src/components/HistoryTable.js
+++ b/src/components/HistoryTable.js
@@ -243,7 +243,7 @@ function FilterInfo(props) {
           document.location.hash = pathname;
           onViewJournalClick();
         }}>
-        View all entries
+        List view
       </a>
       {enableDiffOverview && since != null && (
         <span>
@@ -254,7 +254,7 @@ function FilterInfo(props) {
               event.preventDefault();
               onDiffOverviewClick(since);
             }}>
-            View records list diff overview
+            Diff view
           </a>
         </span>
       )}


### PR DESCRIPTION
Ref #503


While working on #949 I realized that this could be the confusing UI we were refering to in #503 

Before 
![Screenshot from 2019-06-03 16-34-32](https://user-images.githubusercontent.com/546692/58810154-a57b3700-861d-11e9-932e-b05d77fd7ab5.png)

After

![Screenshot from 2019-06-03 16-33-33](https://user-images.githubusercontent.com/546692/58810159-aa3feb00-861d-11e9-9d86-94335b554cac.png)
