### PR TITLE
Replace `connected-react-router` with `redux-first-history`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "bootstrap-icons": "^1.0.0",
         "btoa": "^1.1.2",
         "codemirror": "^5.39.2",
-        "connected-react-router": "^6.9.2",
         "diff": "^5.0.0",
         "express": "^4.14.0",
         "filesize": "^8.0.2",
@@ -35,6 +34,7 @@
         "react-redux": "^7.2.8",
         "react-router": "^5.2.1",
         "react-router-dom": "^5.3.0",
+        "redux-first-history": "^5.0.12",
         "redux-saga": "^1.1.3",
         "rimraf": "^3.0.0",
         "timeago.js": "^4.0.0"
@@ -4009,23 +4009,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
-      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/visitor-keys": "5.27.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.29.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
@@ -4074,113 +4057,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
-      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
-      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/visitor-keys": "5.27.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.29.0",
@@ -4345,23 +4221,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
-      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.27.1",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -5683,26 +5542,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/connected-react-router": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.9.2.tgz",
-      "integrity": "sha512-bE8kNBiZv9Mivp7pYn9JvLH5ItTjLl45kk1/Vha0rmAK9I/ETb5JPJrAm0h2KCG9qLfv7vqU3Jo4UUDo0oJnQg==",
-      "dependencies": {
-        "lodash.isequalwith": "^4.4.0",
-        "prop-types": "^15.7.2"
-      },
-      "optionalDependencies": {
-        "immutable": "^3.8.1 || ^4.0.0",
-        "seamless-immutable": "^7.1.3"
-      },
-      "peerDependencies": {
-        "history": "^4.7.2",
-        "react": "^16.4.0 || ^17.0.0",
-        "react-redux": "^6.0.0 || ^7.1.0",
-        "react-router": "^4.3.1 || ^5.0.0",
-        "redux": "^3.6.0 || ^4.0.0"
       }
     },
     "node_modules/content-disposition": {
@@ -8330,12 +8169,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
-    },
-    "node_modules/immutable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
-      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
-      "optional": true
     },
     "node_modules/import-fresh": {
       "version": "3.2.1",
@@ -11495,11 +11328,6 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
-    "node_modules/lodash.isequalwith": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
-      "integrity": "sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA="
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -13095,6 +12923,15 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-first-history": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/redux-first-history/-/redux-first-history-5.0.12.tgz",
+      "integrity": "sha512-shKaOxYWIQhly/+2bjjhNYQIocs1DZeFPYBhLXLPvHBrc7jXK9jAKrCjjrenIs97699qDO6/jptw+P9IU3PLAw==",
+      "peerDependencies": {
+        "history": "^4.7.2 || ^5.0",
+        "redux": "^3.6.0 || ^4.0.0"
+      }
+    },
     "node_modules/redux-saga": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
@@ -13447,12 +13284,6 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
-    },
-    "node_modules/seamless-immutable": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
-      "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==",
-      "optional": true
     },
     "node_modules/semver": {
       "version": "5.5.0",
@@ -18038,16 +17869,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
-      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/visitor-keys": "5.27.1"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "5.29.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
@@ -18073,73 +17894,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        }
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
-      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
-      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.27.1",
-        "@typescript-eslint/visitor-keys": "5.27.1",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "array-union": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "globby": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.2.9",
-            "ignore": "^5.2.0",
-            "merge2": "^1.4.1",
-            "slash": "^3.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -18242,16 +17996,6 @@
             "lru-cache": "^6.0.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
