### PR TITLE
Bump Node version to used in Github actions to 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
 
       - name: Print environment
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
 
       - name: Print environment
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
 
       - name: Print environment
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 /build
 /dist
 /flow-typed
+.vscode

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Kinto-based systems.
 
 ## Prerequisites
 
-NodeJS v4+ and npm 2.14+ should be installed and available on your machine.
+NodeJS v16+ and npm 8+ should be installed and available on your machine.
 
 Various pre-commit hooks are available to help prevent you from
 pushing sub-optimal code; to use these, ``pip install --user

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "kinto-admin",
       "version": "1.31.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -90,8 +91,8 @@
         "webpack-hot-middleware": "^2.22.3"
       },
       "engines": {
-        "node": ">=10",
-        "npm": "^2.14.7"
+        "node": ">=16",
+        "npm": ">=8"
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   ],
   "engineStrict": false,
   "engines": {
-    "npm": "^2.14.7",
-    "node": ">=10"
+    "npm": ">=8",
+    "node": ">=16"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "images",
     "lib"
   ],
-  "engineStrict": false,
   "engines": {
     "npm": ">=8",
     "node": ">=16"


### PR DESCRIPTION
Bumps `Node.js` to `^16`, [the LTS version](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#16.13.0) at the time of this PR. This also bumps `npm` to version 8.