### PR TITLE
Fix Bootstrap 5

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -264,7 +264,7 @@ class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
             <strong>Filters</strong>
           </div>
           <form className="form card-body">
-            <div className="form-group">
+            <div className="mb-3">
               <div className="input-group">
                 <input
                   type="text"
@@ -282,7 +282,7 @@ class BucketsMenu extends PureComponent<BucketsMenuProps, BucketsMenuState> {
                 </div>
               </div>
             </div>
-            <div className="form-group form-check">
+            <div className="mb-3 form-check">
               <input
                 className="form-check-input"
                 id="read-only-toggle"

--- a/src/components/TagsField.tsx
+++ b/src/components/TagsField.tsx
@@ -69,7 +69,7 @@ export default class TagsField extends PureComponent<Props, State> {
     const { uiSchema, required, readonly } = this.props;
     const { tagsString } = this.state;
     return (
-      <div className="form-group field field-string">
+      <div className="mb-3 field field-string">
         <label className="control-label">
           {this.props.schema.title || this.props.name}
           {required ? "*" : ""}


### PR DESCRIPTION
The `form-group` class is removed in Bootstrap 5, the recommended replacement is `mb-3`.

https://getbootstrap.com/docs/5.1/migration/