### PR TITLE
Fix #1007: Since parameter not taken into account in history list

### DIFF
--- a/src/actions/group.js
+++ b/src/actions/group.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type { HistoryFilters, ResourceHistoryEntry } from "../types";
+import type { ResourceHistoryEntry } from "../types";
 
 import {
   GROUP_BUSY,
@@ -27,15 +27,13 @@ export function resetGroup(): {
 
 export function listGroupHistory(
   bid: string,
-  gid: string,
-  filters: HistoryFilters = {}
+  gid: string
 ): {
   type: "GROUP_HISTORY_REQUEST",
   bid: string,
   gid: string,
-  filters: HistoryFilters,
 } {
-  return { type: GROUP_HISTORY_REQUEST, bid, gid, filters };
+  return { type: GROUP_HISTORY_REQUEST, bid, gid };
 }
 
 export function listGroupNextHistory(): {

--- a/src/actions/record.js
+++ b/src/actions/record.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type { HistoryFilters, ResourceHistoryEntry } from "../types";
+import type { ResourceHistoryEntry } from "../types";
 
 import {
   RECORD_BUSY,
@@ -28,16 +28,14 @@ export function resetRecord(): {
 export function listRecordHistory(
   bid: string,
   cid: string,
-  rid: string,
-  filters: HistoryFilters = {}
+  rid: string
 ): {
   type: "RECORD_HISTORY_REQUEST",
   bid: string,
   cid: string,
   rid: string,
-  filters: HistoryFilters,
 } {
-  return { type: RECORD_HISTORY_REQUEST, bid, cid, rid, filters };
+  return { type: RECORD_HISTORY_REQUEST, bid, cid, rid };
 }
 
 export function listRecordNextHistory(): {

--- a/src/components/group/GroupHistory.js
+++ b/src/components/group/GroupHistory.js
@@ -11,7 +11,6 @@ import React, { PureComponent } from "react";
 
 import * as GroupActions from "../../actions/group";
 import * as NotificationActions from "../../actions/notifications";
-import { parseHistoryFilters } from "../../utils";
 import HistoryTable from "../HistoryTable";
 import CollectionTabs from "./GroupTabs";
 
@@ -35,17 +34,16 @@ export type Props = {
 };
 
 export const onGroupHistoryEnter = (props: Props) => {
-  const { match, listGroupHistory, session, location } = props;
+  const { match, listGroupHistory, session } = props;
   const {
     params: { bid, gid },
   } = match;
-  const filters = parseHistoryFilters(location.search);
   if (!session.authenticated) {
     // We're not authenticated, skip requesting the list of records. This likely
     // occurs when users refresh the page and lose their session.
     return;
   }
-  listGroupHistory && listGroupHistory(bid, gid, filters);
+  listGroupHistory && listGroupHistory(bid, gid);
 };
 
 export default class GroupHistory extends PureComponent<Props> {

--- a/src/components/record/RecordHistory.js
+++ b/src/components/record/RecordHistory.js
@@ -11,7 +11,6 @@ import React, { PureComponent } from "react";
 
 import * as RecordActions from "../../actions/record";
 import * as NotificationActions from "../../actions/notifications";
-import { parseHistoryFilters } from "../../utils";
 import HistoryTable from "../HistoryTable";
 import RecordTabs from "./RecordTabs";
 
@@ -35,15 +34,14 @@ export type Props = {
 };
 
 export const onRecordHistoryEnter = (props: Props) => {
-  const { listRecordHistory, match, session, location } = props;
+  const { listRecordHistory, match, session } = props;
   const {
     params: { bid, cid, rid },
   } = match;
-  const filters = parseHistoryFilters(location.search);
   if (!session.authenticated) {
     return;
   }
-  listRecordHistory(bid, cid, rid, filters);
+  listRecordHistory(bid, cid, rid);
 };
 
 export default class RecordHistory extends PureComponent<Props> {

--- a/src/sagas/collection.js
+++ b/src/sagas/collection.js
@@ -88,7 +88,7 @@ export function* listHistory(
   const {
     bid,
     cid,
-    filters: { resource_name },
+    filters: { resource_name, since },
   } = action;
   try {
     const bucket = getBucket(bid);
@@ -99,6 +99,7 @@ export function* listHistory(
         filters: {
           resource_name,
           collection_id: cid,
+          "gt_target.data.last_modified": since,
         },
       }
     );

--- a/src/sagas/record.js
+++ b/src/sagas/record.js
@@ -18,12 +18,7 @@ export function* listHistory(
   const {
     settings: { maxPerPage },
   } = getState();
-  const {
-    bid,
-    cid,
-    rid,
-    filters: { since },
-  } = action;
+  const { bid, cid, rid } = action;
   try {
     const bucket = getBucket(bid);
     const { data, hasNextPage, next } = yield call(
@@ -33,7 +28,6 @@ export function* listHistory(
         filters: {
           collection_id: cid,
           record_id: rid,
-          "gt_target.data.last_modified": since,
         },
       }
     );

--- a/test/routes_test.js
+++ b/test/routes_test.js
@@ -38,7 +38,7 @@ describe("Routes onEnter", () => {
         ...props,
         listBucketHistory: listBucketHistory,
       });
-      sinon.assert.calledWith(listBucketHistory, "bid", filters);
+      sinon.assert.calledWith(listBucketHistory, "bid");
     });
   });
 
@@ -57,7 +57,7 @@ describe("Routes onEnter", () => {
     it("should dispatch load history", () => {
       const listGroupHistory = sandbox.spy();
       onGroupHistoryEnter({ ...props, listGroupHistory: listGroupHistory });
-      sinon.assert.calledWith(listGroupHistory, "bid", "gid", filters);
+      sinon.assert.calledWith(listGroupHistory, "bid", "gid");
     });
   });
 
@@ -65,7 +65,7 @@ describe("Routes onEnter", () => {
     it("should dispatch load history", () => {
       const listRecordHistory = sandbox.spy();
       onRecordHistoryEnter({ ...props, listRecordHistory: listRecordHistory });
-      sinon.assert.calledWith(listRecordHistory, "bid", "cid", "rid", filters);
+      sinon.assert.calledWith(listRecordHistory, "bid", "cid", "rid");
     });
   });
 });

--- a/test/sagas/collection_test.js
+++ b/test/sagas/collection_test.js
@@ -1036,19 +1036,23 @@ describe("collection sagas", () => {
             filters: {
               resource_name: undefined,
               collection_id: "collection",
+              "gt_target.data.last_modified": undefined,
             },
           })
         );
       });
 
       it("should filter from timestamp if provided", () => {
-        const action = actions.listCollectionHistory("bucket", "collection");
+        const action = actions.listCollectionHistory("bucket", "collection", {
+          since: 42,
+        });
         const historySaga = saga.listHistory(() => ({ settings }), action);
         expect(historySaga.next().value).eql(
           call([client, client.listHistory], {
             filters: {
               resource_name: undefined,
               collection_id: "collection",
+              "gt_target.data.last_modified": 42,
             },
             limit: 42,
           })

--- a/test/sagas/record_test.js
+++ b/test/sagas/record_test.js
@@ -39,28 +39,7 @@ describe("record sagas", () => {
             filters: {
               collection_id: "collection",
               record_id: "record",
-              "gt_target.data.last_modified": undefined,
             },
-          })
-        );
-      });
-
-      it("should filter from timestamp if provided", () => {
-        const action = actions.listRecordHistory(
-          "bucket",
-          "collection",
-          "record",
-          { since: 42 }
-        );
-        const historySaga = saga.listHistory(() => ({ settings }), action);
-        expect(historySaga.next().value).eql(
-          call([client, client.listHistory], {
-            filters: {
-              collection_id: "collection",
-              record_id: "record",
-              "gt_target.data.last_modified": 42,
-            },
-            limit: 42,
           })
         );
       });


### PR DESCRIPTION
Fix #1007

You were right. The since parameter was taken into account in the record history, but not in the collection history -- which is the one used by the signoff toolbar