-      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.27.1",
-        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -19300,17 +19044,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "connected-react-router": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.9.2.tgz",
-      "integrity": "sha512-bE8kNBiZv9Mivp7pYn9JvLH5ItTjLl45kk1/Vha0rmAK9I/ETb5JPJrAm0h2KCG9qLfv7vqU3Jo4UUDo0oJnQg==",
-      "requires": {
-        "immutable": "^3.8.1 || ^4.0.0",
-        "lodash.isequalwith": "^4.4.0",
-        "prop-types": "^15.7.2",
-        "seamless-immutable": "^7.1.3"
       }
     },
     "content-disposition": {
@@ -21292,12 +21025,6 @@
       "version": "9.0.12",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
       "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA=="
-    },
-    "immutable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
-      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
-      "optional": true
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -23707,11 +23434,6 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
-    "lodash.isequalwith": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
-      "integrity": "sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA="
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -24979,6 +24701,12 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "redux-first-history": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/redux-first-history/-/redux-first-history-5.0.12.tgz",
+      "integrity": "sha512-shKaOxYWIQhly/+2bjjhNYQIocs1DZeFPYBhLXLPvHBrc7jXK9jAKrCjjrenIs97699qDO6/jptw+P9IU3PLAw==",
+      "requires": {}
+    },
     "redux-saga": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
@@ -25249,12 +24977,6 @@
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
         }
       }
-    },
-    "seamless-immutable": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/seamless-immutable/-/seamless-immutable-7.1.4.tgz",
-      "integrity": "sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==",
-      "optional": true
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "bootstrap-icons": "^1.0.0",
     "btoa": "^1.1.2",
     "codemirror": "^5.39.2",
-    "connected-react-router": "^6.9.2",
     "diff": "^5.0.0",
     "express": "^4.14.0",
     "filesize": "^8.0.2",
@@ -47,6 +46,7 @@
     "react-redux": "^7.2.8",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
+    "redux-first-history": "^5.0.12",
     "redux-saga": "^1.1.3",
     "rimraf": "^3.0.0",
     "timeago.js": "^4.0.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Router } from "react-router";
 import { Provider } from "react-redux";
 
-import { hashHistory, store } from "./store/configureStore";
+import { store, history } from "./store/configureStore";
 import "bootstrap/dist/css/bootstrap.css";
 import "codemirror/lib/codemirror.css";
 import "../css/styles.css";
