### PR TITLE
Record refresh bugfix and simple-review enhancement to hide rollback button

### DIFF
--- a/src/actions/collection.ts
+++ b/src/actions/collection.ts
@@ -57,18 +57,21 @@ export function listNextRecords(): {
 export function listRecordsSuccess(
   records: RecordData[],
   hasNextRecords: boolean,
-  listNextRecords: Function | null | undefined
+  listNextRecords: Function | null | undefined,
+  isNextPage: boolean = false
 ): {
   type: "COLLECTION_RECORDS_SUCCESS";
   records: RecordData[];
   hasNextRecords: boolean;
   listNextRecords: Function | null | undefined;
+  isNextPage: boolean;
 } {
   return {
     type: COLLECTION_RECORDS_SUCCESS,
     records,
     hasNextRecords,
     listNextRecords,
+    isNextPage,
   };
 }
 

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NavLink, useLocation } from "react-router-dom";
-import { breadcrumbifyPath } from "../../utils";
+import { breadcrumbifyPath } from "../../locationUtils";
 
 import "./style.css";
 

--- a/src/components/collection/CollectionRecords.tsx
+++ b/src/components/collection/CollectionRecords.tsx
@@ -60,14 +60,6 @@ export default function CollectionRecords(props: Props) {
     [bid, cid, listRecords]
   );
 
