### PR TITLE
Fixes issue 633 - Hide buttons users shouldn't be able to click

### DIFF
--- a/src/components/bucket/CollectionDataList.tsx
+++ b/src/components/bucket/CollectionDataList.tsx
@@ -5,10 +5,11 @@ import { Gear, Justify, ClockHistory } from "react-bootstrap-icons";
 import { timeago } from "../../utils";
 import AdminLink from "../AdminLink";
 import PaginatedTable from "../PaginatedTable";
+import { canCreateCollection } from "../../permission";
 
 export function ListActions(props) {
   const { bid, session, bucket } = props;
-  if (session.busy || bucket.busy) {
+  if (session.busy || bucket.busy || !canCreateCollection(session, bucket)) {
     return null;
   }
   return (

--- a/src/components/bucket/GroupDataList.tsx
+++ b/src/components/bucket/GroupDataList.tsx
@@ -5,6 +5,7 @@ import { ClockHistory } from "react-bootstrap-icons";
 
 import { timeago } from "../../utils";
 import AdminLink from "../AdminLink";
+import { canEditBucket } from "../../permission";
 
 export function DataList(props) {
   const { bid, groups, capabilities } = props;
@@ -66,7 +67,7 @@ export function DataList(props) {
 }
 
 export function ListActions({ bid, session, bucket }) {
-  if (session.busy || bucket.busy) {
+  if (session.busy || bucket.busy || !canEditBucket(session, bucket)) {
     return null;
   }
   return (

--- a/src/components/bucket/GroupDataList.tsx
+++ b/src/components/bucket/GroupDataList.tsx
@@ -5,7 +5,7 @@ import { ClockHistory } from "react-bootstrap-icons";
 
 import { timeago } from "../../utils";
 import AdminLink from "../AdminLink";
-import { canEditBucket } from "../../permission";
+import { canCreateGroup } from "../../permission";
 
 export function DataList(props) {
   const { bid, groups, capabilities } = props;
@@ -67,7 +67,7 @@ export function DataList(props) {
 }
 
 export function ListActions({ bid, session, bucket }) {
-  if (session.busy || bucket.busy || !canEditBucket(session, bucket)) {
+  if (session.busy || bucket.busy || !canCreateGroup(session, bucket)) {
     return null;
   }
   return (

--- a/src/components/collection/CollectionForm.tsx
+++ b/src/components/collection/CollectionForm.tsx
@@ -296,7 +296,11 @@ export default function CollectionForm({
   const alert =
     allowEditing || bucket.busy || collection.busy ? null : (
       <div className="alert alert-warning">
-        You don't have the required permission to { collection.data?.id ? "edit this collection" : "create a collection in this bucket" }.
+        You don't have the required permission to{" "}
+        {collection.data?.id
+          ? "edit this collection"
+          : "create a collection in this bucket"}
+        .
       </div>
     );
 

--- a/src/components/collection/CollectionForm.tsx
+++ b/src/components/collection/CollectionForm.tsx
@@ -296,7 +296,7 @@ export default function CollectionForm({
   const alert =
     allowEditing || bucket.busy || collection.busy ? null : (
       <div className="alert alert-warning">
-        You don't have the required permission to edit this collection.
+        You don't have the required permission to { collection.data?.id ? "edit this collection" : "create a collection in this bucket" }.
       </div>
     );
 

--- a/test/components/bucket/CollectionDataList_test.js
+++ b/test/components/bucket/CollectionDataList_test.js
@@ -1,0 +1,99 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import {
+  DataList,
+  ListActions,
+} from "../../../src/components/bucket/CollectionDataList";
+import { canCreateCollection } from "../../../src/permission";
+
+jest.mock("../../../src/permission", () => {
+  return {
+    __esModule: true,
+    canCreateCollection: jest.fn(),
+  };
+});
+
+// to avoid rendering a router around everything, allows for more focused testing
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Link: "a",
+  };
+});
+
+describe("Bucket CollectionDataList", () => {
+  const props = {
+    bid: "test",
+    capabilities: {},
+    listBucketNextCollections: jest.fn(),
+    collections: {
+      entries: [
+        {
+          schema: {
+            type: "object",
+            properties: {
+              title: {
+                type: "string",
+                title: "Title",
+                description: "Short title",
+              },
+              content: {
+                type: "string",
+                title: "Content",
+                description: "Provide details...",
+              },
+            },
+          },
+          cache_expires: 0,
+          uiSchema: {
+            "ui:order": ["title", "content"],
+            content: {
+              "ui:widget": "textarea",
+            },
+          },
+          sort: "-last_modified",
+          displayFields: ["title"],
+          attachment: {
+            enabled: false,
+            required: false,
+          },
+          id: "test-collection-id",
+          last_modified: 1699985728831,
+        },
+      ],
+      loaded: true,
+      hasNextPage: false,
+    },
+  };
+  it("Should render a list of collections as expected", () => {
+    const result = render(<DataList {...props} />);
+    expect(result.queryByText("test-collection-id")).toBeDefined();
+    expect(result.queryByTitle("Browse collection")).toBeDefined();
+    expect(result.queryByTitle("Edit collection attributes")).toBeDefined();
+  });
+});
+
+describe("Bucket CollectionListActions", () => {
+  const props = {
+    session: {
+      busy: false,
+    },
+    bucket: {
+      busy: false,
+    },
+  };
+
+  it("Should render a Create Collection button when the user has permission to create one", () => {
+    canCreateCollection.mockReturnValue(true);
+    const result = render(<ListActions {...props} />);
+    expect(result.queryByText("Create collection")).toBeDefined();
+  });
+
+  it("Should render no Create Collection button when the user lacks permission", () => {
+    canCreateCollection.mockReturnValue(false);
+    const result = render(<ListActions {...props} />);
+    expect(result.queryByText("Create collection")).toBeNull();
+  });
+});

--- a/test/components/bucket/GroupDataList_test.js
+++ b/test/components/bucket/GroupDataList_test.js
@@ -4,12 +4,12 @@ import {
   DataList,
   ListActions,
 } from "../../../src/components/bucket/GroupDataList";
-import { canEditBucket } from "../../../src/permission";
+import { canCreateGroup } from "../../../src/permission";
 
 jest.mock("../../../src/permission", () => {
   return {
     __esModule: true,
-    canEditBucket: jest.fn(),
+    canCreateGroup: jest.fn(),
   };
 });
 
@@ -62,13 +62,13 @@ describe("Bucket GroupListActions", () => {
   };
 
   it("Should render a Create Group button when the user has permission", () => {
-    canEditBucket.mockReturnValue(true);
+    canCreateGroup.mockReturnValue(true);
     const result = render(<ListActions {...props} />);
     expect(result.queryByText("Create group")).toBeDefined();
   });
 
   it("Should render no Create Group button when the user lacks permission", () => {
-    canEditBucket.mockReturnValue(false);
+    canCreateGroup.mockReturnValue(false);
     const result = render(<ListActions {...props} />);
     expect(result.queryByText("Create group")).toBeNull();
   });

--- a/test/components/bucket/GroupDataList_test.js
+++ b/test/components/bucket/GroupDataList_test.js
@@ -1,0 +1,75 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import {
+  DataList,
+  ListActions,
+} from "../../../src/components/bucket/GroupDataList";
+import { canEditBucket } from "../../../src/permission";
+
+jest.mock("../../../src/permission", () => {
+  return {
+    __esModule: true,
+    canEditBucket: jest.fn(),
+  };
+});
+
+// to avoid rendering a router around everything, allows for more focused testing
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Link: "a",
+  };
+});
+
+describe("Bucket GroupDataList", () => {
+  const props = {
+    bid: "test",
+    groups: [
+      {
+        members: ["memberB-1", "memberB-2"],
+        id: "groupB",
+        last_modified: 1699997111073,
+      },
+      {
+        members: ["memberA-1", "memberA-2"],
+        id: "groupA",
+        last_modified: 1699997106916,
+      },
+    ],
+    capabilities: {},
+  };
+
+  it("Should render a list of groups as expected", () => {
+    const result = render(<DataList {...props} />);
+    expect(result.queryByText("groupA")).toBeDefined();
+    expect(result.queryByText("groupB")).toBeDefined();
+    expect(result.queryByText("memberA-1, memberA-2")).toBeDefined();
+    expect(result.queryByText("memberB-1, memberB-2")).toBeDefined();
+  });
+});
+
+describe("Bucket GroupListActions", () => {
+  const props = {
+    bid: "test-bucket",
+    session: {
+      busy: false,
+    },
+    bucket: {
+      busy: false,
+    },
+  };
+
+  it("Should render a Create Group button when the user has permission", () => {
+    canEditBucket.mockReturnValue(true);
+    const result = render(<ListActions {...props} />);
+    expect(result.queryByText("Create group")).toBeDefined();
+  });
+
+  it("Should render no Create Group button when the user lacks permission", () => {
+    canEditBucket.mockReturnValue(false);
+    const result = render(<ListActions {...props} />);
+    expect(result.queryByText("Create group")).toBeNull();
+  });
+});


### PR DESCRIPTION
This PR fixes [issue 633](https://github.com/Kinto/kinto-admin/issues/633).

1. Does not render a "Create collection" button of the user lacks permissions to do create a collection on this bucket
2. Does not render a "Create group" button if the user lacks permissions to edit this bucket
3. Renders a better error if the user happens to land on the Create collection page with a direct link.


With permission:
![image](https://github.com/Kinto/kinto-admin/assets/148472676/c4335c57-c99e-4ed6-be77-c78e0cca0970)

Without permission:
![image](https://github.com/Kinto/kinto-admin/assets/148472676/233d16c0-fc9b-4597-8850-6da80747c6f3)

Better error message:
![image](https://github.com/Kinto/kinto-admin/assets/148472676/fa23a781-2195-4644-b9fa-983f0b2985f5)
