### PR TITLE
Bugfixes for collection create/edit and record loading

### DIFF
--- a/src/components/collection/CollectionForm.tsx
+++ b/src/components/collection/CollectionForm.tsx
@@ -17,6 +17,7 @@ import { canCreateCollection, canEditCollection } from "../../permission";
 import { validateSchema, validateUiSchema } from "../../utils";
 import DeleteForm from "./DeleteForm";
 import { FormInstructions } from "./FormInstructions";
+import { Link } from "react-router-dom";
 
 const defaultSchema = JSON.stringify(
   {
@@ -310,7 +311,7 @@ export default function CollectionForm({
         {` ${creation ? "Create" : "Update"} collection`}
       </button>
       {" or "}
-      <a href="/#/">Cancel</a>
+      <Link to="/">Cancel</Link>
       {" | "}
       <a href="#" onClick={toggleJSON}>
         {asJSON ? "Edit form" : "Edit raw JSON"}

--- a/src/components/collection/CollectionForm.tsx
+++ b/src/components/collection/CollectionForm.tsx
@@ -6,7 +6,6 @@ import type {
 } from "../../types";
 
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
 
 import { Check2 } from "react-bootstrap-icons";
 
@@ -250,8 +249,8 @@ export default function CollectionForm({
   const [showSpinner, setShowSpinner] = useState(false);
 
   const allowEditing = propFormData
-    ? canCreateCollection(session, bucket)
-    : canEditCollection(session, bucket, collection);
+    ? canEditCollection(session, bucket, collection)
+    : canCreateCollection(session, bucket);
 
   const toggleJSON = event => {
     event.preventDefault();
@@ -314,7 +313,7 @@ export default function CollectionForm({
         {` ${creation ? "Create" : "Update"} collection`}
       </button>
       {" or "}
-      <Link to="/">Cancel</Link>
+      <a href="/#/">Cancel</a>
       {" | "}
       <a href="#" onClick={toggleJSON}>
         {asJSON ? "Edit form" : "Edit raw JSON"}

--- a/src/components/collection/CollectionRecords.tsx
+++ b/src/components/collection/CollectionRecords.tsx
@@ -60,17 +60,13 @@ export default function CollectionRecords(props: Props) {
     [bid, cid, listRecords]
   );
 
-  const onCollectionRecordsEnter = useCallback(() => {
+  useEffect(() => {
     if (!session.authenticated) {
       return;
     }
     const { currentSort } = collection;
     listRecords(bid, cid, currentSort);
-  }, [bid, cid, collection, listRecords, session]);
-
-  useEffect(() => {
-    onCollectionRecordsEnter();
-  }, []);
+  }, [bid, cid]);
 
   const {
     busy,

--- a/test/components/BaseForm_test.js
+++ b/test/components/BaseForm_test.js
@@ -39,10 +39,6 @@ const testUiSchema = {
 };
 
 describe("BaseForm component", () => {
-  beforeEach(() => {});
-
-  afterEach(() => {});
-
   it("Should render a jrsf form as expected", async () => {
     const result = render(
       <BaseForm

--- a/test/components/CollectionForm_test.js
+++ b/test/components/CollectionForm_test.js
@@ -9,18 +9,7 @@ const testProps = {
   cid: null,
   bid: "default",
   session: {
-    permissions: [
-      {
-        resource_name: "bucket",
-        permissions: [
-          "group:create",
-          "read",
-          "read:attributes",
-          "collection:create",
-        ],
-        bucket_id: "default",
-      },
-    ],
+    permissions: [],
     buckets: [
       {
         id: "default",
@@ -46,6 +35,16 @@ const testProps = {
   formData: undefined,
 };
 
+// to avoid rendering a router around everything, allows for easier testing
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Link: "a",
+  };
+});
+
 describe("CollectionForm component", () => {
   beforeAll(() => {
     // preventing code mirror errors
@@ -64,8 +63,19 @@ describe("CollectionForm component", () => {
     });
   });
 
-  it("Should render an eitable form for a user with permissions creating a new collection", async () => {
-    const result = render(<CollectionForm {...testProps} />);
+  it("Should render an editable form for a user with permissions creating a new collection", async () => {
+    const localTestProps = JSON.parse(JSON.stringify(testProps));
+    localTestProps.session.permissions.push({
+      resource_name: "bucket",
+      permissions: [
+        "group:create",
+        "read",
+        "read:attributes",
+        "collection:create",
+      ],
+      bucket_id: "default",
+    });
+    const result = render(<CollectionForm {...localTestProps} />);
 
     const warning = result.queryByText(warningText);
     expect(warning).toBeNull();

--- a/test/components/CollectionForm_test.js
+++ b/test/components/CollectionForm_test.js
@@ -1,0 +1,142 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import CollectionForm from "../../src/components/collection/CollectionForm";
+
+const warningText =
+  "You don't have the required permission to edit this collection.";
+
+const testProps = {
+  cid: null,
+  bid: "default",
+  session: {
+    permissions: [
+      {
+        resource_name: "bucket",
+        permissions: [
+          "group:create",
+          "read",
+          "read:attributes",
+          "collection:create",
+        ],
+        bucket_id: "default",
+      },
+    ],
+    buckets: [
+      {
+        id: "default",
+      },
+    ],
+  },
+  bucket: {
+    busy: false,
+    data: {
+      id: "default",
+    },
+    permissions: {},
+    groups: [],
+  },
+  collection: {
+    busy: false,
+    data: {},
+    permissions: {},
+    records: [],
+  },
+  deleteCollection: jest.fn(),
+  onSubmit: jest.fn(),
+  formData: undefined,
+};
+
+describe("CollectionForm component", () => {
+  beforeAll(() => {
+    // preventing code mirror errors
+    Range.prototype.getBoundingClientRect = () => ({
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+    });
+    Range.prototype.getClientRects = () => ({
+      item: () => null,
+      length: 0,
+      [Symbol.iterator]: jest.fn(),
+    });
+  });
+
+  it("Should render an eitable form for a user with permissions creating a new collection", async () => {
+    const result = render(<CollectionForm {...testProps} />);
+
+    const warning = result.queryByText(warningText);
+    expect(warning).toBeNull();
+    const title = await result.findByLabelText("Collection id*");
+    expect(title.disabled).toBe(false);
+  });
+
+  it("Should render an editable form for a user with permissions editing a collection", async () => {
+    const localTestProps = JSON.parse(JSON.stringify(testProps));
+    localTestProps.session.permissions.push({
+      uri: "/buckets/default/test",
+      resource_name: "collection",
+      permissions: ["write"],
+      id: "test",
+      bucket_id: "default",
+      collection_id: "test",
+    });
+    localTestProps.cid = "test";
+    localTestProps.bid = "default";
+    localTestProps.collection.data.id = "test";
+    localTestProps.formData = {};
+
+    const result = render(<CollectionForm {...localTestProps} />);
+
+    const warning = result.queryByText(warningText);
+    expect(warning).toBeNull();
+    const title = await result.findByLabelText("Collection id*");
+    expect(title.disabled).toBe(false);
+  });
+
+  it("Should render an error for a user lacking permissions creating a collection", async () => {
+    const localTestProps = JSON.parse(JSON.stringify(testProps));
+    localTestProps.session.permissions = [
+      {
+        uri: "/buckets/default",
+        resource_name: "bucket",
+        permissions: ["group:create", "read", "read:attributes", "write"],
+        id: "default",
+        bucket_id: "default",
+      },
+    ];
+    const result = render(<CollectionForm {...localTestProps} />);
+
+    const warning = await result.queryByText(warningText);
+    expect(warning).toBeDefined();
+    const title = await result.findByLabelText("Collection id*");
+    expect(title.disabled).toBe(true);
+  });
+
+  it("Should render as read-only for a user lacking permissions editing a collection", async () => {
+    const localTestProps = JSON.parse(JSON.stringify(testProps));
+    localTestProps.collection = {
+      busy: false,
+      data: {
+        id: "test",
+      },
+      permissions: {
+        read: [],
+        "record:create": [],
+      },
+      records: [],
+    };
+    localTestProps.cid = "test";
+    localTestProps.bid = "default";
+    localTestProps.formData = {};
+
+    const result = render(<CollectionForm {...localTestProps} />);
+
+    const warning = await result.queryByText(warningText);
+    expect(warning).toBeDefined();
+    const title = await result.findByLabelText("Collection id*");
+    expect(title.disabled).toBe(true);
+  });
+});

--- a/test/components/CollectionRecords_test.js
+++ b/test/components/CollectionRecords_test.js
@@ -1,21 +1,12 @@
-import { expect } from "chai";
-
-import { createSandbox, createComponent } from "../test_utils";
-
+import {
+  createComponent,
+  renderComponent,
+  rerenderComponent,
+} from "../test_utils";
 import CollectionRecords from "../../src/components/collection/CollectionRecords";
 import * as React from "react";
 
 describe("CollectionRecords component", () => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = createSandbox();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   const capabilities = {
     history: {},
   };
@@ -28,6 +19,68 @@ describe("CollectionRecords component", () => {
       write: [],
     },
   };
+
+  it("Calls listRecords every time bid or cid changes", async () => {
+    const listRecordsMock = jest.fn();
+
+    const props = {
+      session: { authenticated: true, permissions: ["foo"] },
+      bucket,
+      collection: {
+        busy: false,
+        data: {
+          schema: {
+            type: "object",
+            properties: {
+              foo: { type: "string" },
+            },
+          },
+          displayFields: ["foo"],
+        },
+        permissions: {
+          write: ["basicauth:plop"],
+        },
+        recordsLoaded: true,
+        records: [],
+      },
+      capabilities,
+      listRecords: listRecordsMock
+    };
+    const result = renderComponent(
+      <CollectionRecords {...props}
+        match={{ params: { bid: "bucket1", cid: "collection1" } }}
+      />
+    );
+
+    expect(listRecordsMock).toHaveBeenCalledTimes(1);
+
+    rerenderComponent(
+      result,
+      <CollectionRecords {...props}
+        match={{ params: { bid: "bucket1", cid: "collection2" } }}
+      />
+    );
+
+    expect(listRecordsMock).toHaveBeenCalledTimes(2);
+
+    rerenderComponent(
+      result,
+      <CollectionRecords {...props}
+        match={{ params: { bid: "bucket2", cid: "collection2" } }}
+      />
+    );
+
+    expect(listRecordsMock).toHaveBeenCalledTimes(3);
+
+    rerenderComponent(
+      result,
+      <CollectionRecords {...props}
+        match={{ params: { bid: "bucket2", cid: "collection1" } }}
+      />
+    );
+
+    expect(listRecordsMock).toHaveBeenCalledTimes(4);
+  });
 
   describe("Schema defined", () => {
     let node;
@@ -70,15 +123,15 @@ describe("CollectionRecords component", () => {
     });
 
     it("should render a table", () => {
-      expect(node.querySelector("table")).to.exist;
+      expect(node.querySelector("table")).toBeDefined();
     });
 
     it("should render record rows", () => {
       const rows = node.querySelectorAll("tbody tr");
 
-      expect(rows).to.have.a.lengthOf(2);
-      expect(rows[0].querySelectorAll("td")[0].textContent).eql("bar");
-      expect(rows[1].querySelectorAll("td")[0].textContent).eql("baz");
+      expect(rows).toHaveLength(2);
+      expect(rows[0].querySelectorAll("td")[0].textContent).toBe("bar");
+      expect(rows[1].querySelectorAll("td")[0].textContent).toBe("baz");
     });
   });
 
@@ -120,19 +173,19 @@ describe("CollectionRecords component", () => {
     });
 
     it("should render a table", () => {
-      expect(node.querySelector("table")).to.exist;
+      expect(node.querySelector("table")).toBeDefined();
     });
 
     it("should render record rows", () => {
       const rows = node.querySelectorAll("tbody tr");
 
-      expect(rows).to.have.a.lengthOf(2);
-      expect(rows[0].querySelectorAll("td")[0].textContent).eql("id1");
-      expect(rows[0].querySelectorAll("td")[1].textContent).eql(
+      expect(rows).toHaveLength(2);
+      expect(rows[0].querySelectorAll("td")[0].textContent).toBe("id1");
+      expect(rows[0].querySelectorAll("td")[1].textContent).toBe(
         JSON.stringify({ foo: "bar" })
       );
-      expect(rows[1].querySelectorAll("td")[0].textContent).eql("id2");
-      expect(rows[1].querySelectorAll("td")[1].textContent).eql(
+      expect(rows[1].querySelectorAll("td")[0].textContent).toBe("id2");
+      expect(rows[1].querySelectorAll("td")[1].textContent).toBe(
         JSON.stringify({ foo: "baz" })
       );
     });
@@ -166,7 +219,7 @@ describe("CollectionRecords component", () => {
     it("should show the total number of records", () => {
       expect(
         node.querySelector(".card-header-tabs .nav-link.active").textContent
-      ).to.eql("Records (18)");
+      ).toBe("Records (18)");
     });
   });
 
@@ -206,9 +259,12 @@ describe("CollectionRecords component", () => {
       });
 
       it("should render list actions", () => {
-        expect(node.querySelector(".list-actions .btn-record-add")).to.exist;
-        expect(node.querySelector(".list-actions .btn-record-bulk-add")).to
-          .exist;
+        expect(
+          node.querySelector(".list-actions .btn-record-add")
+        ).toBeDefined();
+        expect(
+          node.querySelector(".list-actions .btn-record-bulk-add")
+        ).toBeDefined();
       });
     });
 
@@ -229,8 +285,9 @@ describe("CollectionRecords component", () => {
       });
 
       it("should not render list actions", () => {
-        expect(node.querySelector(".list-actions .btn-record-bulk-add")).to.not
-          .exist;
+        expect(
+          node.querySelector(".list-actions .btn-record-bulk-add")
+        ).toBeNull();
       });
     });
   });

--- a/test/components/CollectionRecords_test.js
+++ b/test/components/CollectionRecords_test.js
@@ -1,8 +1,4 @@
-import {
-  createComponent,
-  renderComponent,
-  rerenderComponent,
-} from "../test_utils";
+import { createComponent, renderWithProvider } from "../test_utils";
 import CollectionRecords from "../../src/components/collection/CollectionRecords";
 import * as React from "react";
 
@@ -46,7 +42,7 @@ describe("CollectionRecords component", () => {
       capabilities,
       listRecords: listRecordsMock,
     };
-    const result = renderComponent(
+    const result = renderWithProvider(
       <CollectionRecords
         {...props}
         match={{ params: { bid: "bucket1", cid: "collection1" } }}
@@ -55,8 +51,7 @@ describe("CollectionRecords component", () => {
 
     expect(listRecordsMock).toHaveBeenCalledTimes(1);
 
-    rerenderComponent(
-      result,
+    result.rerender(
       <CollectionRecords
         {...props}
         match={{ params: { bid: "bucket1", cid: "collection2" } }}
@@ -65,8 +60,7 @@ describe("CollectionRecords component", () => {
 
     expect(listRecordsMock).toHaveBeenCalledTimes(2);
 
-    rerenderComponent(
-      result,
+    result.rerender(
       <CollectionRecords
         {...props}
         match={{ params: { bid: "bucket2", cid: "collection2" } }}
@@ -75,8 +69,7 @@ describe("CollectionRecords component", () => {
 
     expect(listRecordsMock).toHaveBeenCalledTimes(3);
 
-    rerenderComponent(
-      result,
+    result.rerender(
       <CollectionRecords
         {...props}
         match={{ params: { bid: "bucket2", cid: "collection1" } }}

--- a/test/components/CollectionRecords_test.js
+++ b/test/components/CollectionRecords_test.js
@@ -44,10 +44,11 @@ describe("CollectionRecords component", () => {
         records: [],
       },
       capabilities,
-      listRecords: listRecordsMock
+      listRecords: listRecordsMock,
     };
     const result = renderComponent(
-      <CollectionRecords {...props}
+      <CollectionRecords
+        {...props}
         match={{ params: { bid: "bucket1", cid: "collection1" } }}
       />
     );
@@ -56,7 +57,8 @@ describe("CollectionRecords component", () => {
 
     rerenderComponent(
       result,
-      <CollectionRecords {...props}
+      <CollectionRecords
+        {...props}
         match={{ params: { bid: "bucket1", cid: "collection2" } }}
       />
     );
@@ -65,7 +67,8 @@ describe("CollectionRecords component", () => {
 
     rerenderComponent(
       result,
-      <CollectionRecords {...props}
+      <CollectionRecords
+        {...props}
         match={{ params: { bid: "bucket2", cid: "collection2" } }}
       />
     );
@@ -74,7 +77,8 @@ describe("CollectionRecords component", () => {
 
     rerenderComponent(
       result,
-      <CollectionRecords {...props}
+      <CollectionRecords
+        {...props}
         match={{ params: { bid: "bucket2", cid: "collection1" } }}
       />
     );

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -83,8 +83,7 @@ export function sessionFactory(props) {
   };
 }
 
-// temporary solution until we rewrite AdminLink to not require router around it
-export function renderComponent(
+export function renderWithProvider(
   ui,
   {
     initialState,
@@ -97,35 +96,17 @@ export function renderComponent(
     initialState,
     initialHistory
   );
-  return render(
+  const Wrapper = ({ children }) => (
     <Provider store={store}>
       <Router history={history}>
-        <Route path={path}>{ui}</Route>
+        <Route path={path}>{children}</Route>
       </Router>
     </Provider>
   );
-}
-
-// temporary solution until we rewrite AdminLink to not require router around it
-export function rerenderComponent(
-  component,
-  ui,
-  {
-    initialState,
-    route = "/",
-    path = "/",
-    initialHistory = createMemoryHistory({ initialEntries: [route] }),
-  } = {}
-) {
-  const { store, history } = configureAppStoreAndHistory(
-    initialState,
-    initialHistory
-  );
-  return component.rerender(
-    <Provider store={store}>
-      <Router history={history}>
-        <Route path={path}>{ui}</Route>
-      </Router>
-    </Provider>
-  );
+  return {
+    ...render(ui, { wrapper: Wrapper }),
+    store,
+    rerender: updatedComponent =>
+      render(updatedComponent, { container: document.body, wrapper: Wrapper }),
+  };
 }

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -3,6 +3,7 @@
 import React from "react";
 import sinon from "sinon";
 import ReactDOM from "react-dom";
+import { render } from "@testing-library/react";
 import { Router } from "react-router";
 import { Provider } from "react-redux";
 import { configureAppStoreAndHistory } from "../src/store/configureStore";
@@ -80,4 +81,51 @@ export function sessionFactory(props) {
     ...props,
     redirectURL: "",
   };
+}
+
+// temporary solution until we rewrite AdminLink to not require router around it
+export function renderComponent(
+  ui,
+  {
+    initialState,
+    route = "/",
+    path = "/",
+    initialHistory = createMemoryHistory({ initialEntries: [route] }),
+  } = {}
+) {
+  const { store, history } = configureAppStoreAndHistory(
+    initialState,
+    initialHistory
+  );
+  return render(
+    <Provider store={store}>
+      <Router history={history}>
+        <Route path={path}>{ui}</Route>
+      </Router>
+    </Provider>
+  );
+}
+
+// temporary solution until we rewrite AdminLink to not require router around it
+export function rerenderComponent(
+  component,
+  ui,
+  {
+    initialState,
+    route = "/",
+    path = "/",
+    initialHistory = createMemoryHistory({ initialEntries: [route] }),
+  } = {}
+) {
+  const { store, history } = configureAppStoreAndHistory(
+    initialState,
+    initialHistory
+  );
+  return component.rerender(
+    <Provider store={store}>
+      <Router history={history}>
+        <Route path={path}>{ui}</Route>
+      </Router>
+    </Provider>
+  );
 }


### PR DESCRIPTION
Small PR that corrects two bugs and adds unit tests around them. This PR:
1. Corrects a known issue introduced in the functional component conversion [where non-admin users couldn't create a new collection](https://github.com/Kinto/kinto-admin/issues/3045).
2. Corrects an issue I discovered while working on this where collection records didn't load correctly when switching collections/buckets.