@@ -11,7 +11,7 @@ import { Layout } from "./components/Layout";
 export const App = () => {
   return (
     <Provider store={store}>
-      <Router history={hashHistory}>
+      <Router history={history}>
         <Layout />
       </Router>
     </Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ConnectedRouter } from "connected-react-router";
+import { Router } from "react-router";
 import { Provider } from "react-redux";
 
 import { hashHistory, store } from "./store/configureStore";
@@ -11,9 +11,9 @@ import { Layout } from "./components/Layout";
 export const App = () => {
   return (
     <Provider store={store}>
-      <ConnectedRouter history={hashHistory}>
+      <Router history={hashHistory}>
         <Layout />
-      </ConnectedRouter>
+      </Router>
     </Provider>
   );
 };

--- a/src/containers/bucket/BucketGroupsPage.ts
+++ b/src/containers/bucket/BucketGroupsPage.ts
@@ -4,7 +4,7 @@ import type { StateProps } from "../../components/bucket/BucketGroups";
 
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { push as updatePath } from "connected-react-router";
+import { push as updatePath } from "redux-first-history";
 
 import BucketGroups from "../../components/bucket/BucketGroups";
 import * as BucketActions from "../../actions/bucket";

--- a/src/containers/collection/CollectionRecordsPage.ts
+++ b/src/containers/collection/CollectionRecordsPage.ts
@@ -4,7 +4,7 @@ import type { StateProps } from "../../components/collection/CollectionRecords";
 
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { push as updatePath } from "connected-react-router";
+import { push as updatePath } from "redux-first-history";
 
 import CollectionRecords from "../../components/collection/CollectionRecords";
 import * as CollectionActions from "../../actions/collection";

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,7 +1,6 @@
-import type { History } from "history";
-
+import { Reducer } from "redux";
 import { combineReducers } from "@reduxjs/toolkit";
-import { connectRouter } from "connected-react-router";
+import { RouterState } from "redux-first-history";
 
 import session from "./session";
 import bucket from "./bucket";
@@ -12,9 +11,9 @@ import notifications from "./notifications";
 import servers from "./servers";
 import signoff from "./signoff";
 
-export default function createRootReducer(history: History) {
+export default function createRootReducer(routerReducer: Reducer<RouterState>) {
   return combineReducers({
-    router: connectRouter(history),
+    router: routerReducer,
     session,
     bucket,
     collection,

--- a/src/sagas/route.ts
+++ b/src/sagas/route.ts
@@ -4,7 +4,7 @@ import { call, put, take } from "redux-saga/effects";
 import {
   push as updatePath,
   replace as replacePath,
-} from "connected-react-router";
+} from "redux-first-history";
 
 import { getClient } from "../client";
 import { storeRedirectURL } from "../actions/session";

--- a/src/sagas/session.ts
+++ b/src/sagas/session.ts
@@ -9,7 +9,7 @@ import type {
   SagaGen,
 } from "../types";
 
-import { push as updatePath } from "connected-react-router";
+import { push as updatePath } from "redux-first-history";
 import { call, put } from "redux-saga/effects";
 
 import { saveSession, clearSession } from "../store/localStore";

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -3,26 +3,31 @@ import createRootReducer from "../reducers";
 import rootSaga from "../sagas";
 import { createHashHistory } from "history";
 import { configureStore } from "@reduxjs/toolkit";
-import { routerMiddleware } from "connected-react-router";
+import { createReduxHistoryContext } from "redux-first-history";
 
 const sagaMiddleware = createSagaMiddleware();
-
-export const hashHistory = createHashHistory();
-
-export function configureAppStore(initialState = {}, history = hashHistory) {
+const configureAppStore = (initialState = {}, initialHistory = createHashHistory()) => {
+  const {
+    createReduxHistory,
+    routerMiddleware,
+    routerReducer
+  } = createReduxHistoryContext({ history: initialHistory });
   const store = configureStore({
-    reducer: createRootReducer(history),
+    reducer: createRootReducer(routerReducer),
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware({
         thunk: false,
-      }).concat(sagaMiddleware, routerMiddleware(history)),
+      }).concat(sagaMiddleware, routerMiddleware),
     preloadedState: initialState,
   });
+  const history = createReduxHistory(store)
   // Every saga will receive the store getState() function as first argument
   // by default; this allows sagas to share the same signature and access the
   // state consistently.
   sagaMiddleware.run(rootSaga, store.getState.bind(store));
-  return store;
+  return {store, history};
 }
 
-export const store = configureAppStore();
+const { store, history } = configureAppStore();
+export {store, history, configureAppStore}
+

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -6,12 +6,12 @@ import { configureStore } from "@reduxjs/toolkit";
 import { createReduxHistoryContext } from "redux-first-history";
 
 const sagaMiddleware = createSagaMiddleware();
-const configureAppStore = (initialState = {}, initialHistory = createHashHistory()) => {
-  const {
-    createReduxHistory,
-    routerMiddleware,
-    routerReducer
-  } = createReduxHistoryContext({ history: initialHistory });
+const configureAppStoreAndHistory = (
+  initialState = {},
+  initialHistory = createHashHistory()
+) => {
+  const { createReduxHistory, routerMiddleware, routerReducer } =
+    createReduxHistoryContext({ history: initialHistory });
   const store = configureStore({
     reducer: createRootReducer(routerReducer),
     middleware: getDefaultMiddleware =>
@@ -20,14 +20,13 @@ const configureAppStore = (initialState = {}, initialHistory = createHashHistory
       }).concat(sagaMiddleware, routerMiddleware),
     preloadedState: initialState,
   });
-  const history = createReduxHistory(store)
+  const history = createReduxHistory(store);
   // Every saga will receive the store getState() function as first argument
   // by default; this allows sagas to share the same signature and access the
   // state consistently.
   sagaMiddleware.run(rootSaga, store.getState.bind(store));
-  return {store, history};
-}
+  return { store, history };
+};
 
-const { store, history } = configureAppStore();
-export {store, history, configureAppStore}
-
+const { store, history } = configureAppStoreAndHistory();
+export { store, history, configureAppStoreAndHistory };

--- a/test/components/Layout_test.js
+++ b/test/components/Layout_test.js
@@ -2,28 +2,28 @@ import React from "react";
 import { expect } from "chai";
 import sinon from "sinon";
 
-import { configureAppStore, hashHistory } from "../../src/store/configureStore";
+import { configureAppStore } from "../../src/store/configureStore";
 import { createSandbox } from "../test_utils";
 import { mount } from "enzyme";
-import { ConnectedRouter } from "connected-react-router";
+import { Router } from "react-router";
 import { Provider } from "react-redux";
 
 import { Layout } from "../../src/components/Layout";
 import * as sessionActions from "../../src/actions/session";
 
 describe("App component", () => {
-  let app, clock, sandbox, store;
+  let app, clock, sandbox, store, history;
 
   beforeEach(() => {
     sandbox = createSandbox();
     sandbox.spy(sessionActions, "logout");
-    store = configureAppStore();
+    ({ store, history } = configureAppStore());
     clock = sinon.useFakeTimers();
     app = mount(
       <Provider store={store}>
-        <ConnectedRouter history={hashHistory}>
+        <Router history={history}>
           <Layout />
-        </ConnectedRouter>
+        </Router>
       </Provider>
     );
   });

--- a/test/components/Layout_test.js
+++ b/test/components/Layout_test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { expect } from "chai";
 import sinon from "sinon";
 
-import { configureAppStore } from "../../src/store/configureStore";
+import { configureAppStoreAndHistory } from "../../src/store/configureStore";
 import { createSandbox } from "../test_utils";
 import { mount } from "enzyme";
 import { Router } from "react-router";
@@ -17,7 +17,7 @@ describe("App component", () => {
   beforeEach(() => {
     sandbox = createSandbox();
     sandbox.spy(sessionActions, "logout");
-    ({ store, history } = configureAppStore());
+    ({ store, history } = configureAppStoreAndHistory());
     clock = sinon.useFakeTimers();
     app = mount(
       <Provider store={store}>

--- a/test/sagas/index_test.js
+++ b/test/sagas/index_test.js
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import { createSandbox } from "../test_utils";
 
-import { configureAppStore } from "../../src/store/configureStore";
+import { configureAppStoreAndHistory } from "../../src/store/configureStore";
 import * as routeSagas from "../../src/sagas/route";
 import * as sessionSagas from "../../src/sagas/session";
 import * as bucketSagas from "../../src/sagas/bucket";
@@ -14,7 +14,7 @@ import * as collectionActions from "../../src/actions/collection";
 
 function expectSagaCalled(saga, action) {
   // Note: the rootSaga function is called by configureStore
-  const { store } = configureAppStore();
+  const { store } = configureAppStoreAndHistory();
   store.dispatch(action);
 
   expect(saga.firstCall.args[0].name).eql("bound getState");

--- a/test/sagas/index_test.js
+++ b/test/sagas/index_test.js
@@ -14,7 +14,8 @@ import * as collectionActions from "../../src/actions/collection";
 
 function expectSagaCalled(saga, action) {
   // Note: the rootSaga function is called by configureStore
-  configureAppStore().dispatch(action);
+  const { store } = configureAppStore();
+  store.dispatch(action);
 
   expect(saga.firstCall.args[0].name).eql("bound getState");
   expect(saga.firstCall.args[1]).eql(action);

--- a/test/sagas/route_test.js
+++ b/test/sagas/route_test.js
@@ -1,6 +1,6 @@
 import sinon from "sinon";
 import { expect } from "chai";
-import { push as updatePath } from "connected-react-router";
+import { push as updatePath } from "redux-first-history";
 import { call, put, take } from "redux-saga/effects";
 
 import { createSandbox, mockNotifyError } from "../test_utils";

--- a/test/sagas/session_test.js
+++ b/test/sagas/session_test.js
@@ -1,7 +1,7 @@
 import sinon from "sinon";
 import { expect } from "chai";
 import { createSandbox, mockNotifyError } from "../test_utils";
-import { push as updatePath } from "connected-react-router";
+import { push as updatePath } from "redux-first-history";
 import { put, call } from "redux-saga/effects";
 
 import { saveSession, clearSession } from "../../src/store/localStore";

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -3,7 +3,7 @@
 import React from "react";
 import sinon from "sinon";
 import ReactDOM from "react-dom";
-import { ConnectedRouter } from "connected-react-router";
+import { Router } from "react-router";
 import { Provider } from "react-redux";
 import { configureAppStore } from "../src/store/configureStore";
 import * as notificationsActions from "../src/actions/notifications";
@@ -16,16 +16,16 @@ export function createComponent(
     initialState,
     route = "/",
     path = "/",
-    history = createMemoryHistory({ initialEntries: [route] }),
-    store = configureAppStore(initialState, history),
+    initialHistory = createMemoryHistory({ initialEntries: [route] }),
   } = {}
 ) {
+  const { store, history } = configureAppStore(initialState, initialHistory);
   const domContainer = document.createElement("div");
   ReactDOM.render(
     <Provider store={store}>
-      <ConnectedRouter history={history} noInitialPop>
+      <Router history={history}>
         <Route path={path}>{ui}</Route>
-      </ConnectedRouter>
+      </Router>
     </Provider>,
     domContainer
   );

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -5,7 +5,7 @@ import sinon from "sinon";
 import ReactDOM from "react-dom";
 import { Router } from "react-router";
 import { Provider } from "react-redux";
-import { configureAppStore } from "../src/store/configureStore";
+import { configureAppStoreAndHistory } from "../src/store/configureStore";
 import * as notificationsActions from "../src/actions/notifications";
 import { createMemoryHistory } from "history";
 import { Route } from "react-router-dom";
@@ -19,7 +19,10 @@ export function createComponent(
     initialHistory = createMemoryHistory({ initialEntries: [route] }),
   } = {}
 ) {
-  const { store, history } = configureAppStore(initialState, initialHistory);
+  const { store, history } = configureAppStoreAndHistory(
+    initialState,
+    initialHistory
+  );
   const domContainer = document.createElement("div");
   ReactDOM.render(
     <Provider store={store}>


### PR DESCRIPTION
Development seems to have slowed somewhat in `connected-react-router`, and as such, it has us pinned us at old major versions of several important libraries because of the [peer dependencies](https://github.com/supasate/connected-react-router/blob/master/package.json#L34:L40) that they specify:
| Library | Peer dependency version | Current version |
|--------------|-----------|------------|
history | `^4.7.2` | `5.3.0`
react | `^16.4.0 \|\| ^17.0.0` | `18.2.0`
react-redux | `^6.0.0 \|\| ^7.1.0` | `8.0.2`
react-router | `^4.3.1 \|\| ^5.0.0` | `6.3.0`

When looking at issues in that repo, I came across another library ([`redux-first-history`](https://github.com/salvoravida/redux-first-history/)) that connects the router to the Redux store and specifies [fewer peer dependencies](https://github.com/salvoravida/redux-first-history/blob/master/package.json#L44-L47).

This PR migrates `connected-react-router` to `redux-first-history`. 

I will also mention that as a future issue, we should consider whether we need to store location state in Redux at all. From the "original", now deprecated Redux + React Router library:

> This library is not necessary for using Redux together with React Router. You can use the two together just fine without any additional libraries. It is useful if you care about recording, persisting, and replaying user actions, using time travel. If you don't care about these features, just [use Redux and React Router directly](http://stackoverflow.com/questions/36722584/how-to-sync-redux-state-and-url-hash-tag-params/36749963#36749963).