### PR TITLE
Fixes Issue 2340 - fixed bootstrap grid system class names on progress bar

### DIFF
--- a/src/components/signoff/ProgressBar.tsx
+++ b/src/components/signoff/ProgressBar.tsx
@@ -32,7 +32,7 @@ export function ProgressStep({
       ? "complete"
       : "disabled";
   return (
-    <div className={`col-xs-3 bs-wizard-step ${status}`} key={step}>
+    <div className={`col-3 bs-wizard-step ${status}`} key={step}>
       <div className="text-center bs-wizard-stepnum">{label}</div>
       <div className="progress">
         <div className="progress-bar" />


### PR DESCRIPTION
Fixes bootstrap styling [issue 2340](https://github.com/Kinto/kinto-admin/issues/2340) by deleting 3 characters.

![Screenshot from 2023-11-08 12-24-00](https://github.com/Kinto/kinto-admin/assets/148472676/3ef21ab5-3096-48d2-aa8a-c201d6dbe3ca)
