### PR TITLE
Fixes 621 - Allow users to create/edit collections without displayFields

### DIFF
--- a/src/components/collection/CollectionForm.tsx
+++ b/src/components/collection/CollectionForm.tsx
@@ -81,7 +81,7 @@ const schema: RJSFSchema = {
       title: "Records list columns",
       description: "fields to list in the record list table",
       default: ["title"],
-      minItems: 1,
+      minItems: 0,
       items: {
         type: "string",
         minLength: 1,
@@ -194,8 +194,7 @@ const uiSchema = {
     "ui:help": (
       <p>
         This field allows defining the record object properties to display as
-        columns in the main records list table. You must define at least one
-        display field.
+        columns in the main records list table.
       </p>
     ),
   },

--- a/src/components/collection/CollectionRecords.tsx
+++ b/src/components/collection/CollectionRecords.tsx
@@ -117,7 +117,9 @@ export default function CollectionRecords(props: Props) {
             listNextRecords={listNextRecords}
             currentSort={currentSort}
             schema={schema || {}}
-            displayFields={displayFields || ["id", "__json"]}
+            displayFields={
+              displayFields?.length ? displayFields : ["id", "__json"]
+            }
             deleteRecord={deleteRecord}
             updateSort={updateSort}
             redirectTo={redirectTo}

--- a/test/components/CollectionRecords_test.js
+++ b/test/components/CollectionRecords_test.js
@@ -1,4 +1,4 @@
-import { createComponent, renderWithProvider } from "../test_utils";
+import { renderWithProvider } from "../test_utils";
 import CollectionRecords from "../../src/components/collection/CollectionRecords";
 import * as React from "react";
 
@@ -105,7 +105,7 @@ describe("CollectionRecords component", () => {
     };
 
     beforeEach(() => {
-      node = createComponent(
+      node = renderWithProvider(
         <CollectionRecords
           match={{ params: { bid: "bucket", cid: "collection" } }}
           session={{
@@ -117,7 +117,7 @@ describe("CollectionRecords component", () => {
           capabilities={capabilities}
           listRecords={() => {}}
         />
-      );
+      ).container;
     });
 
     it("should render a table", () => {
@@ -138,7 +138,9 @@ describe("CollectionRecords component", () => {
 
     const collection = {
       busy: false,
-      data: {},
+      data: {
+        displayFields: [],
+      },
       permissions: {
         write: [],
       },
@@ -155,7 +157,7 @@ describe("CollectionRecords component", () => {
     };
 
     beforeEach(() => {
-      node = createComponent(
+      node = renderWithProvider(
         <CollectionRecords
           match={{ params: { bid: "bucket", cid: "collection" } }}
           session={{
@@ -167,7 +169,7 @@ describe("CollectionRecords component", () => {
           capabilities={capabilities}
           listRecords={() => {}}
         />
-      );
+      ).container;
     });
 
     it("should render a table", () => {
@@ -202,7 +204,7 @@ describe("CollectionRecords component", () => {
     };
 
     beforeEach(() => {
-      node = createComponent(
+      node = renderWithProvider(
         <CollectionRecords
           match={{ params: { bid: "bucket", cid: "collection" } }}
           session={{}}
@@ -211,7 +213,7 @@ describe("CollectionRecords component", () => {
           capabilities={capabilities}
           listRecords={() => {}}
         />
-      );
+      ).container;
     });
 
     it("should show the total number of records", () => {
@@ -244,7 +246,7 @@ describe("CollectionRecords component", () => {
       let node;
 
       beforeEach(() => {
-        node = createComponent(
+        node = renderWithProvider(
           <CollectionRecords
             match={{ params: { bid: "bucket", cid: "collection" } }}
             session={{ permissions: null }}
@@ -253,7 +255,7 @@ describe("CollectionRecords component", () => {
             capabilities={capabilities}
             listRecords={() => {}}
           />
-        );
+        ).container;
       });
 
       it("should render list actions", () => {
@@ -270,7 +272,7 @@ describe("CollectionRecords component", () => {
       let node;
 
       beforeEach(() => {
-        node = createComponent(
+        node = renderWithProvider(
           <CollectionRecords
             match={{ params: { bid: "bucket", cid: "collection" } }}
             session={{ permissions: [] }}
@@ -279,7 +281,7 @@ describe("CollectionRecords component", () => {
             capabilities={capabilities}
             listRecords={() => {}}
           />
-        );
+        ).container;
       });
 
       it("should not render list actions", () => {


### PR DESCRIPTION
Fixes [issue 621](https://github.com/Kinto/kinto-admin/issues/621) by:
1. Allowing users to create and edit collections without displayFields objects defined (reduced minimum array size and updated validation message)
2. Fixed collection records default display columns to work when an empty array or a nullish object are passed in

![image](https://github.com/Kinto/kinto-admin/assets/148472676/5d31da41-0253-4036-859d-70368af5f222)

![image](https://github.com/Kinto/kinto-admin/assets/148472676/a375aa1d-c1ff-4ce9-a1fe-80402012e37f)
