### PR TITLE
Update to the latest version of redux-saga

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3621,6 +3621,53 @@
         }
       }
     },
+    "@redux-saga/core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-8tInBftak8TPzE6X13ABmEtRJGjtK17w7VUs7qV17S8hCO5S3+aUTWZ/DBsBJPdE8Z5jOPwYALyvofgq1Ws+kg==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@redux-saga/deferred": "^1.1.2",
+        "@redux-saga/delay-p": "^1.1.2",
+        "@redux-saga/is": "^1.1.2",
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0",
+        "redux": "^4.0.4",
+        "typescript-tuple": "^2.2.1"
+      }
+    },
+    "@redux-saga/deferred": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.1.2.tgz",
+      "integrity": "sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ=="
+    },
+    "@redux-saga/delay-p": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.1.2.tgz",
+      "integrity": "sha512-ojc+1IoC6OP65Ts5+ZHbEYdrohmIw1j9P7HS9MOJezqMYtCDgpkoqB5enAAZrNtnbSL6gVCWPHaoaTY5KeO0/g==",
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2"
+      }
+    },
+    "@redux-saga/is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.1.2.tgz",
+      "integrity": "sha512-OLbunKVsCVNTKEf2cH4TYyNbbPgvmZ52iaxBD4I1fTif4+MTXMa4/Z07L83zW/hTCXwpSZvXogqMqLfex2Tg6w==",
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0"
+      }
+    },
+    "@redux-saga/symbols": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.1.2.tgz",
+      "integrity": "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ=="
+    },
+    "@redux-saga/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
+    },
     "@rjsf/core": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.4.0.tgz",
@@ -16186,9 +16233,12 @@
       }
     },
     "redux-saga": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.16.0.tgz",
-      "integrity": "sha1-CiMdsKFIkwHdmA9vL4jYztQY9yQ="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
+      "integrity": "sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==",
+      "requires": {
+        "@redux-saga/core": "^1.1.3"
+      }
     },
     "reflect.ownkeys": {
       "version": "0.2.0",
@@ -18552,6 +18602,27 @@
       "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "requires": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+    },
+    "typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "requires": {
+        "typescript-compare": "^0.0.2"
       }
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
-    "redux-saga": "^0.16.0",
+    "redux-saga": "^1.1.3",
     "rimraf": "^3.0.0",
     "timeago.js": "^4.0.0"
   },

--- a/test/plugin_test.js
+++ b/test/plugin_test.js
@@ -65,12 +65,12 @@ describe("Plugin API", () => {
       const sagas = flattenPluginsSagas(plugins, getState);
 
       expect(sagas).to.have.a.lengthOf(3);
-      expect(sagas[0].FORK.args[0]).eql("ACTION_1");
-      expect(sagas[0].FORK.args[1].name).eql("saga1");
-      expect(sagas[1].FORK.args[0]).eql("ACTION_2");
-      expect(sagas[1].FORK.args[1].name).eql("saga2");
-      expect(sagas[2].FORK.args[0]).eql("ACTION_3");
-      expect(sagas[2].FORK.args[1].name).eql("saga3");
+      expect(sagas[0].payload.args[0]).eql("ACTION_1");
+      expect(sagas[0].payload.args[1].name).eql("saga1");
+      expect(sagas[1].payload.args[0]).eql("ACTION_2");
+      expect(sagas[1].payload.args[1].name).eql("saga2");
+      expect(sagas[2].payload.args[0]).eql("ACTION_3");
+      expect(sagas[2].payload.args[1].name).eql("saga3");
     });
   });
 

--- a/test/plugins/signoff/sagas_test.js
+++ b/test/plugins/signoff/sagas_test.js
@@ -239,7 +239,7 @@ describe("Signoff plugin sagas", () => {
 
       it("should update the collection status as 'to-review'", () => {
         expect(handleRequestReview.next({ id: "coll" }).value)
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("args")
           .to.deep.include({ status: "to-review", last_editor_comment: ":)" });
       });
@@ -250,7 +250,7 @@ describe("Signoff plugin sagas", () => {
             data: { id: "coll", status: "to-review" },
           }).value
         )
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("args")
           .to.deep.include(collection_actions.listRecords("buck", "coll"));
       });
