### PR TITLE
Provide object to destructure if errorData is null

### DIFF
--- a/src/actions/notifications.ts
+++ b/src/actions/notifications.ts
@@ -12,9 +12,11 @@ function getErrorDetails(error: ClientError | null | undefined): string[] {
   if (!error) {
     return [];
   }
-  const { data: errorData, message } = error;
+  const {
+    data: { code, message: errorMessage, details: errorDetails } = {},
+    message,
+  } = error;
   let details = [message];
-  const { code, message: errorMessage, details: errorDetails } = errorData;
   if (!code) {
     return details;
   }

--- a/test/sagas/session_test.js
+++ b/test/sagas/session_test.js
@@ -284,13 +284,16 @@ describe("session sagas", () => {
             },
           },
         });
+        jest.spyOn(console, "error").mockImplementation(() => {});
         setupSession = saga.setupSession(getState, action);
         setupSession.next(); // call getServerInfo.
-        const mocked = mockNotifyError(sandbox);
-        setupSession.next();
-        sinon.assert.calledWith(mocked, "Authentication failed.", {
-          message: "Could not authenticate with Basic Auth",
-        });
+        expect(setupSession.next().value).eql(
+          put(
+            notificationsActions.notifyError("Authentication failed.", {
+              message: "Could not authenticate with Basic Auth",
+            })
+          )
+        );
         expect(setupSession.next().value).eql(
           put(actions.authenticationFailed())
         );


### PR DESCRIPTION
Closes #2119

In `getErrorDetails`, we attempted to destructure a `ClientError`'s
`data` property. But since that property is possibly undefined, we would
get a type error.

This commit fixes this error by providing an empty object as a
fallback in case `errorData` is undefined. It also updates a saga test
where we call this function. We were previously mocking `notifyError`,
but this is where the bug bubbled up. Instead, we now remove that mock
and use the real function in the saga test to prevent a regression.