### PR TITLE
Add ability to test React Router hooks & tests for `RecordPermissions` component

### DIFF
--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -12,11 +12,14 @@ const sagaMiddleware = createSagaMiddleware();
 
 export const hashHistory = createHashHistory();
 
-export default function configureStore(initialState: Object = {}) {
+export default function configureStore(
+  initialState: Object = {},
+  history = hashHistory
+) {
   const finalCreateStore = compose(
     applyMiddleware<AppState, any, any>(
       sagaMiddleware,
-      routerMiddleware(hashHistory)
+      routerMiddleware(history)
     ),
     // prettier-ignore
     (window as any).__REDUX_DEVTOOLS_EXTENSION__
@@ -25,7 +28,7 @@ export default function configureStore(initialState: Object = {}) {
   )(createStore);
 
   const store = finalCreateStore(
-    createRootReducer(hashHistory),
+    createRootReducer(history),
     initialState as any
   );
   // Every saga will receive the store getState() function as first argument

--- a/test/components/record/RecordPermissions_test.js
+++ b/test/components/record/RecordPermissions_test.js
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { expect } from "chai";
+import { RecordPermissions } from "../../../src/components/record/RecordPermissions";
+import { createComponent, sessionFactory } from "../../test_utils";
+
+describe("RecordPermissions component", () => {
+  const route =
+    "/buckets/test-bucket/collections/test-collection/records/test-record/permissions";
+  const path = "/buckets/:bid/collections/:cid/records/:rid/permissions";
+  it("renders", () => {
+    const initialState = {
+      session: sessionFactory(),
+      record: { busy: false },
+    };
+    const node = createComponent(<RecordPermissions />, {
+      initialState,
+      route: route,
+      path: path,
+    });
+    expect(node.querySelector("h1").textContent).to.equal(
+      "Edit test-bucket/test-collection/test-record record permissions"
+    );
+  });
+  it("renders a loading spinner when record is busy", () => {
+    const initialState = {
+      session: sessionFactory(),
+      record: { busy: true },
+    };
+    const node = createComponent(<RecordPermissions />, {
+      initialState,
+      route: route,
+      path: path,
+    });
+    expect(node.querySelector(".spinner")).to.be.ok;
+  });
+});

--- a/test/components/signoff/SimpleReview/SimpleReview_test.js
+++ b/test/components/signoff/SimpleReview/SimpleReview_test.js
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import testUtils from "react-dom/test-utils";
 
-import { createComponent } from "../../../test_utils";
+import { createComponent, sessionFactory } from "../../../test_utils";
 import SimpleReview from "../../../../src/components/signoff/SimpleReview";
 
 function signoffFactory() {
@@ -38,36 +38,6 @@ function signoffFactory() {
     pendingConfirmReviewRequest: false,
     pendingConfirmDeclineChanges: false,
     pendingConfirmRollbackChanges: false,
-  };
-}
-
-function sessionFactory(props) {
-  return {
-    busy: false,
-    authenticating: false,
-    auth: {
-      authType: "basicauth",
-      server: "asdasd",
-      credentials: {
-        username: "user",
-        password: "123",
-      },
-    },
-    authenticated: true,
-    permissions: [],
-    buckets: [],
-    serverInfo: {
-      url: "",
-      project_name: "foo",
-      project_docs: "foo",
-      capabilities: {},
-      user: {
-        id: "user1",
-        principals: [`/buckets/main-workspace/groups/my-collection-reviewers`],
-      },
-    },
-    ...props,
-    redirectURL: "",
   };
 }
 

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -5,17 +5,27 @@ import sinon from "sinon";
 import ReactDOM from "react-dom";
 import { ConnectedRouter } from "connected-react-router";
 import { Provider } from "react-redux";
-import configureStore, { hashHistory } from "../src/store/configureStore";
+import configureStore from "../src/store/configureStore";
 import * as notificationsActions from "../src/actions/notifications";
+import { createMemoryHistory } from "history";
+import { Route } from "react-router-dom";
 
 export function createComponent(
   ui,
-  { initialState, store = configureStore(initialState) } = {}
+  {
+    initialState,
+    route = "/",
+    path = "/",
+    history = createMemoryHistory({ initialEntries: [route] }),
+    store = configureStore(initialState, history),
+  } = {}
 ) {
   const domContainer = document.createElement("div");
   ReactDOM.render(
     <Provider store={store}>
-      <ConnectedRouter history={hashHistory}>{ui}</ConnectedRouter>
+      <ConnectedRouter history={history} noInitialPop>
+        <Route path={path}>{ui}</Route>
+      </ConnectedRouter>
     </Provider>,
     domContainer
   );

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -38,3 +38,33 @@ export function mockNotifyError(sandbox) {
       return args;
     });
 }
+
+export function sessionFactory(props) {
+  return {
+    busy: false,
+    authenticating: false,
+    auth: {
+      authType: "basicauth",
+      server: "asdasd",
+      credentials: {
+        username: "user",
+        password: "123",
+      },
+    },
+    authenticated: true,
+    permissions: [],
+    buckets: [],
+    serverInfo: {
+      url: "",
+      project_name: "foo",
+      project_docs: "foo",
+      capabilities: {},
+      user: {
+        id: "user1",
+        principals: [`/buckets/main-workspace/groups/my-collection-reviewers`],
+      },
+    },
+    ...props,
+    redirectURL: "",
+  };
+}


### PR DESCRIPTION
The main motivation of this PR was to allow for testing components that use React Router hooks. To achieve this, I modified `configureStore` to accept a history object so we could pass a `memoryHistory` in tests. I also modified the `createComponent` test helper to accept a route pattern to match against and a path to provide to the history object used for testing. Inspiration was largely taken from [here](https://spectrum.chat/testing-library/help-react/attempting-to-test-react-router-match~b0550426-f54a-4b76-b402-c7b32204b55e?m=MTU2OTM1MzY4NjUwNw==).

To validate this setup, I created two tests for the `RecordPermissions` component.