### PR TITLE
[signoff] Distinguish interactive progressbar from informative ones

### DIFF
--- a/css/plugins/signoff/styles.css
+++ b/css/plugins/signoff/styles.css
@@ -1,3 +1,7 @@
+.informative {
+  filter: grayscale(0.8);
+}
+
 /*Form Wizard*/
 .bs-wizard {margin-top: 40px;}
 .progress-steps .row.bs-wizard { border-bottom: 0; }

--- a/src/plugins/signoff/components.js
+++ b/src/plugins/signoff/components.js
@@ -136,10 +136,11 @@ export default class SignoffToolBar extends React.Component<SignoffToolBarProps>
     const canRollback = canEdit;
     const hasHistory = "history" in sessionState.serverInfo.capabilities;
 
+    const isCurrentUrl = source.bid == bid && source.cid == cid;
     // Default status is request review
     const currentStep = status == "to-review" ? 1 : status == "signed" ? 2 : 0;
     return (
-      <div>
+      <div className={isCurrentUrl ? "interactive" : "informative"}>
         {hasHistory ? null : (
           <div className="alert alert-warning">
             <p>
@@ -156,7 +157,7 @@ export default class SignoffToolBar extends React.Component<SignoffToolBarProps>
             label="Work in progress"
             step={0}
             currentStep={currentStep}
-            isCurrentUrl={source.bid == bid && source.cid == cid}
+            isCurrentUrl={isCurrentUrl}
             canEdit={canRequestReview}
             hasHistory={hasHistory}
             confirmRequestReview={confirmRequestReview}


### PR DESCRIPTION
![Screenshot from 2020-11-09 13-48-25](https://user-images.githubusercontent.com/546692/98543115-44d03f00-2292-11eb-9733-d1e2e8c27a3f.png)
![Screenshot from 2020-11-09 13-48-08](https://user-images.githubusercontent.com/546692/98543119-469a0280-2292-11eb-816b-867b8eb85780.png)