-  useEffect(() => {
-    if (!session.authenticated) {
-      return;
-    }
-    const { currentSort } = collection;
-    listRecords(bid, cid, currentSort);
-  }, [bid, cid]);
-
   const {
     busy,
     data,
@@ -78,6 +70,14 @@ export default function CollectionRecords(props: Props) {
     totalRecords,
   } = collection;
   const { schema, displayFields } = data;
+
+  useEffect(() => {
+    if (!session.authenticated || !data?.last_modified) {
+      return;
+    }
+    const { currentSort } = collection;
+    listRecords(bid, cid, currentSort);
+  }, [bid, cid, data.last_modified || 0]);
 
   const listActions = (
     <ListActions

--- a/src/components/signoff/SignoffToolBar.tsx
+++ b/src/components/signoff/SignoffToolBar.tsx
@@ -1,11 +1,15 @@
-import type { BucketState, SessionState, CollectionState } from "../../types";
-import type { SignoffState, SignoffSourceInfo, ChangesList } from "../../types";
-
+import type {
+  BucketState,
+  SessionState,
+  CollectionState,
+  SignoffState,
+  SignoffSourceInfo,
+  ChangesList,
+} from "../../types";
 import React, { useState, useEffect } from "react";
 import { CommentDialog, Comment } from "./Comment";
 
-import { ChatLeft } from "react-bootstrap-icons";
-import { XCircleFill } from "react-bootstrap-icons";
+import { ChatLeft, XCircleFill } from "react-bootstrap-icons";
 
 import { canEditCollection } from "../../permission";
 

--- a/src/components/signoff/SimpleReview/SimpleReviewButtons.tsx
+++ b/src/components/signoff/SimpleReview/SimpleReviewButtons.tsx
@@ -2,6 +2,9 @@ import CommentDialog from "../../CommentDialog";
 import React, { useState } from "react";
 import { SignoffCollectionStatus } from "../../../types";
 
+import { useLocation } from "react-router";
+import { parseSearchString } from "../../../locationUtils";
+
 export interface SimpleReviewButtonsProps {
   status: SignoffCollectionStatus;
   approveChanges(): void;
@@ -16,6 +19,8 @@ export default function SimpleReviewButtons({
   rollbackChanges,
 }: SimpleReviewButtonsProps) {
   const [dialog, setDialog] = useState<"reject" | "rollback" | "">("");
+  const searchParams = parseSearchString(useLocation().search);
+
   return (
     <>
       <div className="simple-review-buttons">
@@ -35,7 +40,7 @@ export default function SimpleReviewButtons({
             </button>
           </>
         )}
-        {status === "work-in-progress" && (
+        {status === "work-in-progress" && !searchParams.hideRollback && (
           <button
             className="btn btn-danger"
             onClick={() => setDialog("rollback")}

--- a/src/locationUtils.ts
+++ b/src/locationUtils.ts
@@ -18,7 +18,8 @@ export function breadcrumbifyPath(path: string) {
   return [["home", "/"]].concat(zip(crumbNames, crumbPaths));
 }
 
-// This may become obsolete when upgrading or switching router packages
+// This may become obsolete when upgrading or switching router packages. Functionality
+// is not built in to react-router v5, useSearchParams exists in v6 though.
 export function parseSearchString(search?: string): Record<string, any> {
   if (!search || !search.startsWith("?")) {
     return {};

--- a/src/locationUtils.ts
+++ b/src/locationUtils.ts
@@ -1,0 +1,35 @@
+import zip from "lodash/zip";
+
+/**
+ * Given a pathname, return a 2d array where each inner array is the path
+ * part's name and location
+ *
+ * "/"        => [["home", "/"]]
+ * "/foo"     => [["home", "/"], ["foo", "/foo"]]
+ * "/foo/bar" => [["home", "/"], ["foo", "/foo"], ["bar", "/foo/bar"]]
+ */
+export function breadcrumbifyPath(path: string) {
+  const crumbNames = path.split("/").filter(Boolean);
+  const pathParts = [""];
+  const crumbPaths = crumbNames.map(name => {
+    pathParts.push(name);
+    return pathParts.join("/");
+  });
+  return [["home", "/"]].concat(zip(crumbNames, crumbPaths));
+}
+
+// This may become obsolete when upgrading or switching router packages
+export function parseSearchString(search?: string): Record<string, any> {
+  if (!search || !search.startsWith("?")) {
+    return {};
+  }
+  const params = {};
+  const keyVals = search.substring(1).split("&");
+  for (let kv of keyVals) {
+    const [key, val] = kv.split("=");
+    if (key) {
+      params[decodeURIComponent(key)] = val ? decodeURIComponent(val) : true;
+    }
+  }
+  return params;
+}

--- a/src/reducers/collection.ts
+++ b/src/reducers/collection.ts
@@ -82,10 +82,10 @@ export function collection(
       return { ...state, recordsLoaded: false };
     }
     case COLLECTION_RECORDS_SUCCESS: {
-      const { records, hasNextRecords, listNextRecords } = action;
+      const { records, hasNextRecords, listNextRecords, isNextPage } = action;
       return {
         ...state,
-        records: [...state.records, ...records],
+        records: isNextPage ? [...state.records, ...records] : records,
         recordsLoaded: true,
         hasNextRecords,
         listNextRecords,

--- a/src/reducers/collection.ts
+++ b/src/reducers/collection.ts
@@ -85,6 +85,7 @@ export function collection(
       const { records, hasNextRecords, listNextRecords, isNextPage } = action;
       return {
         ...state,
+        // if isNextPage is true, we're fetching the next page of data so don't wipe state
         records: isNextPage ? [...state.records, ...records] : records,
         recordsLoaded: true,
         hasNextRecords,

--- a/src/sagas/collection.ts
+++ b/src/sagas/collection.ts
@@ -53,7 +53,14 @@ export function* listRecords(
       limit: MAX_PER_PAGE,
     });
     // Show list of records.
-    yield put(actions.listRecordsSuccess(data, hasNextPage, next, false));
+    yield put(
+      actions.listRecordsSuccess(
+        data,
+        hasNextPage,
+        next,
+        /* isNextPage: */ false
+      )
+    );
     // Request number of total records.
     const totalRecords = yield call([coll, coll.getTotalRecords]);
     yield put(actions.collectionTotalRecords(totalRecords));
@@ -71,7 +78,14 @@ export function* listNextRecords(getState: GetStateFn): SagaGen {
   }
   try {
     const { data, hasNextPage, next } = yield call(listNextRecords);
-    yield put(actions.listRecordsSuccess(data, hasNextPage, next, true));
+    yield put(
+      actions.listRecordsSuccess(
+        data,
+        hasNextPage,
+        next,
+        /* isNextPage: */ true
+      )
+    );
   } catch (error) {
     yield put(notifyError("Couldn't process next page.", error));
   }

--- a/src/sagas/collection.ts
+++ b/src/sagas/collection.ts
@@ -53,7 +53,7 @@ export function* listRecords(
       limit: MAX_PER_PAGE,
     });
     // Show list of records.
-    yield put(actions.listRecordsSuccess(data, hasNextPage, next));
+    yield put(actions.listRecordsSuccess(data, hasNextPage, next, false));
     // Request number of total records.
     const totalRecords = yield call([coll, coll.getTotalRecords]);
     yield put(actions.collectionTotalRecords(totalRecords));
@@ -71,7 +71,7 @@ export function* listNextRecords(getState: GetStateFn): SagaGen {
   }
   try {
     const { data, hasNextPage, next } = yield call(listNextRecords);
-    yield put(actions.listRecordsSuccess(data, hasNextPage, next));
+    yield put(actions.listRecordsSuccess(data, hasNextPage, next, true));
   } catch (error) {
     yield put(notifyError("Couldn't process next page.", error));
   }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -9,7 +9,6 @@ import React from "react";
 import { format } from "timeago.js";
 import { diffJson as diff } from "diff";
 import { DEFAULT_KINTO_SERVER, SINGLE_SERVER } from "./constants";
-import zip from "lodash/zip";
 
 export function clone(obj: any) {
   return JSON.parse(JSON.stringify(obj));
@@ -402,21 +401,4 @@ export function diffJson(
       .join("\n");
     return prefixedChunk;
   });
-}
-/**
- * Given a pathname, return a 2d array where each inner array is the path
- * part's name and location
- *
- * "/"        => [["home", "/"]]
- * "/foo"     => [["home", "/"], ["foo", "/foo"]]
- * "/foo/bar" => [["home", "/"], ["foo", "/foo"], ["bar", "/foo/bar"]]
- */
-export function breadcrumbifyPath(path: string) {
-  const crumbNames = path.split("/").filter(Boolean);
-  const pathParts = [""];
-  const crumbPaths = crumbNames.map(name => {
-    pathParts.push(name);
-    return pathParts.join("/");
-  });
-  return [["home", "/"]].concat(zip(crumbNames, crumbPaths));
 }

--- a/test/components/CollectionRecords_test.js
+++ b/test/components/CollectionRecords_test.js
@@ -32,6 +32,7 @@ describe("CollectionRecords component", () => {
             },
           },
           displayFields: ["foo"],
+          last_modified: 123,
         },
         permissions: {
           write: ["basicauth:plop"],

--- a/test/locationUtils_test.js
+++ b/test/locationUtils_test.js
@@ -1,0 +1,35 @@
+import { breadcrumbifyPath, parseSearchString } from "../src/locationUtils";
+
+describe("locationUtils", () => {
+  test("breadcrumbify should return expected arrays", () => {
+    expect(breadcrumbifyPath("/")).toStrictEqual([["home", "/"]]);
+    expect(breadcrumbifyPath("/foo")).toStrictEqual([
+      ["home", "/"],
+      ["foo", "/foo"],
+    ]);
+    expect(breadcrumbifyPath("/foo/bar")).toStrictEqual([
+      ["home", "/"],
+      ["foo", "/foo"],
+      ["bar", "/foo/bar"],
+    ]);
+  });
+
+  test("parseSearchString should return expected parameter objects", () => {
+    // invalid/empty search strings should return empty hashes
+    expect(parseSearchString("/")).toStrictEqual({});
+    expect(parseSearchString("")).toStrictEqual({});
+    expect(parseSearchString(null)).toStrictEqual({});
+    expect(parseSearchString(undefined)).toStrictEqual({});
+    expect(parseSearchString("?")).toStrictEqual({});
+
+    // valid strings should return matching hashes with decodedURI keys/values
+    // default to true for valueless parameters
+    expect(
+      parseSearchString(`?foo&baR&cheese%20pizza=yes%2Fplease`)
+    ).toStrictEqual({
+      foo: true,
+      baR: true,
+      "cheese pizza": "yes/please",
+    });
+  });
+});

--- a/test/reducers/collection_test.js
+++ b/test/reducers/collection_test.js
@@ -157,9 +157,20 @@ describe("collection reducer", () => {
       const state2 = collection(state, {
         type: COLLECTION_RECORDS_SUCCESS,
         records: [4, 5],
+        isNextPage: true,
       });
 
       expect(state2.records).eql([1, 2, 3, 4, 5]);
+    });
+
+    it("should pull fresh records when isNextPage is false", () => {
+      const state2 = collection(state, {
+        type: COLLECTION_RECORDS_SUCCESS,
+        records: [4, 5],
+        isNextPage: false,
+      });
+
+      expect(state2.records).eql([4, 5]);
     });
   });
 

--- a/test/sagas/collection_test.js
+++ b/test/sagas/collection_test.js
@@ -182,7 +182,7 @@ describe("collection sagas", () => {
         const fakeNext = () => {};
         const result = { data: records, hasNextPage: false, next: fakeNext };
         expect(listNextRecords.next(result).value).eql(
-          put(actions.listRecordsSuccess(records, false, fakeNext))
+          put(actions.listRecordsSuccess(records, false, fakeNext, true))
         );
       });
     });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -12,7 +12,6 @@ import {
   buildAttachmentUrl,
   timeago,
   sortHistoryEntryPermissions,
-  breadcrumbifyPath,
   getServerByPriority,
 } from "../src/utils";
 
@@ -410,21 +409,6 @@ describe("diffJson", function () {
       '-   "h": 8,',
       '+   "h": "h",',
       '    "i": 9,\n    "j": 10,\n    "k": 11,\n    "l": 12\n  }',
-    ]);
-  });
-});
-
-describe("breadcrumbify", () => {
-  test("breadcrumbify", () => {
-    expect(breadcrumbifyPath("/")).eql([["home", "/"]]);
-    expect(breadcrumbifyPath("/foo")).eql([
-      ["home", "/"],
-      ["foo", "/foo"],
-    ]);
-    expect(breadcrumbifyPath("/foo/bar")).eql([
-      ["home", "/"],
-      ["foo", "/foo"],
-      ["bar", "/foo/bar"],
     ]);
   });
 });


### PR DESCRIPTION
Resolves two issues and adds unit tests around them:

1. [Add query param to hide rollback button](https://github.com/Kinto/kinto-admin/issues/1953)
2. [List of records is not refreshed after rollback](https://github.com/Kinto/kinto-admin/issues/2361)

**Note:** The added the query param is only useful while the user does not navigate away and back. Should this be a change that needs to be persisted throughout the session please leave a comment and I'll adjust the code to save this to sessionStorage and check against that.

Video demos showing fixes:

[Issue 1953](https://github.com/Kinto/kinto-admin/assets/148472676/e71b7b70-cb58-47bd-a15a-3b25e70e3e06)

[Issue 2361](https://github.com/Kinto/kinto-admin/assets/148472676/f40a6ef1-d4d5-40eb-b48a-374bb2423fd4)
