### PR TITLE
Downgrade react-redux to major-version 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "react-bs-notifier": "^6.0.0",
         "react-codemirror2": "^7.0.0",
         "react-dom": "^17.0.2",
-        "react-redux": "^8.0.1",
+        "react-redux": "^7.2.8",
         "react-router": "^5.2.1",
         "react-router-dom": "^5.3.0",
         "redux-saga": "^1.1.3",
@@ -3645,6 +3645,17 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.24",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
+      "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
     "node_modules/@types/react-router": {
       "version": "5.1.16",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.16.tgz",
@@ -3691,11 +3702,6 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -12588,47 +12594,33 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-redux": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
-      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
       "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
         "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
       },
       "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react-native": ">=0.59",
-        "redux": "^4"
+        "react": "^16.8.3 || ^17 || ^18"
       },
       "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
         "react-dom": {
           "optional": true
         },
         "react-native": {
           "optional": true
-        },
-        "redux": {
-          "optional": true
         }
       }
     },
     "node_modules/react-redux/node_modules/react-is": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz",
-      "integrity": "sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw=="
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-router": {
       "version": "5.2.1",
@@ -14205,14 +14197,6 @@
         "file-loader": {
           "optional": true
         }
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.0.0.tgz",
-      "integrity": "sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0-rc"
       }
     },
     "node_modules/util-deprecate": {
@@ -17500,6 +17484,17 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/react-redux": {
+      "version": "7.1.24",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
+      "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
     "@types/react-router": {
       "version": "5.1.16",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.16.tgz",
@@ -17548,11 +17543,6 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
-    },
-    "@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/warning": {
       "version": "3.0.0",
@@ -24332,22 +24322,22 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-redux": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
-      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
       "requires": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
         "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
       },
       "dependencies": {
         "react-is": {
-          "version": "18.0.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz",
-          "integrity": "sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw=="
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         }
       }
     },
@@ -25595,12 +25585,6 @@
         "mime-types": "^2.1.27",
         "schema-utils": "^3.0.0"
       }
-    },
-    "use-sync-external-store": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.0.0.tgz",
-      "integrity": "sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw==",
-      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-bs-notifier": "^6.0.0",
     "react-codemirror2": "^7.0.0",
     "react-dom": "^17.0.2",
-    "react-redux": "^8.0.1",
+    "react-redux": "^7.2.8",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
     "redux-saga": "^1.1.3",


### PR DESCRIPTION
`peer react-redux@"^6.0.0 || ^7.1.0" from connected-react-router@6.9.2`

Has appeared in the last few CI build failures