### PR TITLE
Add spinners and disable forms while data is being loaded

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -559,6 +559,26 @@ i.fa:before {
   font-size: 12pt;
 }
 
+.formWrapper {
+  position: relative;
+}
+
+.formWrapper > .spinner {
+  position: absolute;
+  left: -1.25em;
+  right: -1.25em;
+  top: -1.5em;
+  bottom: -2.5em;
+  background-color: rgba(0, 0, 0, 0.2);
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: auto;
+  margin: 0;
+  border-radius: 3px;
+}
+
 .modal {
   background-color: rgba(0, 0, 0, 0.3);
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -579,12 +579,48 @@ i.fa:before {
   border-radius: 3px;
 }
 
+.interactive > .spinner {
+  position: absolute;
+  left: -1.25em;
+  right: -1.25em;
+  top: -.5em;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.2);
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: auto;
+  margin: 0;
+  border-radius: 3px;
+}
+
 .modal {
   background-color: rgba(0, 0, 0, 0.3);
 }
 
+.modal-dialog > .spinner {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.2);
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: auto;
+  margin: 0;
+  border-radius: 3px;
+}
+
 .informative {
   filter: grayscale(0.8);
+}
+
+.interactive {
+  position: relative;
 }
 
 /*Form Wizard*/

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -256,6 +256,20 @@ function extendUiSchemaWithHistory(
   };
 }
 