@@ -290,7 +290,7 @@ describe("Signoff plugin sagas", () => {
 
       it("should update the collection status as 'work-in-progress'", () => {
         expect(handleDeclineChanges.next({ id: "coll" }).value)
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("args")
           .to.deep.include({
             status: "work-in-progress",
@@ -304,7 +304,7 @@ describe("Signoff plugin sagas", () => {
             data: { id: "coll", status: "work-in-progress" },
           }).value
         )
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("args")
           .to.deep.include(collection_actions.listRecords("buck", "coll"));
       });
@@ -344,7 +344,7 @@ describe("Signoff plugin sagas", () => {
 
       it("should update the collection status as 'to-sign'", () => {
         expect(handleApproveChanges.next({ id: "coll" }).value)
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("args")
           .to.deep.include({ status: "to-sign", last_reviewer_comment: "" });
       });
@@ -355,7 +355,7 @@ describe("Signoff plugin sagas", () => {
             data: { id: "coll", status: "to-sign" },
           }).value
         )
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("args")
           .to.deep.include(collection_actions.listRecords("buck", "coll"));
       });
@@ -395,7 +395,7 @@ describe("Signoff plugin sagas", () => {
 
       it("should update the collection status as 'to-rollback'", () => {
         expect(handleRollbackChanges.next({ id: "coll" }).value)
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("args")
           .to.deep.include({
             status: "to-rollback",
@@ -409,7 +409,7 @@ describe("Signoff plugin sagas", () => {
             data: { id: "coll", status: "to-rollback" },
           }).value
         )
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("args")
           .to.deep.include(collection_actions.listRecords("buck", "coll"));
       });

--- a/test/sagas/collection_test.js
+++ b/test/sagas/collection_test.js
@@ -869,8 +869,8 @@ describe("collection sagas", () => {
 
         // We can't simply test for the passed batch function, so we're testing
         // the provided argument type here.
-        expect(v.CALL.args[0]).to.be.a("function");
-        expect(v.CALL.args[1]).eql({ aggregate: true });
+        expect(v.payload.args[0]).to.be.a("function");
+        expect(v.payload.args[1]).eql({ aggregate: true });
       });
 
       it("should update the route path", () => {

--- a/test/sagas/index_test.js
+++ b/test/sagas/index_test.js
@@ -25,6 +25,9 @@ describe("root saga", () => {
 
   beforeEach(() => {
     sandbox = createSandbox();
+    // To match the behavior of older versions of redux-saga, we're ignoring
+    // calls to console.error from these tests.
+    jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/test/sagas/route_test.js
+++ b/test/sagas/route_test.js
@@ -106,7 +106,7 @@ describe("route sagas", () => {
 
         it("should batch fetch resources data", () => {
           expect(loadRoute.next().value)
-            .to.have.property("CALL")
+            .to.have.property("payload")
             .to.have.property("context")
             .to.have.property("batch")
             .eql(batch);
@@ -152,7 +152,7 @@ describe("route sagas", () => {
 
         it("should batch fetch resources data", () => {
           expect(loadRoute.next().value)
-            .to.have.property("CALL")
+            .to.have.property("payload")
             .to.have.property("context")
             .to.have.property("batch")
             .eql(batch);
@@ -199,7 +199,7 @@ describe("route sagas", () => {
 
         it("should batch fetch resources data", () => {
           expect(loadRoute.next().value)
-            .to.have.property("CALL")
+            .to.have.property("payload")
             .to.have.property("context")
             .to.have.property("batch")
             .eql(batch);
@@ -247,7 +247,7 @@ describe("route sagas", () => {
 
         it("should batch fetch resources data", () => {
           expect(loadRoute.next().value)
-            .to.have.property("CALL")
+            .to.have.property("payload")
             .to.have.property("context")
             .to.have.property("batch")
             .eql(batch);
@@ -297,7 +297,7 @@ describe("route sagas", () => {
 
       it("should batch fetch resources data", () => {
         expect(loadRoute.next().value)
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("context")
           .to.have.property("batch")
           .eql(batch);
@@ -346,7 +346,7 @@ describe("route sagas", () => {
 
       it("should batch fetch resources data", () => {
         expect(loadRoute.next().value)
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("context")
           .to.have.property("batch")
           .eql(batch);

--- a/test/sagas/session_test.js
+++ b/test/sagas/session_test.js
@@ -365,7 +365,7 @@ describe("session sagas", () => {
         const buckets = { data: [{ id: "b1" }, { id: "b2" }] };
 
         expect(listBuckets.next(buckets).value)
-          .to.have.property("CALL")
+          .to.have.property("payload")
           .to.have.property("fn")
           .eql(client.batch);
       });
@@ -474,7 +474,7 @@ describe("session sagas", () => {
           listBuckets.throw(new Error("HTTP 403"));
           // Saga continues without failing.
           expect(listBuckets.next().value)
-            .to.have.property("CALL")
+            .to.have.property("payload")
             .to.have.property("fn")
             .eql(client.listPermissions);
         });
@@ -484,7 +484,7 @@ describe("session sagas", () => {
           listBuckets.throw(new Error("HTTP 401"));
           // Saga continues without failing.
           expect(listBuckets.next().value)
-            .to.have.property("CALL")
+            .to.have.property("payload")
             .to.have.property("fn")
             .eql(client.listPermissions);
         });


### PR DESCRIPTION
This PR updates to the latest version of `redux-saga`. One of the first mentioned breaking changes for v1 is that "errors thrown during put execution are no longer caught and swallowed". This means that we're now logging considerably more errors than before, all of which aren't important to tests actually passing. This PR disables `console.error` during a specifically noisy set of tests. In the future we should examine the calls and determine if we really need to be reporting those errors as test failures, but in the meantime this gets us back to where we were prior to upgrading.