### PR TITLE
Fixes issue #3059 - scroll to first validation error on BaseForm

### DIFF
--- a/src/components/BaseForm.tsx
+++ b/src/components/BaseForm.tsx
@@ -41,7 +41,6 @@ export default function BaseForm(props: BaseFormProps) {
       <FormWithTheme
         {...restProps}
         focusOnFirstError={errorFocus}
-        error
         className={`rjsf ${className ? className : ""}`}
         validator={validator}
         onSubmit={handleOnSubmit}

--- a/src/components/BaseForm.tsx
+++ b/src/components/BaseForm.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { withTheme, FormProps } from "@rjsf/core";
 import { Theme as Bootstrap4Theme } from "@rjsf/bootstrap-4";
 import validator from "@rjsf/validator-ajv8";
-import { RJSFSchema } from "@rjsf/utils";
+import { RJSFSchema, RJSFValidationError } from "@rjsf/utils";
 
 import TagsField from "./TagsField";
 import Spinner from "./Spinner";
@@ -18,6 +18,7 @@ export type BaseFormProps = Omit<FormProps, "validator"> & {
 
 export default function BaseForm(props: BaseFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const formRef = useRef(null);
   const { className, disabled, showSpinner, onSubmit, ...restProps } = props;
 
   const handleOnSubmit = form => {
@@ -25,10 +26,22 @@ export default function BaseForm(props: BaseFormProps) {
     onSubmit(form);
   };
 
+  const errorFocus = (err: RJSFValidationError) => {
+    if (err?.property !== ".") {
+      formRef.current
+        .querySelector(`[for="root${err.property.replace(/\./g, "_")}"]`)
+        .scrollIntoView({ behavior: "auto", block: "center" });
+    } else {
+      formRef.current.scrollIntoView({ behavior: "auto", block: "start" });
+    }
+  };
+
   return (
-    <div className="formWrapper">
+    <div className="formWrapper" ref={formRef} data-testid="formWrapper">
       <FormWithTheme
         {...restProps}
+        focusOnFirstError={errorFocus}
+        error
         className={`rjsf ${className ? className : ""}`}
         validator={validator}
         onSubmit={handleOnSubmit}

--- a/test/components/BaseForm_test.js
+++ b/test/components/BaseForm_test.js
@@ -148,6 +148,7 @@ describe("BaseForm component", () => {
     titleLabel.scrollIntoView = testFn;
     fireEvent.click(submit);
     expect(testFn).toHaveBeenCalledTimes(1);
+    expect(result.container.querySelector(`[for="root_title"]`)).not.toBeNull();
   });
 
   it("Should scroll to the top of the form if validation failed without a specific property", async () => {

--- a/test/components/BaseForm_test.js
+++ b/test/components/BaseForm_test.js
@@ -127,4 +127,48 @@ describe("BaseForm component", () => {
     expect(submit.disabled).toBe(true);
     expect(result.queryByTestId("spinner")).toBeDefined();
   });
+
+  it("Should scroll to the first property that fails validation", async () => {
+    const result = render(
+      <BaseForm
+        className="testClass"
+        schema={testSchema}
+        uiSchema={testUiSchema}
+        onSubmit={jest.fn()}
+        customValidate={(data, errors) => {
+          errors.title.addError("test error");
+          return errors;
+        }}
+      />
+    );
+    const testFn = jest.fn();
+
+    const submit = await result.findByText("Submit");
+    const titleLabel = await result.findByText("Title");
+    titleLabel.scrollIntoView = testFn;
+    fireEvent.click(submit);
+    expect(testFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("Should scroll to the top of the form if validation failed without a specific property", async () => {
+    const result = render(
+      <BaseForm
+        className="testClass"
+        schema={testSchema}
+        uiSchema={testUiSchema}
+        onSubmit={jest.fn()}
+        customValidate={(data, errors) => {
+          errors.addError("test error");
+          return errors;
+        }}
+      />
+    );
+    const testFn = jest.fn();
+
+    const submit = await result.findByText("Submit");
+    const formWrapper = await result.findByTestId("formWrapper");
+    formWrapper.scrollIntoView = testFn;
+    fireEvent.click(submit);
+    expect(testFn).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Fixes [issue 3059](https://github.com/Kinto/kinto-admin/issues/3059). When a user receives a validation error for a specific property, it will now scroll and center the label for that property in their view. 

If an error is thrown for the form rather than a specific property, it will scroll to the top of the form where the full errors list appears.


[demo video](https://github.com/Kinto/kinto-admin/assets/148472676/6902e40d-6221-457e-8318-9944e3cdedc0)