+function getSupportedAuthMethods(session: SessionState): string[] {
+  const {
+    serverInfo: { capabilities },
+  } = session;
+  const { openid: { providers } = { providers: [] } } = capabilities;
+  // Check which of our known auth implementations are supported by the server.
+  const supportedAuthMethods = KNOWN_AUTH_METHODS.filter(
+    a => a in capabilities
+  );
+  // Add an auth method for each single openid provider supported by the server.
+  const openIdMethods = providers.map(provider => `openid-${provider.name}`);
+  return [ANONYMOUS_AUTH].concat(supportedAuthMethods).concat(openIdMethods);
+}
+
 type AuthFormProps = {
   session: SessionState;
   servers: ServerEntry[];
@@ -281,6 +295,7 @@ export default function AuthForm({
   const { schema: currentSchema, uiSchema: curentUiSchema } =
     authSchemas(authType);
 
+  const [showSpinner, setshowSpinner] = useState(false);
   const [schema, setSchema] = useState(currentSchema);
   const [uiSchema, setUiSchema] = useState(curentUiSchema);
   const [formData, setFormData] = useState({
@@ -288,28 +303,35 @@ export default function AuthForm({
     server: getServerByPriority(servers),
   });
 
-  const getSupportedAuthMethods = (): string[] => {
-    const {
-      serverInfo: { capabilities },
-    } = session;
-    const { openid: { providers } = { providers: [] } } = capabilities;
-    // Check which of our known auth implementations are supported by the server.
-    const supportedAuthMethods = KNOWN_AUTH_METHODS.filter(
-      a => a in capabilities
-    );
-    // Add an auth method for each single openid provider supported by the server.
-    const openIdMethods = providers.map(provider => `openid-${provider.name}`);
-    return [ANONYMOUS_AUTH].concat(supportedAuthMethods).concat(openIdMethods);
+  const serverChangeCallback = () => {
+    serverChange();
   };
+
+  const serverInfoCallback = auth => {
+    getServerInfo(auth);
+    setshowSpinner(false);
+  };
+
+  const authMethods = getSupportedAuthMethods(session);
+  const singleAuthMethod = authMethods.length === 1;
+  const finalSchema = extendSchemaWithHistory(schema, servers, authMethods);
+  const finalUiSchema = extendUiSchemaWithHistory(
+    uiSchema,
+    servers,
+    clearServers,
+    serverInfoCallback,
+    serverChangeCallback,
+    singleAuthMethod
+  );
 
   const onChange = ({ formData: updatedData }: RJSFSchema) => {
     if (formData.server !== updatedData.server) {
+      setshowSpinner(true);
       const newServer = servers.find(x => x.server === updatedData.server);
       updatedData.authType = newServer?.authType || ANONYMOUS_AUTH;
     }
     const { authType } = updatedData;
-    const { uiSchema } = authSchemas(authType);
-    const { schema } = authSchemas(authType);
+    const { schema, uiSchema } = authSchemas(authType);
     const omitCredentials =
       [ANONYMOUS_AUTH, "fxa", "portier"].includes(authType) ||
       authType.startsWith("openid-");
@@ -323,6 +345,7 @@ export default function AuthForm({
   };
 
   const onSubmit = ({ formData }: RJSFSchema) => {
+    setshowSpinner(true);
     let { authType } = formData;
     let openidProvider = null;
     if (authType.startsWith("openid-")) {
@@ -355,17 +378,6 @@ export default function AuthForm({
     }
   };
 
-  const authMethods = getSupportedAuthMethods();
-  const singleAuthMethod = authMethods.length === 1;
-  const finalSchema = extendSchemaWithHistory(schema, servers, authMethods);
-  const finalUiSchema = extendUiSchemaWithHistory(
-    uiSchema,
-    servers,
-    clearServers,
-    getServerInfo,
-    serverChange,
-    singleAuthMethod
-  );
   return (
     <div className="card">
       <div className="card-body">
@@ -375,6 +387,7 @@ export default function AuthForm({
           formData={formData}
           onChange={onChange}
           onSubmit={onSubmit}
+          showSpinner={showSpinner}
         >
           <button type="submit" className="btn btn-info">
             {"Sign in using "}

--- a/src/components/BaseForm.tsx
+++ b/src/components/BaseForm.tsx
@@ -4,23 +4,30 @@ import { Theme as Bootstrap4Theme } from "@rjsf/bootstrap-4";
 import validator from "@rjsf/validator-ajv8";
 
 import TagsField from "./TagsField";
+import Spinner from "./Spinner";
 
 const adminFields = { tags: TagsField };
 
 const FormWithTheme = withTheme(Bootstrap4Theme);
 
-export type BaseFormProps = Omit<FormProps, "validator">;
+export type BaseFormProps = Omit<FormProps, "validator"> & {
+  showSpinner?: boolean;
+};
 
 export default function BaseForm(props: BaseFormProps) {
-  const { className, ...restProps } = props;
+  const { className, disabled, showSpinner, ...restProps } = props;
 
   return (
-    <FormWithTheme
-      {...restProps}
-      className={`rjsf ${className ? className : ""}`}
-      validator={validator}
-      // @ts-ignore
-      fields={adminFields}
-    />
+    <div className="formWrapper">
+      <FormWithTheme
+        {...restProps}
+        className={`rjsf ${className ? className : ""}`}
+        validator={validator}
+        // @ts-ignore
+        fields={adminFields}
+        disabled={disabled || showSpinner}
+      />
+      {showSpinner && <Spinner />}
+    </div>
   );
 }

--- a/src/components/PermissionsForm.tsx
+++ b/src/components/PermissionsForm.tsx
@@ -1,6 +1,6 @@
 import type { Permissions } from "../types";
 
-import React from "react";
+import React, { useState } from "react";
 
 import BaseForm from "./BaseForm";
 import {
@@ -26,7 +26,10 @@ export function PermissionsForm({
   acls,
   onSubmit: onSubmit_,
 }: Props) {
+  const [showSpinner, setShowSpinner] = useState(false);
+
   const onSubmit = ({ formData }: RJSFSchema) => {
+    setShowSpinner(true);
     onSubmit_({ formData: formDataToPermissions(bid, formData) });
   };
   const { bid } = useParams<{ bid: string }>();
@@ -48,6 +51,7 @@ export function PermissionsForm({
       uiSchema={uiSchema}
       formData={formData}
       onSubmit={onSubmit}
+      showSpinner={showSpinner}
     />
   );
 }

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Spinner() {
   return (
-    <div className="spinner">
+    <div className="spinner" data-testid="spinner">
       <div className="bounce1" />
       <div className="bounce2" />
       <div className="bounce3" />

--- a/src/components/bucket/BucketForm.tsx
+++ b/src/components/bucket/BucketForm.tsx
@@ -1,11 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 
 import { Check2 } from "react-bootstrap-icons";
 
 import BaseForm from "../BaseForm";
 import JSONEditor from "../JSONEditor";
-import Spinner from "../Spinner";
 import { RJSFSchema } from "@rjsf/utils";
 import { canEditBucket } from "../../permission";
 import { omit } from "../../utils";
@@ -52,6 +51,8 @@ export default function BucketForm({
   deleteBucket,
   onSubmit,
 }: Props) {
+  const [showSpinner, setShowSpinner] = useState(false);
+
   const creation = !formData.id;
   const hasWriteAccess = canEditBucket(session, bucket);
   const formIsEditable = creation || hasWriteAccess;
@@ -100,25 +101,25 @@ export default function BucketForm({
   return (
     <div>
       {alert}
-      {bucket.busy ? (
-        <Spinner />
-      ) : (
-        <BaseForm
-          schema={schema}
-          uiSchema={
-            formIsEditable ? _uiSchema : { ..._uiSchema, "ui:readonly": true }
-          }
-          formData={formDataSerialized}
-          onSubmit={({ formData }) => {
-            const { id, data } = formData;
-            // Parse JSON fields so they can be sent to the server
-            const attributes = JSON.parse(data);
-            onSubmit({ id, ...attributes });
-          }}
-        >
-          {buttons}
-        </BaseForm>
-      )}
+
+      <BaseForm
+        schema={schema}
+        uiSchema={
+          formIsEditable ? _uiSchema : { ..._uiSchema, "ui:readonly": true }
+        }
+        formData={formDataSerialized}
+        showSpinner={showSpinner || bucket.busy}
+        onSubmit={({ formData }) => {
+          setShowSpinner(true);
+          const { id, data } = formData;
+          // Parse JSON fields so they can be sent to the server
+          const attributes = JSON.parse(data);
+          onSubmit({ id, ...attributes });
+        }}
+      >
+        {buttons}
+      </BaseForm>
+
       {showDeleteForm && <DeleteForm bid={bid} onSubmit={deleteBucket} />}
     </div>
   );

--- a/src/components/bucket/DeleteForm.tsx
+++ b/src/components/bucket/DeleteForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { Trash } from "react-bootstrap-icons";
 
@@ -11,6 +11,8 @@ const deleteSchema: RJSFSchema = {
 };
 
 export default function DeleteForm({ bid, onSubmit }) {
+  const [showSpinner, setShowSpinner] = useState(false);
+
   const validate = (formData, errors) => {
     if (formData !== bid) {
       errors.addError("The bucket id does not match.");
@@ -31,7 +33,9 @@ export default function DeleteForm({ bid, onSubmit }) {
         <BaseForm
           schema={deleteSchema}
           customValidate={validate}
+          showSpinner={showSpinner}
           onSubmit={({ formData }) => {
+            setShowSpinner(true);
             if (typeof onSubmit === "function") {
               onSubmit(formData);
             }

--- a/src/components/collection/CollectionForm.tsx
+++ b/src/components/collection/CollectionForm.tsx
@@ -247,6 +247,8 @@ export default function CollectionForm({
   formData: propFormData = undefined,
 }: Props) {
   const [asJSON, setAsJSON] = useState(false);
+  const [showSpinner, setShowSpinner] = useState(false);
+
   const allowEditing = propFormData
     ? canCreateCollection(session, bucket)
     : canEditCollection(session, bucket, collection);
@@ -263,6 +265,7 @@ export default function CollectionForm({
   };
 
   const handleOnSubmit = ({ formData }) => {
+    setShowSpinner(true);
     const collectionData = asJSON
       ? formData
       : {
@@ -327,6 +330,7 @@ export default function CollectionForm({
           cid={cid}
           formData={collection.data}
           onSubmit={handleOnSubmit}
+          showSpinner={showSpinner}
         >
           {buttons}
         </JSONCollectionForm>
@@ -342,6 +346,7 @@ export default function CollectionForm({
             customValidate={validate}
             // @ts-ignore
             onSubmit={handleOnSubmit}
+            showSpinner={showSpinner}
           >
             {buttons}
           </BaseForm>

--- a/src/components/collection/DeleteForm.tsx
+++ b/src/components/collection/DeleteForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { Trash } from "react-bootstrap-icons";
 
@@ -11,6 +11,8 @@ const deleteSchema: RJSFSchema = {
 };
 
 export default function DeleteForm({ cid, onSubmit }) {
+  const [showSpinner, setShowSpinner] = useState(false);
+
   const validate = (formData, errors) => {
     if (formData !== cid) {
       errors.addError("The collection name does not match.");
@@ -29,7 +31,9 @@ export default function DeleteForm({ cid, onSubmit }) {
         <BaseForm
           schema={deleteSchema}
           customValidate={validate}
+          showSpinner={showSpinner}
           onSubmit={({ formData }) => {
+            setShowSpinner(true);
             if (typeof onSubmit === "function") {
               onSubmit(formData);
             }

--- a/src/components/collection/JSONCollectionForm.tsx
+++ b/src/components/collection/JSONCollectionForm.tsx
@@ -7,6 +7,7 @@ import validator from "@rjsf/validator-ajv8";
 import JSONEditor from "../JSONEditor";
 import { omit } from "../../utils";
 import type { CollectionData } from "../../types";
+import Spinner from "../Spinner";
 
 const FormWithTheme = withTheme(Bootstrap4Theme);
 
@@ -37,8 +38,10 @@ const uiSchema: UiSchema = {
 type Props = {
   children?: React.ReactNode;
   cid?: string | null;
+  disabled?: boolean;
   formData: CollectionData;
   onSubmit: (data: { formData: CollectionData }) => void;
+  showSpinner?: boolean;
 };
 
 export default function JSONCollectionForm({
@@ -46,6 +49,8 @@ export default function JSONCollectionForm({
   cid,
   formData,
   onSubmit,
+  disabled,
+  showSpinner,
 }: Props) {
   const handleSubmit = ({
     formData: formInput,
@@ -76,15 +81,19 @@ export default function JSONCollectionForm({
       };
 
   return (
-    <FormWithTheme
-      schema={schema}
-      uiSchema={_uiSchema}
-      formData={formDataSerialized}
-      validator={validator}
-      // @ts-ignore
-      onSubmit={handleSubmit}
-    >
-      {children}
-    </FormWithTheme>
+    <div className="formWrapper">
+      <FormWithTheme
+        schema={schema}
+        uiSchema={_uiSchema}
+        formData={formDataSerialized}
+        validator={validator}
+        // @ts-ignore
+        onSubmit={handleSubmit}
+        disabled={disabled || showSpinner}
+      >
+        {children}
+      </FormWithTheme>
+      {showSpinner && <Spinner />}
+    </div>
   );
 }

--- a/src/components/group/DeleteForm.tsx
+++ b/src/components/group/DeleteForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { Trash } from "react-bootstrap-icons";
 
@@ -12,6 +12,8 @@ const deleteSchema: RJSFSchema = {
 };
 
 export default function DeleteForm({ gid, onSubmit }) {
+  const [showSpinner, setShowSpinner] = useState(false);
+
   const validate = (formData, errors) => {
     if (formData !== gid) {
       errors.addError("The group id does not match.");
@@ -30,7 +32,9 @@ export default function DeleteForm({ gid, onSubmit }) {
         <BaseForm
           schema={deleteSchema}
           customValidate={validate}
+          showSpinner={showSpinner}
           onSubmit={({ formData }) => {
+            setShowSpinner(true);
             if (typeof onSubmit === "function") {
               onSubmit(formData);
             }

--- a/src/components/group/GroupForm.tsx
+++ b/src/components/group/GroupForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import type {
   SessionState,
   BucketState,
@@ -60,6 +60,8 @@ type Props = {
 };
 
 export default function GroupForm(props: Props) {
+  const [showSpinner, setShowSpinner] = useState(false);
+
   const {
     gid,
     session,
@@ -72,6 +74,7 @@ export default function GroupForm(props: Props) {
 
   const onSubmit = useCallback(
     ({ formData }) => {
+      setShowSpinner(true);
       const { data } = formData;
       const attributes = JSON.parse(data);
       propOnSubmit({
@@ -143,6 +146,7 @@ export default function GroupForm(props: Props) {
             formIsEditable ? _uiSchema : { ..._uiSchema, "ui:readonly": true }
           }
           formData={formDataSerialized}
+          showSpinner={showSpinner}
           onSubmit={onSubmit}
         >
           {buttons}

--- a/src/components/record/JSONRecordForm.tsx
+++ b/src/components/record/JSONRecordForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import BaseForm from "../BaseForm";
 import JSONEditor from "../JSONEditor";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
@@ -29,7 +29,10 @@ export default function JSONRecordForm({
   onSubmit,
   children,
 }: Props) {
+  const [showSpinner, setShowSpinner] = useState(false);
+
   const handleOnSubmit = data => {
+    setShowSpinner(true);
     onSubmit({ ...data, formData: JSON.parse(data.formData) });
   };
 
@@ -40,6 +43,7 @@ export default function JSONRecordForm({
         formData={record}
         uiSchema={disabled ? { ...uiSchema, "ui:readonly": true } : uiSchema}
         onSubmit={handleOnSubmit}
+        showSpinner={showSpinner}
       >
         {children}
       </BaseForm>

--- a/src/components/record/RecordBulk.tsx
+++ b/src/components/record/RecordBulk.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 
 import type { CollectionState, CollectionRouteMatch } from "../../types";
 
@@ -6,7 +6,6 @@ import * as CollectionActions from "../../actions/collection";
 import * as NotificationActions from "../../actions/notifications";
 import BaseForm from "../BaseForm";
 import AdminLink from "../AdminLink";
-import Spinner from "../Spinner";
 import JSONEditor from "../JSONEditor";
 import {
   extendSchemaWithAttachment,
@@ -33,6 +32,8 @@ export default function RecordBulk({
   notifyError,
   bulkCreateRecords,
 }: Props) {
+  const [showSpinner, setShowSpinner] = useState(false);
+
   const onSubmit = useCallback(
     ({ formData }) => {
       const {
@@ -45,6 +46,8 @@ export default function RecordBulk({
       if (formData.length === 0) {
         return notifyError("The form is empty.");
       }
+
+      setShowSpinner(true);
 
       if (Object.keys(schema).length === 0) {
         return bulkCreateRecords(
@@ -109,30 +112,27 @@ export default function RecordBulk({
         </b>{" "}
         creation
       </h1>
-      {busy ? (
-        <Spinner />
-      ) : (
-        <div className="card">
-          <div className="card-body">
-            <BaseForm
-              schema={bulkSchema}
-              uiSchema={bulkUiSchema}
-              formData={bulkFormData}
-              onSubmit={onSubmit}
-            >
-              <input
-                type="submit"
-                className="btn btn-primary"
-                value="Bulk create"
-              />
-              {" or "}
-              <AdminLink name="collection:records" params={{ bid, cid }}>
-                Cancel
-              </AdminLink>
-            </BaseForm>
-          </div>
+      <div className="card">
+        <div className="card-body">
+          <BaseForm
+            schema={bulkSchema}
+            uiSchema={bulkUiSchema}
+            formData={bulkFormData}
+            onSubmit={onSubmit}
+            showSpinner={showSpinner || busy}
+          >
+            <input
+              type="submit"
+              className="btn btn-primary"
+              value="Bulk create"
+            />
+            {" or "}
+            <AdminLink name="collection:records" params={{ bid, cid }}>
+              Cancel
+            </AdminLink>
+          </BaseForm>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -11,7 +11,6 @@ import { Trash } from "react-bootstrap-icons";
 import * as CollectionActions from "../../actions/collection";
 import BaseForm from "../BaseForm";
 import AdminLink from "../AdminLink";
-import Spinner from "../Spinner";
 import JSONRecordForm from "./JSONRecordForm";
 import { canCreateRecord, canEditRecord } from "../../permission";
 import {
@@ -63,6 +62,7 @@ type Props = {
 
 export default function RecordForm(props: Props) {
   const [asJSON, setAsJSON] = useState(false);
+  const [showSpinner, setShowSpinner] = useState(false);
 
   const {
     bid,
@@ -102,6 +102,7 @@ export default function RecordForm(props: Props) {
   };
 
   const handleOnSubmit = ({ formData }: RJSFSchema) => {
+    setShowSpinner(true);
     onSubmit(formData);
   };
 
@@ -112,12 +113,6 @@ export default function RecordForm(props: Props) {
     } = collection;
     const emptySchema = Object.keys(schema).length === 0;
     const recordData = record ? record.data : {};
-
-    // Show a spinner if the collection metadata is being loaded, or the record
-    // itself on edition.
-    if (collection.busy || (record && record.busy)) {
-      return <Spinner />;
-    }
 
     const buttons = (
       <div className="row record-form-buttons">
@@ -188,6 +183,7 @@ export default function RecordForm(props: Props) {
         uiSchema={_uiSchema}
         formData={recordData}
         onSubmit={handleOnSubmit}
+        showSpinner={showSpinner || collection.busy || (record && record.busy)}
       >
         {buttons}
       </BaseForm>

--- a/src/components/signoff/Comment.tsx
+++ b/src/components/signoff/Comment.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Spinner from "../Spinner";
 
 export function Comment({ text }: { text: string }) {
   return (
@@ -27,12 +28,16 @@ export function CommentDialog({
   onCancel,
 }: CommentDialogProps) {
   const [comment, setComment] = useState<string>("");
+  const [showSpinner, setShowSpinner] = useState(false);
 
   const onCommentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setComment(e.target.value);
   };
 
-  const onClickConfirm = () => onConfirm(comment);
+  const onClickConfirm = () => {
+    setShowSpinner(true);
+    onConfirm(comment);
+  };
 
   return (
     <div
@@ -81,6 +86,7 @@ export function CommentDialog({
             </button>
           </div>
         </div>
+        {showSpinner && <Spinner />}
       </div>
     </div>
   );

--- a/src/components/signoff/SignoffToolBar.tsx
+++ b/src/components/signoff/SignoffToolBar.tsx
@@ -1,7 +1,7 @@
 import type { BucketState, SessionState, CollectionState } from "../../types";
 import type { SignoffState, SignoffSourceInfo, ChangesList } from "../../types";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { CommentDialog, Comment } from "./Comment";
 
 import { ChatLeft } from "react-bootstrap-icons";
@@ -14,6 +14,7 @@ import { ProgressBar, ProgressStep } from "./ProgressBar";
 import HumanDate from "./HumanDate";
 import { Signed } from "./Signed";
 import { Review, DiffInfo } from "./Review";
+import Spinner from "../Spinner";
 
 function isMember(groupKey, source, sessionState) {
   const {
@@ -81,6 +82,19 @@ export default function SignoffToolBar({
   cancelPendingConfirm,
   declineChanges,
 }: SignoffToolBarProps) {
+  const [showSpinner, setShowSpinner] = useState(false);
+
+  const handleApproveChanges = () => {
+    setShowSpinner(true);
+    approveChanges();
+  };
+
+  useEffect(() => {
+    if (showSpinner) {
+      setShowSpinner(false);
+    }
+  }, [collectionState.data]);
+
   const canEdit = canEditCollection(sessionState, bucketState, collectionState);
 
   const {
@@ -150,7 +164,7 @@ export default function SignoffToolBar({
           isCurrentUrl={!!preview && preview.bid == bid && preview.cid == cid}
           canEdit={canReview}
           hasHistory={hasHistory}
-          approveChanges={approveChanges}
+          approveChanges={handleApproveChanges}
           confirmDeclineChanges={confirmDeclineChanges}
           source={source}
           preview={preview}
@@ -194,6 +208,7 @@ export default function SignoffToolBar({
           onCancel={cancelPendingConfirm}
         />
       )}
+      {showSpinner && <Spinner />}
     </div>
   );
 }

--- a/test/components/AuthForm_test.js
+++ b/test/components/AuthForm_test.js
@@ -2,24 +2,21 @@ import { createSandbox, createComponent } from "../test_utils";
 import { DEFAULT_KINTO_SERVER } from "../../src/constants";
 import { DEFAULT_SERVERINFO } from "../../src/reducers/session";
 import { expect } from "chai";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
 import * as React from "react";
 import AuthForm from "../../src/components/AuthForm";
 import sinon from "sinon";
 
 describe("AuthForm component", () => {
   let sandbox;
-  let clock;
 
   beforeEach(() => {
     jest.resetModules();
     sandbox = createSandbox();
-    clock = sinon.useFakeTimers();
   });
 
   afterEach(() => {
     sandbox.restore();
-    clock.restore();
   });
   describe("Single server config option", () => {
     it("should set the default server url in a visible field", () => {
@@ -82,10 +79,12 @@ describe("AuthForm component", () => {
     });
 
     describe("Basic Auth", () => {
-      it("should submit setup data", () => {
+      it("should submit setup data", async () => {
         fireEvent.change(node.querySelector("#root_server"), {
           target: { value: "http://test.server/v1" },
         });
+        await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
+
         fireEvent.click(node.querySelectorAll("[type=radio]")[1]);
         fireEvent.change(node.querySelector("#root_credentials_username"), {
           target: { value: "user" },
@@ -108,10 +107,11 @@ describe("AuthForm component", () => {
     });
 
     describe("LDAP", () => {
-      it("should submit setup data", () => {
+      it("should submit setup data", async () => {
         fireEvent.change(node.querySelector("#root_server"), {
           target: { value: "http://test.server/v1" },
         });
+        await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
         fireEvent.click(node.querySelectorAll("[type=radio]")[3]);
         fireEvent.change(node.querySelector("#root_credentials_username"), {
           target: { value: "you@email.com" },
@@ -133,10 +133,11 @@ describe("AuthForm component", () => {
     });
 
     describe("FxA", () => {
-      it("should navigate to external auth URL", () => {
+      it("should navigate to external auth URL", async () => {
         fireEvent.change(node.querySelector("#root_server"), {
           target: { value: "http://test.server/v1" },
         });
+        await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
         fireEvent.click(node.querySelectorAll("[type=radio]")[2]);
         fireEvent.change(node.querySelector("form"));
         fireEvent.submit(node.querySelector("form"));
@@ -149,10 +150,11 @@ describe("AuthForm component", () => {
     });
 
     describe("OpenID", () => {
-      it("should navigate to external auth URL", () => {
+      it("should navigate to external auth URL", async () => {
         fireEvent.change(node.querySelector("#root_server"), {
           target: { value: "http://test.server/v1" },
         });
+        await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
         fireEvent.click(node.querySelectorAll("[type=radio]")[4]);
         fireEvent.submit(node.querySelector("form"));
         sinon.assert.calledWithExactly(
@@ -221,6 +223,7 @@ describe("AuthForm component", () => {
       fireEvent.change(serverField, {
         target: { value: "http://test.server/v1" },
       });
+      await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
       expect(serverField.value).eql("http://test.server/v1");
       expect(authTypeField.value).eql("openid-google");
 

--- a/test/components/BaseForm_test.js
+++ b/test/components/BaseForm_test.js
@@ -1,0 +1,107 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import BaseForm from "../../src/components/BaseForm";
+
+const testSchema = {
+  type: "object",
+  properties: {
+    title: {
+      type: "string",
+      title: "Title",
+      description: "Short title",
+    },
+    content: {
+      type: "string",
+      title: "Content",
+      description: "Provide details...",
+    },
+  },
+};
+
+const testUiSchema = {
+  "ui:order": ["title", "content"],
+  content: {
+    "ui:widget": "textarea",
+  },
+  id: {
+    "ui:widget": "text",
+    "ui:disabled": true,
+  },
+  last_modified: {
+    "ui:widget": "hidden",
+    "ui:disabled": true,
+  },
+  schema: {
+    "ui:widget": "hidden",
+    "ui:disabled": true,
+  },
+  "ui:disabled": false,
+};
+
+describe("BaseForm component", () => {
+  beforeEach(() => {});
+
+  afterEach(() => {});
+
+  it("Should render a jrsf form as expected", async () => {
+    const result = render(
+      <BaseForm
+        className="testClass"
+        schema={testSchema}
+        uiSchema={testUiSchema}
+      />
+    );
+
+    const inputTitle = await result.findByLabelText("Title");
+    const inputContent = await result.findByLabelText("Content");
+    const submit = await result.findByText("Submit");
+    const spinner = await result.queryByTestId("spinner");
+
+    expect(inputTitle.disabled).toBe(false);
+    expect(inputContent.disabled).toBe(false);
+    expect(submit.disabled).toBe(false);
+    expect(spinner).toBeNull();
+  });
+
+  it("Should disable the form disabled true", async () => {
+    const result = render(
+      <BaseForm
+        className="testClass"
+        disabled={true}
+        schema={testSchema}
+        uiSchema={testUiSchema}
+      />
+    );
+
+    const inputTitle = await result.findByLabelText("Title");
+    const inputContent = await result.findByLabelText("Content");
+    const submit = await result.findByText("Submit");
+    const spinner = await result.queryByTestId("spinner");
+
+    expect(inputTitle.disabled).toBe(true);
+    expect(inputContent.disabled).toBe(true);
+    expect(submit.disabled).toBe(true);
+    expect(spinner).toBeNull();
+  });
+
+  it("Should show a spinner and disable the form when showSpinner is true", async () => {
+    const result = render(
+      <BaseForm
+        className="testClass"
+        showSpinner={true}
+        schema={testSchema}
+        uiSchema={testUiSchema}
+      />
+    );
+
+    const inputTitle = await result.findByLabelText("Title");
+    const inputContent = await result.findByLabelText("Content");
+    const submit = await result.findByText("Submit");
+    const spinner = await result.queryByTestId("spinner");
+
+    expect(inputTitle.disabled).toBe(true);
+    expect(inputContent.disabled).toBe(true);
+    expect(submit.disabled).toBe(true);
+    expect(spinner).toBeDefined();
+  });
+});


### PR DESCRIPTION
The goal of this PR is to prevent users from interacting with forms while we're waiting on server responses. I think the easiest way to do that is to:

1. Disable the forms while we're waiting for responses after user submissions/onChange events that trigger API calls
2. Provide a visual cue to users that data is being loaded

This should resolve the following open issues:
1. [Display a busy state whenever the server info is fetched](https://github.com/Kinto/kinto-admin/issues/579)
2. [Prevent double submission of forms](https://github.com/Kinto/kinto-admin/issues/1360)
3. [Simple review should disable the approve/reject buttons after they're clicked](https://github.com/Kinto/kinto-admin/issues/2206)
4. [Loading indicator not shown when loading history](https://github.com/Kinto/kinto-admin/issues/1596)

[Video of this in action](https://github.com/alexcottner/kinto-admin/assets/148472676/d6030b1d-9d4d-4489-8249-caa6682ab3f7)

