### PR TITLE
Switch to react-bootstrap-icons

### DIFF
--- a/interfaces/external-modules/react-bootstrap-icons.d.js
+++ b/interfaces/external-modules/react-bootstrap-icons.d.js
@@ -1,0 +1,3 @@
+declare module "react-bootstrap-icons" {
+  declare module.exports: any;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16104,6 +16104,34 @@
         }
       }
     },
+    "react-bootstrap-icons": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-icons/-/react-bootstrap-icons-1.1.0.tgz",
+      "integrity": "sha512-VDqoeXm/wCXfPuStJfsOztqYpZ3WdjaUaWZk6z78bjNc0JwQCme4nxuML+ISn151Vm6RAZKs2U4c/IbMhuJzpQ==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
+      }
+    },
     "react-breadcrumbs": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-breadcrumbs/-/react-breadcrumbs-2.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "patch-package": "^6.2.2",
     "react": "^16.8.6",
     "react-bootstrap": "^1.3.0",
+    "react-bootstrap-icons": "^1.1.0",
     "react-breadcrumbs": "^2.1.6",
     "react-bs-notifier": "^6.0.0",
     "react-codemirror2": "^7.0.0",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -33,9 +33,9 @@ import RecordAttributesPage from "../containers/record/RecordAttributesPage";
 import RecordPermissionsPage from "../containers/record/RecordPermissionsPage";
 import RecordHistoryPage from "../containers/record/RecordHistoryPage";
 
