### PR TITLE
Modify `createComponent` test helper to accept JSX

### DIFF
--- a/test/components/AuthForm_test.js
+++ b/test/components/AuthForm_test.js
@@ -3,13 +3,10 @@ import { DEFAULT_SERVERINFO } from "../../src/reducers/session";
 import { createSandbox, createComponent } from "../test_utils";
 import { expect } from "chai";
 import { DEFAULT_KINTO_SERVER } from "../../src/constants";
+import * as React from "react";
 
 describe("AuthForm component", () => {
-  let sandbox,
-    setupSession,
-    getServerInfo,
-    navigateToExternalAuth,
-    serverChange;
+  let sandbox;
 
   beforeEach(() => {
     jest.resetModules();
@@ -20,15 +17,12 @@ describe("AuthForm component", () => {
     sandbox.restore();
   });
   it("should set the default server url in a visible field", () => {
-    const node = createComponent(AuthForm, {
-      match: {},
-      setupSession,
-      serverChange,
-      getServerInfo,
-      servers: [],
-      navigateToExternalAuth,
-      session: { authenticated: false, serverInfo: DEFAULT_SERVERINFO },
-    });
+    const node = createComponent(
+      <AuthForm
+        session={{ authenticated: false, serverInfo: DEFAULT_SERVERINFO }}
+      />
+    );
+
     const element = node.querySelector("input[id='root_server']");
     expect(element.type).eql("text");
     expect(element.value).eql(DEFAULT_KINTO_SERVER);
@@ -44,15 +38,11 @@ describe("AuthForm component", () => {
       };
     });
     const AuthForm = require("../../src/components/AuthForm").default;
-    const node = createComponent(AuthForm, {
-      match: {},
-      setupSession,
-      serverChange,
-      getServerInfo,
-      servers: [],
-      navigateToExternalAuth,
-      session: { authenticated: false, serverInfo: DEFAULT_SERVERINFO },
-    });
+    const node = createComponent(
+      <AuthForm
+        session={{ authenticated: false, serverInfo: DEFAULT_SERVERINFO }}
+      />
+    );
     const element = node.querySelector("input[id='root_server']");
     expect(element.type).eql("hidden");
     expect(element.value).eql("http://www.example.com/");

--- a/test/components/CollectionRecords_test.js
+++ b/test/components/CollectionRecords_test.js
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import { createSandbox, createComponent } from "../test_utils";
 
 import CollectionRecords from "../../src/components/collection/CollectionRecords";
+import * as React from "react";
 
 describe("CollectionRecords component", () => {
   let sandbox;
@@ -53,14 +54,19 @@ describe("CollectionRecords component", () => {
     };
 
     beforeEach(() => {
-      node = createComponent(CollectionRecords, {
-        match: { params: { bid: "bucket", cid: "collection" } },
-        session: { authenticated: true, serverInfo: { user: { id: "plop" } } },
-        bucket,
-        collection,
-        capabilities,
-        listRecords: () => {},
-      });
+      node = createComponent(
+        <CollectionRecords
+          match={{ params: { bid: "bucket", cid: "collection" } }}
+          session={{
+            authenticated: true,
+            serverInfo: { user: { id: "plop" } },
+          }}
+          bucket={bucket}
+          collection={collection}
+          capabilities={capabilities}
+          listRecords={() => {}}
+        />
+      );
     });
 
     it("should render a table", () => {
@@ -98,14 +104,19 @@ describe("CollectionRecords component", () => {
     };
 
     beforeEach(() => {
-      node = createComponent(CollectionRecords, {
-        match: { params: { bid: "bucket", cid: "collection" } },
-        session: { authenticated: true, serverInfo: { user: { id: "plop" } } },
-        bucket,
-        collection,
-        capabilities,
-        listRecords: () => {},
-      });
+      node = createComponent(
+        <CollectionRecords
+          match={{ params: { bid: "bucket", cid: "collection" } }}
+          session={{
+            authenticated: true,
+            serverInfo: { user: { id: "plop" } },
+          }}
+          bucket={bucket}
+          collection={collection}
+          capabilities={capabilities}
+          listRecords={() => {}}
+        />
+      );
     });
 
     it("should render a table", () => {
@@ -140,14 +151,16 @@ describe("CollectionRecords component", () => {
     };
 
     beforeEach(() => {
-      node = createComponent(CollectionRecords, {
-        match: { params: { bid: "bucket", cid: "collection" } },
-        session: {},
-        bucket,
-        collection,
-        capabilities,
-        listRecords: () => {},
-      });
+      node = createComponent(
+        <CollectionRecords
+          match={{ params: { bid: "bucket", cid: "collection" } }}
+          session={{}}
+          bucket={bucket}
+          collection={collection}
+          capabilities={capabilities}
+          listRecords={() => {}}
+        />
+      );
     });
 
     it("should show the total number of records", () => {
@@ -180,14 +193,16 @@ describe("CollectionRecords component", () => {
       let node;
 
       beforeEach(() => {
-        node = createComponent(CollectionRecords, {
-          match: { params: { bid: "bucket", cid: "collection" } },
-          session: { permissions: null },
-          bucket,
-          collection,
-          capabilities,
-          listRecords: () => {},
-        });
+        node = createComponent(
+          <CollectionRecords
+            match={{ params: { bid: "bucket", cid: "collection" } }}
+            session={{ permissions: null }}
+            bucket={bucket}
+            collection={collection}
+            capabilities={capabilities}
+            listRecords={() => {}}
+          />
+        );
       });
 
       it("should render list actions", () => {
@@ -201,14 +216,16 @@ describe("CollectionRecords component", () => {
       let node;
 
       beforeEach(() => {
-        node = createComponent(CollectionRecords, {
-          match: { params: { bid: "bucket", cid: "collection" } },
-          session: { permissions: [] },
-          bucket,
-          collection,
-          capabilities,
-          listRecords: () => {},
-        });
+        node = createComponent(
+          <CollectionRecords
+            match={{ params: { bid: "bucket", cid: "collection" } }}
+            session={{ permissions: [] }}
+            bucket={bucket}
+            collection={collection}
+            capabilities={capabilities}
+            listRecords={() => {}}
+          />
+        );
       });
 
       it("should not render list actions", () => {

--- a/test/components/Homepage_test.js
+++ b/test/components/Homepage_test.js
@@ -38,7 +38,7 @@ describe("HomePage component", () => {
         getServerInfo = sandbox.spy();
         navigateToExternalAuth = sandbox.spy();
         navigateToOpenID = sandbox.spy();
-        node = createComponent(HomePage, {
+        const props = {
           match: {},
           setupSession,
           serverChange,
@@ -63,7 +63,8 @@ describe("HomePage component", () => {
               },
             },
           },
-        });
+        };
+        node = createComponent(<HomePage {...props} />);
       });
 
       it("should render a setup form", () => {
@@ -170,13 +171,14 @@ describe("HomePage component", () => {
 
     describe("Servers history support", () => {
       it("should set the server field value using a default value if there's no servers", () => {
-        const node = createComponent(HomePage, {
+        const props = {
           match: {},
           serverChange: sandbox.spy(),
           getServerInfo: sandbox.spy(),
           servers: [],
           session: { authenticated: false, serverInfo: DEFAULT_SERVERINFO },
-        });
+        };
+        const node = createComponent(<HomePage {...props} />);
 
         expect(node.querySelector("#root_server").value).eql(
           "https://demo.kinto-storage.org/v1/"
@@ -184,13 +186,14 @@ describe("HomePage component", () => {
       });
 
       it("should set the server field value using latest entry from servers", () => {
-        const node = createComponent(HomePage, {
+        const props = {
           match: {},
           serverChange: sandbox.spy(),
           getServerInfo: sandbox.spy(),
           servers: [{ server: "http://server.test/v1", authType: "anonymous" }],
           session: { authenticated: false, serverInfo: DEFAULT_SERVERINFO },
-        });
+        };
+        const node = createComponent(<HomePage {...props} />);
 
         expect(node.querySelector("#root_server").value).eql(
           "http://server.test/v1"
@@ -267,7 +270,7 @@ describe("HomePage component", () => {
 
       beforeEach(() => {
         setupSession = sinon.spy();
-        createComponent(HomePage, {
+        const props = {
           match: {
             params: {
               payload:
@@ -281,7 +284,8 @@ describe("HomePage component", () => {
           getServerInfo: sandbox.spy(),
           servers: [],
           session: { authenticated: false, serverInfo: DEFAULT_SERVERINFO },
-        });
+        };
+        createComponent(<HomePage {...props} />);
       });
 
       it("should setup session when component is mounted", () => {
@@ -298,22 +302,23 @@ describe("HomePage component", () => {
 
   describe("Authenticated", () => {
     let node;
-
-    beforeEach(() => {
-      node = createComponent(HomePage, {
-        match: {},
-        session: {
-          authenticated: true,
-          server: "http://test.server/v1",
-          username: "user",
-          password: "pass",
-          serverInfo: {
-            foo: {
-              bar: "plop",
-            },
+    const props = {
+      match: {},
+      session: {
+        authenticated: true,
+        server: "http://test.server/v1",
+        username: "user",
+        password: "pass",
+        serverInfo: {
+          foo: {
+            bar: "plop",
           },
         },
-      });
+      },
+    };
+
+    beforeEach(() => {
+      node = createComponent(<HomePage {...props} />);
     });
 
     it("should render server information heading", () => {

--- a/test/components/Notifications_test.js
+++ b/test/components/Notifications_test.js
@@ -4,6 +4,7 @@ import { Simulate } from "react-dom/test-utils";
 
 import { createSandbox, createComponent } from "../test_utils";
 import Notifications from "../../src/components/Notifications";
+import * as React from "react";
 
 describe("Notifications component", () => {
   let sandbox, removeNotification;
@@ -18,22 +19,26 @@ describe("Notifications component", () => {
   });
 
   it("should render an error", () => {
-    const node = createComponent(Notifications, {
-      removeNotification,
-      notifications: [{ type: "danger", message: "fail" }],
-    });
+    const node = createComponent(
+      <Notifications
+        removeNotification={removeNotification}
+        notifications={[{ type: "danger", message: "fail" }]}
+      />
+    );
 
     expect(node.querySelectorAll(".alert")).to.have.a.lengthOf(1);
   });
 
   it("should render multiple notifications", () => {
-    const node = createComponent(Notifications, {
-      removeNotification,
-      notifications: [
-        { type: "info", message: "info" },
-        { type: "danger", message: "fail" },
-      ],
-    });
+    const node = createComponent(
+      <Notifications
+        removeNotification={removeNotification}
+        notifications={[
+          { type: "info", message: "info" },
+          { type: "danger", message: "fail" },
+        ]}
+      />
+    );
 
     expect(
       [].map.call(node.querySelectorAll(".alert h4"), n => n.textContent)
@@ -41,10 +46,12 @@ describe("Notifications component", () => {
   });
 
   it("should remove a single notif when the list has one", () => {
-    const node = createComponent(Notifications, {
-      removeNotification,
-      notifications: [{ type: "info", message: "plop" }],
-    });
+    const node = createComponent(
+      <Notifications
+        removeNotification={removeNotification}
+        notifications={[{ type: "info", message: "plop" }]}
+      />
+    );
 
     Simulate.click(node.querySelector(".close"));
 
@@ -52,14 +59,15 @@ describe("Notifications component", () => {
   });
 
   it("should remove a single notif when the list has two", () => {
-    const node = createComponent(Notifications, {
-      removeNotification,
-      notifications: [
-        { type: "info", message: "plop" },
-        { type: "info", message: "plap" },
-      ],
-    });
-
+    const node = createComponent(
+      <Notifications
+        removeNotification={removeNotification}
+        notifications={[
+          { type: "info", message: "plop" },
+          { type: "info", message: "plap" },
+        ]}
+      />
+    );
     // second notification close button clicked
     Simulate.click(node.querySelectorAll(".close")[1]);
 

--- a/test/components/RecordAttributes_test.js
+++ b/test/components/RecordAttributes_test.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import { Simulate } from "react-dom/test-utils";
+import * as React from "react";
 
 import { createSandbox, createComponent } from "../test_utils";
 
@@ -68,10 +69,9 @@ describe("RecordAttributes component", () => {
 
     beforeEach(() => {
       updateRecord = sinon.spy();
-      node = createComponent(RecordAttributes, {
-        ...props,
-        updateRecord,
-      });
+      node = createComponent(
+        <RecordAttributes {...props} updateRecord={updateRecord} />
+      );
     });
 
     it("should render a form", () => {
@@ -113,11 +113,13 @@ describe("RecordAttributes component", () => {
     };
 
     beforeEach(() => {
-      node = createComponent(RecordAttributes, {
-        ...props,
-        capabilities: { attachments: { base_url: "" } },
-        record,
-      });
+      node = createComponent(
+        <RecordAttributes
+          {...props}
+          capabilities={{ attachments: { base_url: "" } }}
+          record={record}
+        />
+      );
     });
 
     it("should render the attachment info", () => {
@@ -136,11 +138,13 @@ describe("RecordAttributes component", () => {
       };
 
       beforeEach(() => {
-        node = createComponent(RecordAttributes, {
-          ...props,
-          capabilities: { attachments: { base_url: "" } },
-          record: gzipped,
-        });
+        node = createComponent(
+          <RecordAttributes
+            {...props}
+            capabilities={{ attachments: { base_url: "" } }}
+            record={gzipped}
+          />
+        );
       });
 
       it("should show original file attributes", () => {
@@ -162,10 +166,9 @@ describe("RecordAttributes component", () => {
 
       describe("ID not in UISchema", () => {
         beforeEach(() => {
-          const node = createComponent(RecordAttributes, {
-            ...props,
-            collection: withID,
-          });
+          const node = createComponent(
+            <RecordAttributes {...props} collection={withID} />
+          );
           field = node.querySelector("#root_id");
         });
 
@@ -191,10 +194,9 @@ describe("RecordAttributes component", () => {
         };
 
         beforeEach(() => {
-          const node = createComponent(RecordAttributes, {
-            ...props,
-            collection: withUISchema,
-          });
+          const node = createComponent(
+            <RecordAttributes {...props} collection={withUISchema} />
+          );
           field = node.querySelector("#root_id");
         });
 
@@ -216,10 +218,9 @@ describe("RecordAttributes component", () => {
       let node;
       describe("ID not in UISchema", () => {
         beforeEach(() => {
-          node = createComponent(RecordAttributes, {
-            ...props,
-            collection,
-          });
+          node = createComponent(
+            <RecordAttributes {...props} collection={collection} />
+          );
         });
 
         it("should not show the id field", () => {
@@ -238,10 +239,9 @@ describe("RecordAttributes component", () => {
         };
 
         beforeEach(() => {
-          const node = createComponent(RecordAttributes, {
-            ...props,
-            collection: withUISchema,
-          });
+          const node = createComponent(
+            <RecordAttributes {...props} collection={withUISchema} />
+          );
           field = node.querySelector("#root_id");
         });
 
@@ -267,11 +267,13 @@ describe("RecordAttributes component", () => {
 
       describe("Schema version not in UISchema", () => {
         beforeEach(() => {
-          const node = createComponent(RecordAttributes, {
-            ...props,
-            collection: withSchemaVersion,
-            record,
-          });
+          const node = createComponent(
+            <RecordAttributes
+              {...props}
+              collection={withSchemaVersion}
+              record={record}
+            />
+          );
           field = node.querySelector("#root_schema");
         });
 
@@ -296,11 +298,13 @@ describe("RecordAttributes component", () => {
         };
 
         beforeEach(() => {
-          const node = createComponent(RecordAttributes, {
-            ...props,
-            collection: withUISchema,
-            record,
-          });
+          const node = createComponent(
+            <RecordAttributes
+              {...props}
+              collection={withUISchema}
+              record={record}
+            />
+          );
           field = node.querySelector("#root_schema");
         });
 
@@ -322,11 +326,13 @@ describe("RecordAttributes component", () => {
       let node;
       describe("Schema version not in UISchema", () => {
         beforeEach(() => {
-          node = createComponent(RecordAttributes, {
-            ...props,
-            collection,
-            record,
-          });
+          node = createComponent(
+            <RecordAttributes
+              {...props}
+              collection={collection}
+              record={record}
+            />
+          );
         });
 
         it("should not show the schema field", () => {
@@ -346,10 +352,9 @@ describe("RecordAttributes component", () => {
         };
 
         beforeEach(() => {
-          createComponent(RecordAttributes, {
-            ...props,
-            collection: withUISchema,
-          });
+          createComponent(
+            <RecordAttributes {...props} collection={withUISchema} />
+          );
         });
 
         it("should not show the schema field", () => {
@@ -375,11 +380,13 @@ describe("RecordAttributes component", () => {
 
       describe("Last modified not in UISchema", () => {
         beforeEach(() => {
-          const node = createComponent(RecordAttributes, {
-            ...props,
-            collection: withLastmodified,
-            record,
-          });
+          const node = createComponent(
+            <RecordAttributes
+              {...props}
+              collection={withLastmodified}
+              record={record}
+            />
+          );
           field = node.querySelector("#root_last_modified");
         });
 
@@ -404,11 +411,13 @@ describe("RecordAttributes component", () => {
         };
 
         beforeEach(() => {
-          const node = createComponent(RecordAttributes, {
-            ...props,
-            collection: withUISchema,
-            record,
-          });
+          const node = createComponent(
+            <RecordAttributes
+              {...props}
+              collection={withUISchema}
+              record={record}
+            />
+          );
           field = node.querySelector("#root_last_modified");
         });
 
@@ -430,11 +439,13 @@ describe("RecordAttributes component", () => {
       let node;
       describe("Last modified not in UISchema", () => {
         beforeEach(() => {
-          node = createComponent(RecordAttributes, {
-            ...props,
-            collection,
-            record,
-          });
+          node = createComponent(
+            <RecordAttributes
+              {...props}
+              collection={collection}
+              record={record}
+            />
+          );
         });
 
         it("should not show the schema field", () => {
@@ -454,10 +465,9 @@ describe("RecordAttributes component", () => {
         };
 
         beforeEach(() => {
-          createComponent(RecordAttributes, {
-            ...props,
-            collection: withUISchema,
-          });
+          createComponent(
+            <RecordAttributes {...props} collection={withUISchema} />
+          );
         });
 
         it("should not show the schema field", () => {

--- a/test/components/RecordBulk_test.js
+++ b/test/components/RecordBulk_test.js
@@ -5,6 +5,7 @@ import { Simulate } from "react-dom/test-utils";
 import { createSandbox, createComponent } from "../test_utils";
 
 import RecordBulk from "../../src/components/record/RecordBulk";
+import * as React from "react";
 
 describe("RecordBulk component", () => {
   let sandbox;
@@ -34,11 +35,13 @@ describe("RecordBulk component", () => {
 
     beforeEach(() => {
       bulkCreateRecords = sinon.spy();
-      node = createComponent(RecordBulk, {
-        match: { params: { bid: "bucket", cid: "collection" } },
-        collection,
-        bulkCreateRecords,
-      });
+      node = createComponent(
+        <RecordBulk
+          match={{ params: { bid: "bucket", cid: "collection" } }}
+          collection={collection}
+          bulkCreateRecords={bulkCreateRecords}
+        />
+      );
     });
 
     it("should render a form", () => {

--- a/test/components/RecordCreate_test.js
+++ b/test/components/RecordCreate_test.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import { Simulate } from "react-dom/test-utils";
+import * as React from "react";
 
 import { createSandbox, createComponent } from "../test_utils";
 
@@ -56,10 +57,9 @@ describe("RecordCreate component", () => {
 
     beforeEach(() => {
       createRecord = sinon.spy();
-      node = createComponent(RecordCreate, {
-        ...props,
-        createRecord,
-      });
+      node = createComponent(
+        <RecordCreate {...props} createRecord={createRecord} />
+      );
     });
 
     it("should render a form", () => {
@@ -91,10 +91,9 @@ describe("RecordCreate component", () => {
 
         describe("ID not in UISchema", () => {
           beforeEach(() => {
-            const node = createComponent(RecordCreate, {
-              ...props,
-              collection: withID,
-            });
+            const node = createComponent(
+              <RecordCreate {...props} collection={withID} />
+            );
             field = node.querySelector("#root_id");
           });
 
@@ -116,10 +115,9 @@ describe("RecordCreate component", () => {
           };
 
           beforeEach(() => {
-            const node = createComponent(RecordCreate, {
-              ...props,
-              collection: withUISchema,
-            });
+            const node = createComponent(
+              <RecordCreate {...props} collection={withUISchema} />
+            );
             field = node.querySelector("#root_id");
           });
 
@@ -137,10 +135,9 @@ describe("RecordCreate component", () => {
         let node;
         describe("ID not in UISchema", () => {
           beforeEach(() => {
-            node = createComponent(RecordCreate, {
-              ...props,
-              collection,
-            });
+            node = createComponent(
+              <RecordCreate {...props} collection={collection} />
+            );
           });
 
           it("should not show the id field", () => {
@@ -159,10 +156,9 @@ describe("RecordCreate component", () => {
           };
 
           beforeEach(() => {
-            const node = createComponent(RecordCreate, {
-              ...props,
-              collection: withUISchema,
-            });
+            const node = createComponent(
+              <RecordCreate {...props} collection={withUISchema} />
+            );
             field = node.querySelector("#root_id");
           });
 

--- a/test/components/Sidebar_test.js
+++ b/test/components/Sidebar_test.js
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import { createSandbox, createComponent } from "../test_utils";
 import { Sidebar } from "../../src/components/Sidebar";
 import { clone } from "../../src/utils";
+import * as React from "react";
 
 describe("Sidebar component", () => {
   let sandbox;
@@ -18,13 +19,12 @@ describe("Sidebar component", () => {
   describe("Not authenticated", () => {
     it("should not render any bucket menus", () => {
       const node = createComponent(
-        Sidebar,
-        {
-          match: { params: {} },
-          location: { pathname: "" },
-          capabilities: { history: {} },
-        },
-        { session: { authenticated: false } }
+        <Sidebar
+          match={{ params: {} }}
+          location={{ pathname: "" }}
+          capabilities={{ history: {} }}
+        />,
+        { initialState: { session: { authenticated: false } } }
       );
 
       expect(node.querySelectorAll(".bucket-menu")).to.have.a.lengthOf(0);
@@ -57,13 +57,12 @@ describe("Sidebar component", () => {
 
     beforeEach(() => {
       node = createComponent(
-        Sidebar,
-        {
-          match: { params },
-          location,
-          capabilities,
-        },
-        { session }
+        <Sidebar
+          match={{ params }}
+          location={location}
+          capabilities={capabilities}
+        />,
+        { initialState: { session } }
       );
       bucketMenus = node.querySelectorAll(".bucket-menu");
     });
@@ -106,13 +105,12 @@ describe("Sidebar component", () => {
     describe("Create bucket", () => {
       it("should be shown by default", () => {
         node = createComponent(
-          Sidebar,
-          {
-            match: { params },
-            location,
-            capabilities,
-          },
-          { session }
+          <Sidebar
+            match={{ params }}
+            location={location}
+            capabilities={capabilities}
+          />,
+          { initialState: { session } }
         );
         expect(node.querySelector(".bucket-create")).to.exist;
       });
@@ -122,13 +120,12 @@ describe("Sidebar component", () => {
         notAllowed.permissions = [{ resource_name: "root", permissions: [] }];
 
         node = createComponent(
-          Sidebar,
-          {
-            match: { params },
-            location,
-            capabilities,
-          },
-          { session: notAllowed }
+          <Sidebar
+            match={{ params }}
+            location={location}
+            capabilities={capabilities}
+          />,
+          { initialState: { session: notAllowed } }
         );
         expect(node.querySelector(".bucket-create")).to.not.exist;
       });

--- a/test/components/TagsField_test.js
+++ b/test/components/TagsField_test.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import sinon, { useFakeTimers } from "sinon";
 import { Simulate } from "react-dom/test-utils";
+import * as React from "react";
 
 import { createSandbox, createComponent } from "../test_utils";
 import TagsField from "../../src/components/TagsField";
@@ -20,34 +21,37 @@ describe("TagsField component", () => {
 
   describe("Separator", () => {
     it('should use "," as a default separator', () => {
-      const node = createComponent(TagsField, {
+      const props = {
         schema: {},
         formData: ["a", "b", "c"],
-      });
+      };
+      const node = createComponent(<TagsField {...props} />);
 
       expect(node.querySelector("input").value).eql("a, b, c");
     });
 
     it("should accept and use a custom separator", () => {
-      const node = createComponent(TagsField, {
+      const props = {
         schema: {},
         formData: ["a", "b", "c"],
         uiSchema: {
           "ui:options": { separator: ":" },
         },
-      });
+      };
+      const node = createComponent(<TagsField {...props} />);
 
       expect(node.querySelector("input").value).eql("a: b: c");
     });
 
     it("should special case the space separator", () => {
-      const node = createComponent(TagsField, {
+      const props = {
         schema: {},
         formData: ["a", "b", "c"],
         uiSchema: {
           "ui:options": { separator: " " },
         },
-      });
+      };
+      const node = createComponent(<TagsField {...props} />);
 
       expect(node.querySelector("input").value).eql("a b c");
     });
@@ -55,21 +59,23 @@ describe("TagsField component", () => {
 
   describe("Unique items", () => {
     it("should accept duplicates by default", () => {
-      const node = createComponent(TagsField, {
+      const props = {
         schema: {},
         formData: ["a", "b", "a"],
-      });
+      };
+      const node = createComponent(<TagsField {...props} />);
 
       expect(node.querySelector("input").value).eql("a, b, a");
     });
 
     it("should drop duplicates with an uniqueItems enabled schema", () => {
       const onChange = sinon.spy();
-      const node = createComponent(TagsField, {
+      const props = {
         schema: { uniqueItems: true },
         formData: ["a", "b"],
         onChange,
-      });
+      };
+      const node = createComponent(<TagsField {...props} />);
 
       Simulate.change(node.querySelector("input"), {
         target: { value: "a, b, a" },

--- a/test/components/signoff/SimpleReview/PerRecordDiffView_test.js
+++ b/test/components/signoff/SimpleReview/PerRecordDiffView_test.js
@@ -2,15 +2,13 @@ import { expect } from "chai";
 import { createComponent } from "../../../test_utils";
 
 import PerRecordDiffView, {
-  PerRecordDiffViewProps,
   findChangeTypes,
   ChangeType,
 } from "../../../../src/components/signoff/SimpleReview/PerRecordDiffView";
+import * as React from "react";
 
-function defaultSimpleViewDiffsProps(
-  props: Partial<PerRecordDiffViewProps> = null
-): PerRecordDiffViewProps {
-  return {
+function renderSimpleReview(props = null) {
+  const mergedProps = {
     oldRecords: [],
     newRecords: [],
     collectionData: {
@@ -20,44 +18,36 @@ function defaultSimpleViewDiffsProps(
     },
     ...props,
   };
+  return createComponent(<PerRecordDiffView {...mergedProps} />);
 }
 
 describe("PerRecordDiffView component", () => {
   it("should render loading when authenticating", () => {
-    const node = createComponent(
-      PerRecordDiffView,
-      defaultSimpleViewDiffsProps({
-        collectionData: {
-          status: "signed",
-          bid: "a",
-          cid: "b",
-        },
-      })
-    );
+    const node = renderSimpleReview({
+      collectionData: {
+        status: "signed",
+        bid: "a",
+        cid: "b",
+      },
+    });
     expect(node.textContent).to.equal(
       "No changes to review, collection status is signed."
     );
   });
 
   it("should render diffs", () => {
-    const node = createComponent(
-      PerRecordDiffView,
-      defaultSimpleViewDiffsProps({
-        oldRecords: [{ id: "foo" }, { id: "bar" }],
-        newRecords: [{ id: "foo" }, { id: "baz" }],
-      })
-    );
+    const node = renderSimpleReview({
+      oldRecords: [{ id: "foo" }, { id: "bar" }],
+      newRecords: [{ id: "foo" }, { id: "baz" }],
+    });
     expect(node.querySelectorAll(".record-diff")).to.have.lengthOf(2);
   });
 
   it("should render per-record diffs", () => {
-    const node = createComponent(
-      PerRecordDiffView,
-      defaultSimpleViewDiffsProps({
-        oldRecords: [{ id: "foo" }],
-        newRecords: [{ id: "foo" }, { id: "bar" }],
-      })
-    );
+    const node = renderSimpleReview({
+      oldRecords: [{ id: "foo" }],
+      newRecords: [{ id: "foo" }, { id: "bar" }],
+    });
     expect(node.querySelectorAll(".record-diff")).to.have.lengthOf(1);
   });
 });

--- a/test/components/signoff/SimpleReview/SimpleReviewButtons_test.js
+++ b/test/components/signoff/SimpleReview/SimpleReviewButtons_test.js
@@ -2,17 +2,16 @@ import { expect } from "chai";
 import { createComponent } from "../../../test_utils";
 import ReactDomTestUtils from "react-dom/test-utils";
 import sinon from "sinon";
+import * as React from "react";
 
-import SimpleReviewButtons, {
-  SimpleReviewButtonsProps,
-} from "../../../../src/components/signoff/SimpleReview/SimpleReviewButtons";
+import SimpleReviewButtons from "../../../../src/components/signoff/SimpleReview/SimpleReviewButtons";
 
-function renderButtons(props: Partial<SimpleReviewButtonsProps> = null) {
+function renderButtons(props = null) {
   const approveChanges = sinon.stub();
   const declineChanges = sinon.stub();
   const rollbackChanges = sinon.stub();
 
-  const mergedProps: SimpleReviewButtonsProps = {
+  const mergedProps = {
     status: "to-review",
     approveChanges,
     declineChanges,
@@ -20,7 +19,7 @@ function renderButtons(props: Partial<SimpleReviewButtonsProps> = null) {
     ...props,
   };
 
-  const node = createComponent(SimpleReviewButtons, mergedProps);
+  const node = createComponent(<SimpleReviewButtons {...mergedProps} />);
   return { approveChanges, declineChanges, rollbackChanges, node };
 }
 

--- a/test/components/signoff/SimpleReview/SimpleReviewHeader_test.js
+++ b/test/components/signoff/SimpleReview/SimpleReviewHeader_test.js
@@ -2,9 +2,9 @@ import { expect } from "chai";
 import { createComponent } from "../../../test_utils";
 
 import SimpleReviewHeader from "../../../../src/components/signoff/SimpleReview/SimpleReviewHeader";
-import { SourceInfo } from "../../../../src/types";
+import * as React from "react";
 
-const toReviewProps: SourceInfo = {
+const toReviewProps = {
   bid: "a",
   cid: "b",
   status: "to-review",
@@ -12,7 +12,7 @@ const toReviewProps: SourceInfo = {
   lastEditorComment: "please review",
 };
 
-const wipProps: SourceInfo = {
+const wipProps = {
   bid: "a",
   cid: "b",
   status: "work-in-progress",
@@ -21,25 +21,25 @@ const wipProps: SourceInfo = {
 
 describe("SimpleReviewHeader component", () => {
   it("should render title when component is to-review", () => {
-    const node = createComponent(SimpleReviewHeader, toReviewProps);
+    const node = createComponent(<SimpleReviewHeader {...toReviewProps} />);
     expect(node.querySelector(".card-header").textContent).to.equal(
       "Review requested by ana:"
     );
   });
   it("should render an editor comment when component is to-review", () => {
-    const node = createComponent(SimpleReviewHeader, toReviewProps);
+    const node = createComponent(<SimpleReviewHeader {...toReviewProps} />);
     expect(node.querySelector(".card-text").textContent).to.equal(
       "please review"
     );
   });
   it("should render a wip header", () => {
-    const node = createComponent(SimpleReviewHeader, wipProps);
+    const node = createComponent(<SimpleReviewHeader {...wipProps} />);
     expect(node.querySelector(".card-header").textContent).to.equal(
       "Status is work-in-progress. Most recent reviewer comment was:"
     );
   });
   it("should render a reviewer comment when component is wip", () => {
-    const node = createComponent(SimpleReviewHeader, wipProps);
+    const node = createComponent(<SimpleReviewHeader {...wipProps} />);
     expect(node.querySelector(".card-text").textContent).to.equal("no thanks");
   });
 });

--- a/test/components/signoff/SimpleReview/SimpleReview_test.js
+++ b/test/components/signoff/SimpleReview/SimpleReview_test.js
@@ -1,15 +1,12 @@
 import { expect } from "chai";
+import * as React from "react";
 
 import testUtils from "react-dom/test-utils";
 
 import { createComponent } from "../../../test_utils";
-import SimpleReview, {
-  SimpleReviewProps,
-} from "../../../../src/components/signoff/SimpleReview";
+import SimpleReview from "../../../../src/components/signoff/SimpleReview";
 
-import { SessionState, SignoffState } from "../../../../src/types";
-
-function signoffFactory(): SignoffState {
+function signoffFactory() {
   return {
     collectionsInfo: {
       source: {
@@ -44,7 +41,7 @@ function signoffFactory(): SignoffState {
   };
 }
 
-function sessionFactory(props: Partial<SessionState> = null): SessionState {
+function sessionFactory(props) {
   return {
     busy: false,
     authenticating: false,
@@ -74,22 +71,23 @@ function sessionFactory(props: Partial<SessionState> = null): SessionState {
   };
 }
 
-async function renderSimpleReview(props: Partial<SimpleReviewProps> = null) {
-  let node: HTMLElement;
-  await testUtils.act(async () => {
-    node = createComponent(SimpleReview, {
-      match: {
-        params: {
-          bid: "main-workspace",
-          cid: "my-collection",
-        },
+async function renderSimpleReview(props = null) {
+  let node;
+  const mergedProps = {
+    match: {
+      params: {
+        bid: "main-workspace",
+        cid: "my-collection",
       },
-      listRecords() {},
-      session: sessionFactory(),
-      signoff: signoffFactory(),
-      async fetchRecords() {},
-      ...props,
-    });
+    },
+    listRecords() {},
+    session: sessionFactory(),
+    signoff: signoffFactory(),
+    async fetchRecords() {},
+    ...props,
+  };
+  await testUtils.act(async () => {
+    node = createComponent(<SimpleReview {...mergedProps} />);
   });
   return node;
 }

--- a/test/components/signoff/components_test.js
+++ b/test/components/signoff/components_test.js
@@ -2,6 +2,7 @@ import { expect } from "chai";
 
 import { createSandbox, createComponent } from "../../test_utils";
 import SignoffToolBar from "../../../src/components/signoff/SignoffToolBar";
+import * as React from "react";
 
 describe("SignoffToolBar component", () => {
   let sandbox;
@@ -66,17 +67,14 @@ describe("SignoffToolBar component", () => {
   });
 
   it("should not be rendered if current collection is not listed in resources", () => {
-    const node = createComponent(SignoffToolBar, {
-      ...props,
-      signoff: {},
-    });
+    const node = createComponent(<SignoffToolBar {...props} signoff={{}} />);
     expect(node).eql(null);
   });
 
   it("should show the request review button if current user is editor", () => {
     // As the group is configured with a placeholder on the server, the group
     // name is resolved with the current collection.
-    const node = createComponent(SignoffToolBar, {
+    const propsOverride = {
       ...props,
       sessionState: {
         ...props.sessionState,
@@ -88,7 +86,8 @@ describe("SignoffToolBar component", () => {
           },
         },
       },
-    });
+    };
+    const node = createComponent(<SignoffToolBar {...propsOverride} />);
     expect(node.querySelectorAll("button.request-review")).to.have.a.lengthOf(
       1
     );

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -5,6 +5,7 @@ import * as sessionActions from "../src/actions/session";
 import { SESSION_SETUP } from "../src/constants";
 import App from "../src/App";
 import * as localStore from "../src/store/localStore";
+import * as React from "react";
 
 describe("App", () => {
   let sandbox;
@@ -28,14 +29,13 @@ describe("App", () => {
       buckets: [{}],
       serverInfo: {},
     };
-    const createApp = () => createComponent(App, {});
 
     it("should call setupSession if session available", () => {
       localStore.saveSession(session);
       const setup = sandbox
         .stub(sessionActions, "setupSession")
         .returns({ type: SESSION_SETUP, auth });
-      createApp();
+      createComponent(<App />);
 
       sinon.assert.calledWithExactly(setup, {
         authType: "anonymous",
@@ -45,7 +45,7 @@ describe("App", () => {
 
     it("should call getServerInfo if no session", () => {
       const getServerInfo = sandbox.spy(sessionActions, "getServerInfo");
-      createApp();
+      createComponent(<App />);
 
       sinon.assert.calledWithExactly(getServerInfo, {
         authType: "anonymous",

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -8,14 +8,14 @@ import { Provider } from "react-redux";
 import configureStore, { hashHistory } from "../src/store/configureStore";
 import * as notificationsActions from "../src/actions/notifications";
 
-export function createComponent(Component, props, initialState = {}) {
-  const store = configureStore(initialState);
+export function createComponent(
+  ui,
+  { initialState, store = configureStore(initialState) } = {}
+) {
   const domContainer = document.createElement("div");
   ReactDOM.render(
     <Provider store={store}>
-      <ConnectedRouter history={hashHistory}>
-        <Component {...props} />
-      </ConnectedRouter>
+      <ConnectedRouter history={hashHistory}>{ui}</ConnectedRouter>
     </Provider>,
     domContainer
   );


### PR DESCRIPTION
This PR updates our `createComponent` helper to accept a component with props as JSX (`createComponent(<Component prop={prop} />, ...)` rather than `createComponent(Component, {props}, ...)`. 

This subtle change will make the work of migrating container components easier. It also aligns us more with the [API of `testing-library`](https://testing-library.com/docs/react-testing-library/setup#custom-render), which might be something we want to think about using for our component tests.