-import { ReactComponent as BoxArrowRight } from "bootstrap-icons/icons/box-arrow-right.svg";
-import { ReactComponent as QuestionCircleFillIcon } from "bootstrap-icons/icons/question-circle-fill.svg";
-import { ReactComponent as ClipboardIcon } from "bootstrap-icons/icons/clipboard.svg";
+import { BoxArrowRight } from "react-bootstrap-icons";
+import { QuestionCircleFill } from "react-bootstrap-icons";
+import { Clipboard } from "react-bootstrap-icons";
 
 function UserInfo({ session }) {
   const {
@@ -69,13 +69,13 @@ function SessionInfoBar({ session, logout, copyAuthenticationHeader }) {
           onClick={event =>
             event.preventDefault() || copyAuthenticationHeader()
           }>
-          <ClipboardIcon className="icon" />
+          <Clipboard className="icon" />
         </a>
         <a
           href={project_docs}
           target="_blank"
           className="spaced btn btn-sm btn-secondary project-docs">
-          <QuestionCircleFillIcon className="icon" /> Documentation
+          <QuestionCircleFill className="icon" /> Documentation
         </a>
         <a
           href=""

--- a/src/components/HistoryTable.js
+++ b/src/components/HistoryTable.js
@@ -5,9 +5,9 @@ import type { Location } from "react-router-dom";
 
 import React, { PureComponent } from "react";
 
-import { ReactComponent as EyeIcon } from "bootstrap-icons/icons/eye.svg";
-import { ReactComponent as EyeSlashIcon } from "bootstrap-icons/icons/eye-slash.svg";
-import { ReactComponent as SkipStartIcon } from "bootstrap-icons/icons/skip-start.svg";
+import { Eye } from "react-bootstrap-icons";
+import { EyeSlash } from "react-bootstrap-icons";
+import { SkipStart } from "react-bootstrap-icons";
 
 import * as NotificationActions from "../actions/notifications";
 import { diffJson, timeago, humanDate, parseHistoryFilters } from "../utils";
@@ -173,7 +173,7 @@ class HistoryRow extends PureComponent<HistoryRowProps, HistoryRowState> {
                   name="collection:history"
                   params={{ bid, cid }}
                   query={{ since: last_modified, resource_name: "record" }}>
-                  <SkipStartIcon className="icon" />
+                  <SkipStart className="icon" />
                 </AdminLink>{" "}
               </span>
             )}
@@ -182,11 +182,7 @@ class HistoryRow extends PureComponent<HistoryRowProps, HistoryRowState> {
               className="btn btn-sm btn-secondary"
               onClick={this.toggle}
               title="View entry details">
-              {open ? (
-                <EyeSlashIcon className="icon" />
-              ) : (
-                <EyeIcon className="icon" />
-              )}
+              {open ? <EyeSlash className="icon" /> : <Eye className="icon" />}
             </a>
           </td>
         </tr>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -10,15 +10,15 @@ import type { Location, Match } from "react-router-dom";
 import { PureComponent } from "react";
 import * as React from "react";
 
-import { ReactComponent as PlusIcon } from "bootstrap-icons/icons/plus.svg";
-import { ReactComponent as XCircleFillIcon } from "bootstrap-icons/icons/x-circle-fill.svg";
-import { ReactComponent as Folder2Icon } from "bootstrap-icons/icons/folder2.svg";
-import { ReactComponent as Folder2OpenIcon } from "bootstrap-icons/icons/folder2-open.svg";
-import { ReactComponent as GearIcon } from "bootstrap-icons/icons/gear.svg";
-import { ReactComponent as LockIcon } from "bootstrap-icons/icons/lock.svg";
-import { ReactComponent as JustifyIcon } from "bootstrap-icons/icons/justify.svg";
-import { ReactComponent as ThreeDotsIcon } from "bootstrap-icons/icons/three-dots.svg";
-import { ReactComponent as ArrowRepeatIcon } from "bootstrap-icons/icons/arrow-repeat.svg";
+import { Plus } from "react-bootstrap-icons";
+import { XCircleFill } from "react-bootstrap-icons";
+import { Folder2 } from "react-bootstrap-icons";
+import { Folder2Open } from "react-bootstrap-icons";
+import { Gear } from "react-bootstrap-icons";
+import { Lock } from "react-bootstrap-icons";
+import { Justify } from "react-bootstrap-icons";
+import { ThreeDots } from "react-bootstrap-icons";
+import { ArrowRepeat } from "react-bootstrap-icons";
 
 import * as SessionActions from "../actions/session";
 import Spinner from "./Spinner";
@@ -64,7 +64,7 @@ function HomeMenu(props) {
       <div className="list-group list-group-flush">
         <SideBarLink name="home" currentPath={currentPath} params={{}}>
           Home
-          <ArrowRepeatIcon onClick={onRefresh} className="icon" />
+          <ArrowRepeat onClick={onRefresh} className="icon" />
         </SideBarLink>
       </div>
     </div>
@@ -92,9 +92,9 @@ function CollectionMenuEntry(props) {
         currentPath={currentPath}
         className="">
         {collection.readonly ? (
-          <LockIcon className="icon" />
+          <Lock className="icon" />
         ) : (
-          <JustifyIcon className="icon" />
+          <Justify className="icon" />
         )}
         {cid}
       </SideBarLink>
@@ -104,7 +104,7 @@ function CollectionMenuEntry(props) {
         currentPath={currentPath}
         className="collections-menu-entry-edit"
         title="Edit collection attributes">
-        <GearIcon className="icon" />
+        <Gear className="icon" />
       </SideBarLink>
     </div>
   );
@@ -149,7 +149,7 @@ function BucketCollectionsMenu(props) {
             name="bucket:collections"
             params={{ bid: bucket.id }}
             currentPath={currentPath}>
-            <ThreeDotsIcon className="icon" />
+            <ThreeDots className="icon" />
             See all collections
           </SideBarLink>
         )}
@@ -158,7 +158,7 @@ function BucketCollectionsMenu(props) {
           name="collection:create"
           params={{ bid: bucket.id }}
           currentPath={currentPath}>
-          <PlusIcon className="icon" />
+          <Plus className="icon" />
           Create collection
         </SideBarLink>
       )}
@@ -259,7 +259,7 @@ class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
                 name="bucket:create"
                 currentPath={currentPath}
                 params={{}}>
-                <PlusIcon className="icon" />
+                <Plus className="icon" />
                 Create bucket
               </SideBarLink>
             </div>
@@ -284,7 +284,7 @@ class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
                     href=""
                     className="btn btn-outline-secondary"
                     onClick={this.resetSearch}>
-                    <XCircleFillIcon className="icon" />
+                    <XCircleFill className="icon" />
                   </button>
                 </div>
               </div>
@@ -317,11 +317,11 @@ class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
                 } bucket-menu`}>
                 <div className="card-header">
                   {bucket.readonly ? (
-                    <LockIcon className="icon" />
+                    <Lock className="icon" />
                   ) : current ? (
-                    <Folder2OpenIcon className="icon" />
+                    <Folder2Open className="icon" />
                   ) : (
-                    <Folder2Icon className="icon" />
+                    <Folder2 className="icon" />
                   )}
                   <strong>{id}</strong> bucket
                   <SideBarLink
@@ -330,7 +330,7 @@ class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
                     currentPath={currentPath}
                     className="bucket-menu-entry-edit"
                     title="Manage bucket">
-                    <GearIcon className="icon" />
+                    <Gear className="icon" />
                   </SideBarLink>
                 </div>
                 <BucketCollectionsMenu

--- a/src/components/bucket/BucketCollections.js
+++ b/src/components/bucket/BucketCollections.js
@@ -9,9 +9,9 @@ import type { Location } from "react-router-dom";
 
 import React, { PureComponent } from "react";
 
-import { ReactComponent as GearIcon } from "bootstrap-icons/icons/gear.svg";
-import { ReactComponent as JustifyIcon } from "bootstrap-icons/icons/justify.svg";
-import { ReactComponent as ClockHistoryIcon } from "bootstrap-icons/icons/clock-history.svg";
+import { Gear } from "react-bootstrap-icons";
+import { Justify } from "react-bootstrap-icons";
+import { ClockHistory } from "react-bootstrap-icons";
 
 import * as BucketActions from "../../actions/bucket";
 import { timeago } from "../../utils";
@@ -67,7 +67,7 @@ function DataList(props) {
                   params={{ bid, cid }}
                   className="btn btn-sm btn-secondary"
                   title="Browse collection">
-                  <JustifyIcon className="icon" />
+                  <Justify className="icon" />
                 </AdminLink>
                 {"history" in capabilities && (
                   <AdminLink
@@ -75,7 +75,7 @@ function DataList(props) {
                     params={{ bid, cid }}
                     className="btn btn-sm btn-secondary"
                     title="View collection history">
-                    <ClockHistoryIcon className="icon" />
+                    <ClockHistory className="icon" />
                   </AdminLink>
                 )}
                 <AdminLink
@@ -83,7 +83,7 @@ function DataList(props) {
                   params={{ bid, cid }}
                   className="btn btn-sm btn-secondary"
                   title="Edit collection attributes">
-                  <GearIcon className="icon" />
+                  <Gear className="icon" />
                 </AdminLink>
               </div>
             </td>

--- a/src/components/bucket/BucketForm.js
+++ b/src/components/bucket/BucketForm.js
@@ -4,8 +4,8 @@ import type { BucketState, BucketData, SessionState } from "../../types";
 import React, { PureComponent } from "react";
 import { Link } from "react-router-dom";
 
-import { ReactComponent as Check2Icon } from "bootstrap-icons/icons/check2.svg";
-import { ReactComponent as TrashIcon } from "bootstrap-icons/icons/trash.svg";
+import { Check2 } from "react-bootstrap-icons";
+import { Trash } from "react-bootstrap-icons";
 
 import BaseForm from "../BaseForm";
 import JSONEditor from "../JSONEditor";
@@ -74,7 +74,7 @@ function DeleteForm({ bid, onSubmit }) {
             }
           }}>
           <button type="submit" className="btn btn-danger">
-            <TrashIcon className="icon" /> Delete bucket
+            <Trash className="icon" /> Delete bucket
           </button>
         </BaseForm>
       </div>
@@ -137,7 +137,7 @@ export default class BucketForm extends PureComponent<Props> {
           type="submit"
           disabled={!formIsEditable}
           className="btn btn-primary">
-          <Check2Icon className="icon" />
+          <Check2 className="icon" />
           {` ${creation ? "Create" : "Update"} bucket`}
         </button>
         {" or "}

--- a/src/components/bucket/BucketGroups.js
+++ b/src/components/bucket/BucketGroups.js
@@ -8,8 +8,8 @@ import type {
 
 import React, { PureComponent } from "react";
 
-import { ReactComponent as GearIcon } from "bootstrap-icons/icons/gear.svg";
-import { ReactComponent as ClockHistoryIcon } from "bootstrap-icons/icons/clock-history.svg";
+import { Gear } from "react-bootstrap-icons";
+import { ClockHistory } from "react-bootstrap-icons";
 
 import { timeago } from "../../utils";
 import AdminLink from "../AdminLink";
@@ -52,7 +52,7 @@ function DataList(props) {
                       params={{ bid, gid }}
                       className="btn btn-sm btn-secondary"
                       title="View group history">
-                      <ClockHistoryIcon className="icon" />
+                      <ClockHistory className="icon" />
                     </AdminLink>
                   )}
                   <AdminLink
@@ -60,7 +60,7 @@ function DataList(props) {
                     params={{ bid, gid }}
                     className="btn btn-sm btn-secondary"
                     title="Edit groups attributes">
-                    <GearIcon className="icon" />
+                    <Gear className="icon" />
                   </AdminLink>
                 </div>
               </td>

--- a/src/components/bucket/BucketTabs.js
+++ b/src/components/bucket/BucketTabs.js
@@ -4,11 +4,11 @@ import type { Capabilities } from "../../types";
 import { PureComponent } from "react";
 import * as React from "react";
 
-import { ReactComponent as GearIcon } from "bootstrap-icons/icons/gear.svg";
-import { ReactComponent as LockIcon } from "bootstrap-icons/icons/lock.svg";
-import { ReactComponent as JustifyIcon } from "bootstrap-icons/icons/justify.svg";
-import { ReactComponent as PersonFillIcon } from "bootstrap-icons/icons/person-fill.svg";
-import { ReactComponent as ClockHistoryIcon } from "bootstrap-icons/icons/clock-history.svg";
+import { Gear } from "react-bootstrap-icons";
+import { Lock } from "react-bootstrap-icons";
+import { Justify } from "react-bootstrap-icons";
+import { PersonFill } from "react-bootstrap-icons";
+import { ClockHistory } from "react-bootstrap-icons";
 
 import AdminLink from "../AdminLink";
 
@@ -34,7 +34,7 @@ export default class BucketTabs extends PureComponent<Props> {
                 className={
                   selected === "collections" ? "nav-link active" : "nav-link"
                 }>
-                <JustifyIcon className="icon" />
+                <Justify className="icon" />
                 Collections
               </AdminLink>
             </li>
@@ -45,7 +45,7 @@ export default class BucketTabs extends PureComponent<Props> {
                 className={
                   selected === "groups" ? "nav-link active" : "nav-link"
                 }>
-                <PersonFillIcon className="icon" />
+                <PersonFill className="icon" />
                 Groups
               </AdminLink>
             </li>
@@ -56,7 +56,7 @@ export default class BucketTabs extends PureComponent<Props> {
                 className={
                   selected === "attributes" ? "nav-link active" : "nav-link"
                 }>
-                <GearIcon className="icon" />
+                <Gear className="icon" />
                 Attributes
               </AdminLink>
             </li>
@@ -67,7 +67,7 @@ export default class BucketTabs extends PureComponent<Props> {
                 className={
                   selected === "permissions" ? "nav-link active" : "nav-link"
                 }>
-                <LockIcon className="icon" />
+                <Lock className="icon" />
                 Permissions
               </AdminLink>
             </li>
@@ -79,7 +79,7 @@ export default class BucketTabs extends PureComponent<Props> {
                   className={
                     selected === "history" ? "nav-link active" : "nav-link"
                   }>
-                  <ClockHistoryIcon className="icon" />
+                  <ClockHistory className="icon" />
                   History
                 </AdminLink>
               </li>

--- a/src/components/collection/CollectionForm.js
+++ b/src/components/collection/CollectionForm.js
@@ -9,8 +9,8 @@ import type {
 import React, { PureComponent } from "react";
 import { Link } from "react-router-dom";
 
-import { ReactComponent as Check2Icon } from "bootstrap-icons/icons/check2.svg";
-import { ReactComponent as TrashIcon } from "bootstrap-icons/icons/trash.svg";
+import { Check2 } from "react-bootstrap-icons";
+import { Trash } from "react-bootstrap-icons";
 
 import BaseForm from "../BaseForm";
 import JSONCollectionForm from "./JSONCollectionForm";
@@ -75,7 +75,7 @@ function DeleteForm({ cid, onSubmit }) {
             }
           }}>
           <button type="submit" className="btn btn-danger">
-            <TrashIcon className="icon" /> Delete collection
+            <Trash className="icon" /> Delete collection
           </button>
         </BaseForm>
       </div>
@@ -391,7 +391,7 @@ export default class CollectionForm extends PureComponent<Props, State> {
           type="submit"
           disabled={!this.allowEditing}
           className="btn btn-primary">
-          <Check2Icon className="icon" />
+          <Check2 className="icon" />
           {` ${creation ? "Create" : "Update"} collection`}
         </button>
         {" or "}

--- a/src/components/collection/CollectionRecords.js
+++ b/src/components/collection/CollectionRecords.js
@@ -11,12 +11,12 @@ import type { Location } from "react-router-dom";
 
 import React, { PureComponent } from "react";
 
-import { ReactComponent as PaperclipIcon } from "bootstrap-icons/icons/paperclip.svg";
-import { ReactComponent as PencilIcon } from "bootstrap-icons/icons/pencil.svg";
-import { ReactComponent as LockIcon } from "bootstrap-icons/icons/lock.svg";
-import { ReactComponent as TrashIcon } from "bootstrap-icons/icons/trash.svg";
-import { ReactComponent as SortUpIcon } from "bootstrap-icons/icons/sort-up.svg";
-import { ReactComponent as SortDownIcon } from "bootstrap-icons/icons/sort-down.svg";
+import { Paperclip } from "react-bootstrap-icons";
+import { Pencil } from "react-bootstrap-icons";
+import { Lock } from "react-bootstrap-icons";
+import { Trash } from "react-bootstrap-icons";
+import { SortUp } from "react-bootstrap-icons";
+import { SortDown } from "react-bootstrap-icons";
 
 import * as CollectionActions from "../../actions/collection";
 import * as RouteActions from "../../actions/route";
@@ -111,7 +111,7 @@ class Row extends PureComponent<RowProps> {
                 className="btn btn-sm btn-secondary"
                 title="The record has an attachment"
                 target="_blank">
-                <PaperclipIcon className="icon" />
+                <Paperclip className="icon" />
               </a>
             )}
             <AdminLink
@@ -119,21 +119,21 @@ class Row extends PureComponent<RowProps> {
               params={{ bid, cid, rid }}
               className="btn btn-sm btn-info"
               title="Edit record">
-              <PencilIcon className="icon" />
+              <Pencil className="icon" />
             </AdminLink>
             <AdminLink
               name="record:permissions"
               params={{ bid, cid, rid }}
               className="btn btn-sm btn-warning"
               title="Record permissions">
-              <LockIcon className="icon" />
+              <Lock className="icon" />
             </AdminLink>
             <button
               type="button"
               className="btn btn-sm btn-danger"
               onClick={this.onDeleteClick.bind(this)}
               title="Delete record">
-              <TrashIcon className="icon" />
+              <Trash className="icon" />
             </button>
           </div>
         </td>
@@ -160,9 +160,9 @@ function SortLink(props) {
         }
       }}>
       {dir === "up" ? (
-        <SortUpIcon className="icon" />
+        <SortUp className="icon" />
       ) : (
-        <SortDownIcon className="icon" />
+        <SortDown className="icon" />
       )}
     </a>
   );

--- a/src/components/collection/CollectionTabs.js
+++ b/src/components/collection/CollectionTabs.js
@@ -4,10 +4,10 @@ import type { Capabilities } from "../../types";
 import { PureComponent } from "react";
 import * as React from "react";
 
-import { ReactComponent as GearIcon } from "bootstrap-icons/icons/gear.svg";
-import { ReactComponent as LockIcon } from "bootstrap-icons/icons/lock.svg";
-import { ReactComponent as JustifyIcon } from "bootstrap-icons/icons/justify.svg";
-import { ReactComponent as ClockHistoryIcon } from "bootstrap-icons/icons/clock-history.svg";
+import { Gear } from "react-bootstrap-icons";
+import { Lock } from "react-bootstrap-icons";
+import { Justify } from "react-bootstrap-icons";
+import { ClockHistory } from "react-bootstrap-icons";
 
 import AdminLink from "../AdminLink";
 
@@ -42,7 +42,7 @@ export default class CollectionTabs extends PureComponent<Props> {
                 className={
                   selected === "records" ? "nav-link active" : "nav-link"
                 }>
-                <JustifyIcon className="icon" />
+                <Justify className="icon" />
                 Records {totalRecords ? `(${totalRecords})` : null}
               </AdminLink>
             </li>
@@ -53,7 +53,7 @@ export default class CollectionTabs extends PureComponent<Props> {
                 className={
                   selected === "attributes" ? "nav-link active" : "nav-link"
                 }>
-                <GearIcon className="icon" />
+                <Gear className="icon" />
                 Attributes
               </AdminLink>
             </li>
@@ -64,7 +64,7 @@ export default class CollectionTabs extends PureComponent<Props> {
                 className={
                   selected === "permissions" ? "nav-link active" : "nav-link"
                 }>
-                <LockIcon className="icon" />
+                <Lock className="icon" />
                 Permissions
               </AdminLink>
             </li>
@@ -76,7 +76,7 @@ export default class CollectionTabs extends PureComponent<Props> {
                   className={
                     selected === "history" ? "nav-link active" : "nav-link"
                   }>
-                  <ClockHistoryIcon className="icon" />
+                  <ClockHistory className="icon" />
                   History
                 </AdminLink>
               </li>

--- a/src/components/group/GroupForm.js
+++ b/src/components/group/GroupForm.js
@@ -8,8 +8,8 @@ import type {
 
 import React, { PureComponent } from "react";
 
-import { ReactComponent as Check2Icon } from "bootstrap-icons/icons/check2.svg";
-import { ReactComponent as TrashIcon } from "bootstrap-icons/icons/trash.svg";
+import { Check2 } from "react-bootstrap-icons";
+import { Trash } from "react-bootstrap-icons";
 
 import BaseForm from "../BaseForm";
 import AdminLink from "../AdminLink";
@@ -84,7 +84,7 @@ function DeleteForm({ gid, onSubmit }) {
             }
           }}>
           <button type="submit" className="btn btn-danger">
-            <TrashIcon className="icon" /> Delete group
+            <Trash className="icon" /> Delete group
           </button>
         </BaseForm>
       </div>
@@ -162,7 +162,7 @@ export default class GroupForm extends PureComponent<Props> {
           type="submit"
           disabled={!formIsEditable}
           className="btn btn-primary">
-          <Check2Icon className="icon" />
+          <Check2 className="icon" />
           {` ${creation ? "Create" : "Update"} group`}
         </button>
         {" or "}

--- a/src/components/group/GroupTabs.js
+++ b/src/components/group/GroupTabs.js
@@ -3,9 +3,9 @@ import type { Capabilities } from "../../types";
 
 import React, { PureComponent } from "react";
 
-import { ReactComponent as GearIcon } from "bootstrap-icons/icons/gear.svg";
-import { ReactComponent as LockIcon } from "bootstrap-icons/icons/lock.svg";
-import { ReactComponent as ClockHistoryIcon } from "bootstrap-icons/icons/clock-history.svg";
+import { Gear } from "react-bootstrap-icons";
+import { Lock } from "react-bootstrap-icons";
+import { ClockHistory } from "react-bootstrap-icons";
 
 import AdminLink from "../AdminLink";
 
@@ -32,7 +32,7 @@ export default class GroupTabs extends PureComponent<Props> {
                 className={
                   selected === "attributes" ? "nav-link active" : "nav-link"
                 }>
-                <GearIcon className="icon" />
+                <Gear className="icon" />
                 Attributes
               </AdminLink>
             </li>
@@ -43,7 +43,7 @@ export default class GroupTabs extends PureComponent<Props> {
                 className={
                   selected === "permissions" ? "nav-link active" : "nav-link"
                 }>
-                <LockIcon className="icon" />
+                <Lock className="icon" />
                 Permissions
               </AdminLink>
             </li>
@@ -55,7 +55,7 @@ export default class GroupTabs extends PureComponent<Props> {
                   className={
                     selected === "history" ? "nav-link active" : "nav-link"
                   }>
-                  <ClockHistoryIcon className="icon" />
+                  <ClockHistory className="icon" />
                   History
                 </AdminLink>
               </li>

--- a/src/components/record/RecordForm.js
+++ b/src/components/record/RecordForm.js
@@ -11,9 +11,9 @@ import type {
 import React, { PureComponent } from "react";
 import filesize from "filesize";
 
-import { ReactComponent as Check2Icon } from "bootstrap-icons/icons/check2.svg";
-import { ReactComponent as TrashIcon } from "bootstrap-icons/icons/trash.svg";
-import { ReactComponent as PaperclipIcon } from "bootstrap-icons/icons/paperclip.svg";
+import { Check2 } from "react-bootstrap-icons";
+import { Trash } from "react-bootstrap-icons";
+import { Paperclip } from "react-bootstrap-icons";
 
 import * as CollectionActions from "../../actions/collection";
 import BaseForm from "./../BaseForm";
@@ -158,7 +158,7 @@ function AttachmentInfo(props: AttachmentInfoProps) {
   return (
     <div className="card attachment-info">
       <div className="card-header">
-        <PaperclipIcon className="icon" />
+        <Paperclip className="icon" />
         <b>Attachment information</b>
       </div>
       <div className="card-body">
@@ -315,7 +315,7 @@ export default class RecordForm extends PureComponent<Props, State> {
             type="submit"
             className="btn btn-primary"
             disabled={!this.allowEditing}>
-            <Check2Icon className="icon" />
+            <Check2 className="icon" />
             {` ${record ? "Update" : "Create"} record`}
           </button>
           {" or "}
@@ -337,7 +337,7 @@ export default class RecordForm extends PureComponent<Props, State> {
               type="button"
               className="btn btn-danger delete"
               onClick={this.deleteRecord}>
-              <TrashIcon className="icon" /> Delete record
+              <Trash className="icon" /> Delete record
             </button>
           )}
         </div>

--- a/src/components/record/RecordTabs.js
+++ b/src/components/record/RecordTabs.js
@@ -4,9 +4,9 @@ import type { Capabilities } from "../../types";
 import { PureComponent } from "react";
 import * as React from "react";
 
-import { ReactComponent as GearIcon } from "bootstrap-icons/icons/gear.svg";
-import { ReactComponent as LockIcon } from "bootstrap-icons/icons/lock.svg";
-import { ReactComponent as ClockHistoryIcon } from "bootstrap-icons/icons/clock-history.svg";
+import { Gear } from "react-bootstrap-icons";
+import { Lock } from "react-bootstrap-icons";
+import { ClockHistory } from "react-bootstrap-icons";
 
 import AdminLink from "../AdminLink";
 
@@ -34,7 +34,7 @@ export default class RecordTabs extends PureComponent<Props> {
                 className={
                   selected === "attributes" ? "nav-link active" : "nav-link"
                 }>
-                <GearIcon className="icon" />
+                <Gear className="icon" />
                 Attributes
               </AdminLink>
             </li>
@@ -45,7 +45,7 @@ export default class RecordTabs extends PureComponent<Props> {
                 className={
                   selected === "permissions" ? "nav-link active" : "nav-link"
                 }>
-                <LockIcon className="icon" />
+                <Lock className="icon" />
                 Permissions
               </AdminLink>
             </li>
@@ -57,7 +57,7 @@ export default class RecordTabs extends PureComponent<Props> {
                   className={
                     selected === "history" ? "nav-link active" : "nav-link"
                   }>
-                  <ClockHistoryIcon className="icon" />
+                  <ClockHistory className="icon" />
                   History
                 </AdminLink>
               </li>

--- a/src/plugins/signoff/components.js
+++ b/src/plugins/signoff/components.js
@@ -11,9 +11,9 @@ import type {
 import { PureComponent } from "react";
 import * as React from "react";
 
-import { ReactComponent as ChatLeftIcon } from "bootstrap-icons/icons/chat-left.svg";
-import { ReactComponent as XCircleFillIcon } from "bootstrap-icons/icons/x-circle-fill.svg";
-import { ReactComponent as Check2Icon } from "bootstrap-icons/icons/check2.svg";
+import { ChatLeft } from "react-bootstrap-icons";
+import { XCircleFill } from "react-bootstrap-icons";
+import { Check2 } from "react-bootstrap-icons";
 
 import { canEditCollection } from "../../permission";
 import { timeago, humanDate } from "../../utils";
@@ -342,7 +342,7 @@ function RequestReviewButton(props: { onClick: () => void }) {
   const { onClick } = props;
   return (
     <button className="btn btn-info request-review" onClick={onClick}>
-      <ChatLeftIcon className="icon" /> Request review...
+      <ChatLeft className="icon" /> Request review...
     </button>
   );
 }
@@ -351,7 +351,7 @@ function RollbackChangesButton(props: { onClick: () => void }) {
   const { onClick } = props;
   return (
     <button className="btn btn-info rollback-changes" onClick={onClick}>
-      <XCircleFillIcon className="icon" /> Rollback changes...
+      <XCircleFill className="icon" /> Rollback changes...
     </button>
   );
 }
@@ -522,10 +522,10 @@ function ReviewButtons(props: {
   return (
     <div className="btn-group">
       <button className="btn btn-success" onClick={onApprove}>
-        <Check2Icon className="icon" /> Approve
+        <Check2 className="icon" /> Approve
       </button>
       <button className="btn btn-danger" onClick={onDecline}>
-        <ChatLeftIcon className="icon" /> Decline...
+        <ChatLeft className="icon" /> Decline...
       </button>
     </div>
   );
@@ -675,7 +675,7 @@ class CommentDialog extends PureComponent<
                   type="button"
                   className="btn btn-primary"
                   onClick={onClickConfirm}>
-                  <Check2Icon className="icon" /> {confirmLabel}
+                  <Check2 className="icon" /> {confirmLabel}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
This PR switches from relying on the svgr webpack plugin to using a pre-compiled version of the `bootstrap-icons` library.

Before:
```js
import { ReactComponent as ClipboardIcon } from "bootstrap-icons/icons/clipboard.svg";
```

After:
```js
import { Clipboard } from "react-bootstrap-icons";
```

This should circumvent [this issue](https://github.com/facebook/create-react-app/issues/9991) since we're no longer relying on the consuming bundler to handle the SVG -> React Component conversion. It should fix https://github.com/Kinto/kinto/issues/2646.
