### PR TITLE
Fixes issue #2269 - Using simple-review as default review process

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -197,6 +197,22 @@ table.record-list td.load-more {
   text-decoration: none;
 }
 
+.card-body > .spinner {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.2);
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: auto;
+  margin: 0;
+  border-radius: 3px;
+}
+
 .load-more .spinner {
   margin-top: 0.25em;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@rjsf/bootstrap-4": "^5.13.2",
         "@rjsf/core": "^5.13.2",
         "@rjsf/validator-ajv8": "^5.13.2",
+        "@testing-library/react-hooks": "^8.0.1",
         "atob": "^2.0.3",
         "bootstrap": "^4.6.2",
         "bootstrap-icons": "^1.11.1",
@@ -4031,6 +4032,35 @@
       "peerDependencies": {
         "react": "<18.0.0",
         "react-dom": "<18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-test-renderer": "^16.9.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tootallnate/once": {
@@ -13301,6 +13331,21 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -18974,6 +19019,15 @@
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0",
         "@types/react-dom": "<18.0.0"
+      }
+    },
+    "@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
       }
     },
     "@tootallnate/once": {
@@ -25928,6 +25982,14 @@
             "object-assign": "^4.1.1"
           }
         }
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@rjsf/bootstrap-4": "^5.13.2",
     "@rjsf/core": "^5.13.2",
     "@rjsf/validator-ajv8": "^5.13.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "atob": "^2.0.3",
     "bootstrap": "^4.6.2",
     "bootstrap-icons": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinto-admin",
-  "version": "2.0.0",
+  "version": "2.1.0-dev",
   "description": "Kinto Web Administration Console in React.js",
   "scripts": {
     "build": "rimraf build && cross-env NODE_ENV=production webpack --progress --config webpack.prod.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinto-admin",
-  "version": "2.1.0-dev",
+  "version": "2.1.0",
   "description": "Kinto Web Administration Console in React.js",
   "scripts": {
     "build": "rimraf build && cross-env NODE_ENV=production webpack --progress --config webpack.prod.js",

--- a/src/components/BaseForm.tsx
+++ b/src/components/BaseForm.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { withTheme, FormProps } from "@rjsf/core";
 import { Theme as Bootstrap4Theme } from "@rjsf/bootstrap-4";
 import validator from "@rjsf/validator-ajv8";
-import { RJSFSchema } from "@rjsf/utils";
+import { RJSFSchema, RJSFValidationError } from "@rjsf/utils";
 
 import TagsField from "./TagsField";
 import Spinner from "./Spinner";
@@ -18,6 +18,7 @@ export type BaseFormProps = Omit<FormProps, "validator"> & {
 
 export default function BaseForm(props: BaseFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const formRef = useRef(null);
   const { className, disabled, showSpinner, onSubmit, ...restProps } = props;
 
   const handleOnSubmit = form => {
@@ -25,10 +26,21 @@ export default function BaseForm(props: BaseFormProps) {
     onSubmit(form);
   };
 
+  const errorFocus = (err: RJSFValidationError) => {
+    if (err?.property !== ".") {
+      formRef.current
+        .querySelector(`[for="root${err.property.replace(/\./g, "_")}"]`)
+        .scrollIntoView({ behavior: "auto", block: "center" });
+    } else {
+      formRef.current.scrollIntoView({ behavior: "auto", block: "start" });
+    }
+  };
+
   return (
-    <div className="formWrapper">
+    <div className="formWrapper" ref={formRef} data-testid="formWrapper">
       <FormWithTheme
         {...restProps}
+        focusOnFirstError={errorFocus}
         className={`rjsf ${className ? className : ""}`}
         validator={validator}
         onSubmit={handleOnSubmit}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -9,7 +9,7 @@ import Spinner from "./Spinner";
 import AuthForm from "./AuthForm";
 import { getServerByPriority, isObject } from "../utils";
 import { loadSession } from "../store/localStore";
-import { useAppDispatch, useAppSelector } from "../hooks";
+import { useAppDispatch, useAppSelector } from "../hooks/app";
 import { useParams } from "react-router";
 
 function ServerProps({ node }: { node: any }) {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -30,7 +30,7 @@ import { Sidebar } from "../components/Sidebar";
 import Notifications from "../containers/Notifications";
 
 import { SessionInfoBar } from "./SessionInfoBar";
-import { useAppSelector } from "../hooks";
+import { useAppSelector } from "../hooks/app";
 
 export function Layout() {
   const authenticated = useAppSelector(store => store.session.authenticated);

--- a/src/components/PermissionsForm.tsx
+++ b/src/components/PermissionsForm.tsx
@@ -9,7 +9,7 @@ import {
   preparePermissionsForm,
 } from "../permission";
 import { useParams } from "react-router";
-import { useAppSelector } from "../hooks";
+import { useAppSelector } from "../hooks/app";
 
 import { RJSFSchema } from "@rjsf/utils";
 

--- a/src/components/SessionInfoBar.tsx
+++ b/src/components/SessionInfoBar.tsx
@@ -3,7 +3,7 @@ import { BoxArrowRight } from "react-bootstrap-icons";
 import { QuestionCircleFill } from "react-bootstrap-icons";
 import { Clipboard } from "react-bootstrap-icons";
 
-import { useAppSelector, useAppDispatch } from "../hooks";
+import { useAppSelector, useAppDispatch } from "../hooks/app";
 import * as SessionActions from "../actions/session";
 
 export function SessionInfoBar() {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,7 +19,7 @@ import AdminLink from "./AdminLink";
 import url from "../url";
 import { canCreateBucket } from "../permission";
 import { SIDEBAR_MAX_LISTED_COLLECTIONS } from "../constants";
-import { useAppSelector, useAppDispatch } from "../hooks";
+import { useAppSelector, useAppDispatch } from "../hooks/app";
 
 type SideBarLinkProps = {
   currentPath: string;

--- a/src/components/bucket/BucketForm.tsx
+++ b/src/components/bucket/BucketForm.tsx
@@ -53,7 +53,7 @@ export default function BucketForm({
   onSubmit,
 }: Props) {
   const creation = !formData.id;
-  const hasWriteAccess = canEditBucket(session, bucket);
+  const hasWriteAccess = canEditBucket(session, bid);
   const formIsEditable = creation || hasWriteAccess;
   const showDeleteForm = !creation && hasWriteAccess;
 

--- a/src/components/bucket/BucketPermissions.tsx
+++ b/src/components/bucket/BucketPermissions.tsx
@@ -9,7 +9,7 @@ import { PermissionsForm } from "../PermissionsForm";
 import { canEditBucket } from "../../permission";
 import { useParams } from "react-router";
 
-import { useAppSelector, useAppDispatch } from "../../hooks";
+import { useAppSelector, useAppDispatch } from "../../hooks/app";
 
 export function BucketPermissions() {
   const dispatch = useAppDispatch();
@@ -38,7 +38,7 @@ export function BucketPermissions() {
         <PermissionsForm
           permissions={permissions}
           acls={acls}
-          readonly={!canEditBucket(session, bucket)}
+          readonly={!canEditBucket(session, bid)}
           onSubmit={onSubmit}
         />
       </BucketTabs>

--- a/src/components/bucket/CollectionDataList.tsx
+++ b/src/components/bucket/CollectionDataList.tsx
@@ -9,7 +9,7 @@ import { canCreateCollection } from "../../permission";
 
 export function ListActions(props) {
   const { bid, session, bucket } = props;
-  if (session.busy || bucket.busy || !canCreateCollection(session, bucket)) {
+  if (session.busy || bucket.busy || !canCreateCollection(session, bid)) {
     return null;
   }
   return (

--- a/src/components/bucket/GroupDataList.tsx
+++ b/src/components/bucket/GroupDataList.tsx
@@ -67,7 +67,7 @@ export function DataList(props) {
 }
 
 export function ListActions({ bid, session, bucket }) {
-  if (session.busy || bucket.busy || !canCreateGroup(session, bucket)) {
+  if (session.busy || bucket.busy || !canCreateGroup(session, bid)) {
     return null;
   }
   return (

--- a/src/components/collection/CollectionForm.tsx
+++ b/src/components/collection/CollectionForm.tsx
@@ -247,8 +247,8 @@ export default function CollectionForm({
 }: Props) {
   const [asJSON, setAsJSON] = useState(false);
   const allowEditing = propFormData
-    ? canEditCollection(session, bucket, collection)
-    : canCreateCollection(session, bucket);
+    ? canEditCollection(session, bucket?.data?.id, collection)
+    : canCreateCollection(session, bucket?.data?.id);
 
   const toggleJSON = event => {
     event.preventDefault();

--- a/src/components/collection/CollectionPermissions.tsx
+++ b/src/components/collection/CollectionPermissions.tsx
@@ -8,7 +8,7 @@ import CollectionTabs from "./CollectionTabs";
 import { PermissionsForm } from "../PermissionsForm";
 import { canEditCollection } from "../../permission";
 import { useParams } from "react-router";
-import { useAppSelector, useAppDispatch } from "../../hooks";
+import { useAppSelector, useAppDispatch } from "../../hooks/app";
 interface RouteParams {
   bid: string;
   cid: string;
@@ -17,7 +17,6 @@ interface RouteParams {
 export function CollectionPermissions() {
   const { bid, cid } = useParams<RouteParams>();
   const session = useAppSelector(state => state.session);
-  const bucket = useAppSelector(state => state.bucket);
   const collection = useAppSelector(state => state.collection);
   const { busy, permissions } = collection;
   const acls = ["read", "write", "record:create"];
@@ -50,7 +49,7 @@ export function CollectionPermissions() {
         <PermissionsForm
           permissions={permissions}
           acls={acls}
-          readonly={!canEditCollection(session, bucket, collection)}
+          readonly={!canEditCollection(session, bid, collection)}
           onSubmit={onSubmit}
         />
       </CollectionTabs>

--- a/src/components/collection/CollectionRecords.tsx
+++ b/src/components/collection/CollectionRecords.tsx
@@ -142,6 +142,10 @@ export default function CollectionRecords(props: Props) {
             onClick={() => {
               setUseSimpleReview(true);
             }}
+            style={{
+              float: "right",
+              marginTop: "1.5em",
+            }}
           >
             <Shuffle className="icon" /> Switch to Default Review UI
           </AdminLink>

--- a/src/components/collection/CollectionRecords.tsx
+++ b/src/components/collection/CollectionRecords.tsx
@@ -15,6 +15,9 @@ import { CommonProps, CommonStateProps } from "./commonPropTypes";
 
 import * as CollectionActions from "../../actions/collection";
 import * as RouteActions from "../../actions/route";
+import AdminLink from "../AdminLink";
+import { storageKeys, useLocalStorage } from "../../hooks/storage";
+import { Shuffle } from "react-bootstrap-icons";
 
 type OwnProps = {
   match: CollectionRouteMatch;
@@ -71,6 +74,10 @@ export default function CollectionRecords(props: Props) {
   } = collection;
   const { schema, displayFields } = data;
 
+  const [useSimpleReview, setUseSimpleReview] = useLocalStorage(
+    storageKeys.useSimpleReview,
+    true
+  );
   useEffect(() => {
     if (!session.authenticated || !data?.last_modified) {
       return;
@@ -127,6 +134,18 @@ export default function CollectionRecords(props: Props) {
           />
         )}
         {listActions}
+        {capabilities.signer && !useSimpleReview && (
+          <AdminLink
+            className="btn btn-secondary"
+            params={{ bid, cid }}
+            name="collection:simple-review"
+            onClick={() => {
+              setUseSimpleReview(true);
+            }}
+          >
+            <Shuffle className="icon" /> Switch to Default Review UI
+          </AdminLink>
+        )}
       </CollectionTabs>
     </div>
   );

--- a/src/components/collection/CollectionTabs.tsx
+++ b/src/components/collection/CollectionTabs.tsx
@@ -1,13 +1,25 @@
 import React from "react";
-import { Gear, Lock, Justify, ClockHistory } from "react-bootstrap-icons";
+import {
+  Gear,
+  Lock,
+  Justify,
+  ClockHistory,
+  Braces,
+} from "react-bootstrap-icons";
 
 import AdminLink from "../AdminLink";
 import type { Capabilities } from "../../types";
+import { storageKeys, useLocalStorage } from "../../hooks/storage";
 
 type Props = {
   bid: string;
   cid: string;
-  selected: "records" | "attributes" | "permissions" | "history";
+  selected:
+    | "records"
+    | "attributes"
+    | "permissions"
+    | "history"
+    | "simple-review";
   capabilities: Capabilities;
   children?: React.ReactNode;
   totalRecords?: number | null;
@@ -21,6 +33,8 @@ export default function CollectionTabs({
   children,
   totalRecords,
 }: Props) {
+  const [useSimpleReview] = useLocalStorage(storageKeys.useSimpleReview, true);
+
   return (
     <div className="card">
       <div className="card-header">
@@ -37,6 +51,20 @@ export default function CollectionTabs({
               Records {totalRecords ? `(${totalRecords})` : null}
             </AdminLink>
           </li>
+          {capabilities.signer && useSimpleReview && (
+            <li className="nav-item" role="presentation">
+              <AdminLink
+                name="collection:simple-review"
+                params={{ bid, cid }}
+                className={
+                  selected === "simple-review" ? "nav-link active" : "nav-link"
+                }
+              >
+                <Braces className="icon" />
+                Review
+              </AdminLink>
+            </li>
+          )}
           <li className="nav-item" role="presentation">
             <AdminLink
               name="collection:attributes"

--- a/src/components/collection/RecordTable.tsx
+++ b/src/components/collection/RecordTable.tsx
@@ -17,13 +17,13 @@ import SignoffContainer from "../../containers/signoff/SignoffToolBar";
 import { CommonProps } from "./commonPropTypes";
 
 export function ListActions(props) {
-  const { bid, cid, session, bucket, collection } = props;
+  const { bid, cid, session, collection } = props;
   if (session.busy || collection.busy) {
     return null;
   }
   return (
     <div className="list-actions">
-      {canCreateRecord(session, bucket, collection) && (
+      {canCreateRecord(session, bid, collection) && (
         <>
           <AdminLink
             key="__1"

--- a/src/components/group/GroupForm.tsx
+++ b/src/components/group/GroupForm.tsx
@@ -86,8 +86,8 @@ export default function GroupForm(props: Props) {
 
   const creation = !formData.id;
   const hasWriteAccess = creation
-    ? canCreateGroup(session, bucket)
-    : canEditGroup(session, bucket, group);
+    ? canCreateGroup(session, bucket.data.id)
+    : canEditGroup(session, bucket.data.id, group);
   const formIsEditable = creation || hasWriteAccess;
   const showDeleteForm = !creation && hasWriteAccess;
 

--- a/src/components/group/GroupPermissions.tsx
+++ b/src/components/group/GroupPermissions.tsx
@@ -10,11 +10,10 @@ import Spinner from "../Spinner";
 import GroupTabs from "./GroupTabs";
 import { PermissionsForm } from "../PermissionsForm";
 import { canEditGroup } from "../../permission";
-import { useAppSelector, useAppDispatch } from "../../hooks";
+import { useAppSelector, useAppDispatch } from "../../hooks/app";
 import { useParams } from "react-router";
 
 export function GroupPermissions() {
-  const bucket = useAppSelector(state => state.bucket);
   const group = useAppSelector(state => state.group);
   const { busy, permissions } = group;
   const session = useAppSelector(state => state.session);
@@ -45,7 +44,7 @@ export function GroupPermissions() {
         <PermissionsForm
           permissions={permissions}
           acls={["read", "write"]}
-          readonly={!canEditGroup(session, bucket, group)}
+          readonly={!canEditGroup(session, bid, group)}
           onSubmit={onSubmit}
         />
       </GroupTabs>

--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import type {
   SessionState,
-  BucketState,
   CollectionState,
   RecordState,
   Capabilities,
@@ -52,7 +51,6 @@ type Props = {
   cid: string;
   rid?: string;
   session: SessionState;
-  bucket: BucketState;
   collection: CollectionState;
   record?: RecordState;
   deleteRecord?: typeof CollectionActions.deleteRecord;
@@ -68,7 +66,6 @@ export default function RecordForm(props: Props) {
     bid,
     cid,
     session,
-    bucket,
     collection,
     record,
     deleteRecord,
@@ -77,8 +74,8 @@ export default function RecordForm(props: Props) {
   } = props;
 
   const allowEditing = record
-    ? canEditRecord(session, bucket, collection, record)
-    : canCreateRecord(session, bucket, collection);
+    ? canEditRecord(session, bid, collection, record)
+    : canCreateRecord(session, bid, collection);
 
   const handleDeleteRecord = () => {
     const { rid } = props;

--- a/src/components/record/RecordPermissions.tsx
+++ b/src/components/record/RecordPermissions.tsx
@@ -6,7 +6,7 @@ import RecordTabs from "./RecordTabs";
 import { PermissionsForm } from "../PermissionsForm";
 import { canEditRecord } from "../../permission";
 import { useParams } from "react-router";
-import { useAppSelector, useAppDispatch } from "../../hooks";
+import { useAppSelector, useAppDispatch } from "../../hooks/app";
 
 interface RouteParams {
   bid: string;
@@ -14,7 +14,6 @@ interface RouteParams {
   rid: string;
 }
 export function RecordPermissions() {
-  const bucket = useAppSelector(state => state.bucket);
   const session = useAppSelector(state => state.session);
   const collection = useAppSelector(state => state.collection);
   const record = useAppSelector(state => state.record);
@@ -50,7 +49,7 @@ export function RecordPermissions() {
         <PermissionsForm
           permissions={permissions}
           acls={acls}
-          readonly={!canEditRecord(session, bucket, collection, record)}
+          readonly={!canEditRecord(session, bid, collection, record)}
           onSubmit={onSubmit}
         />
       </RecordTabs>

--- a/src/components/signoff/Review.tsx
+++ b/src/components/signoff/Review.tsx
@@ -3,12 +3,12 @@ import type { SignoffSourceInfo, PreviewInfo, ChangesList } from "../../types";
 import React from "react";
 import { Comment } from "./Comment";
 
-import { ChatLeft } from "react-bootstrap-icons";
-import { Check2 } from "react-bootstrap-icons";
+import { Braces, ChatLeft, Check2 } from "react-bootstrap-icons";
 
 import AdminLink from "../AdminLink";
 import { ProgressStep } from "./ProgressBar";
 import HumanDate from "./HumanDate";
+import { storageKeys, useLocalStorage } from "../../hooks/storage";
 
 type ReviewProps = {
   label: string;
@@ -24,20 +24,20 @@ type ReviewProps = {
   changes: ChangesList | null;
 };
 
-export function Review(props: ReviewProps) {
-  const {
-    label,
-    canEdit,
-    hasHistory,
-    currentStep,
-    step,
-    isCurrentUrl,
-    approveChanges,
-    confirmDeclineChanges,
-    source,
-    preview,
-    changes,
-  } = props;
+export function Review({
+  label,
+  canEdit,
+  hasHistory,
+  currentStep,
+  step,
+  isCurrentUrl,
+  approveChanges,
+  confirmDeclineChanges,
+  source,
+  preview,
+  changes,
+}: ReviewProps) {
+  const [useSimpleReview] = useLocalStorage(storageKeys.useSimpleReview, true);
   const isCurrentStep = step == currentStep;
 
   // If preview disabled, the preview object is empty.
@@ -63,11 +63,20 @@ export function Review(props: ReviewProps) {
           changes={changes}
         />
       )}
-      {isCurrentStep && canEdit && (
+      {isCurrentStep && canEdit && !useSimpleReview && (
         <ReviewButtons
           onApprove={approveChanges}
           onDecline={confirmDeclineChanges}
         />
+      )}
+      {isCurrentStep && canEdit && useSimpleReview && (
+        <AdminLink
+          className="btn btn-info"
+          params={{ bid: source.bid, cid: source.cid }}
+          name="collection:simple-review"
+        >
+          <Braces className="icon" /> Review Changes
+        </AdminLink>
       )}
     </ProgressStep>
   );

--- a/src/components/signoff/SignoffToolBar.tsx
+++ b/src/components/signoff/SignoffToolBar.tsx
@@ -19,24 +19,7 @@ import HumanDate from "./HumanDate";
 import { Signed } from "./Signed";
 import { Review, DiffInfo } from "./Review";
 import Spinner from "../Spinner";
-
-function isMember(groupKey, source, sessionState) {
-  const {
-    serverInfo: { user = {}, capabilities },
-  } = sessionState;
-  if (!source || !user.principals) {
-    return false;
-  }
-  const { principals } = user;
-  const { bid, cid } = source;
-  const { signer = {} } = capabilities;
-  const { [groupKey]: defaultGroupName } = signer;
-  const { [groupKey]: groupName = defaultGroupName } = source;
-  const expectedGroup = groupName.replace("{collection_id}", cid);
-  const expectedPrincipal = `/buckets/${bid}/groups/${expectedGroup}`;
-
-  return principals.includes(expectedPrincipal);
-}
+import { isMember } from "./utils";
 
 function isEditor(source, sessionState) {
   return isMember("editors_group", source, sessionState);
@@ -99,11 +82,11 @@ export default function SignoffToolBar({
     }
   }, [collectionState.data]);
 
-  const canEdit = canEditCollection(sessionState, bucketState, collectionState);
-
   const {
     data: { id: bid },
   } = bucketState;
+
+  const canEdit = canEditCollection(sessionState, bid, collectionState);
 
   const {
     data: { id: cid },
@@ -187,7 +170,6 @@ export default function SignoffToolBar({
       {canRollback && status != "signed" && (
         <RollbackChangesButton onClick={confirmRollbackChanges} />
       )}
-
       {pendingConfirmReviewRequest && (
         <CommentDialog
           description="Leave some notes for the reviewer:"
@@ -327,7 +309,7 @@ function RequestReviewButton(props: { onClick: () => void }) {
 function RollbackChangesButton(props: { onClick: () => void }) {
   const { onClick } = props;
   return (
-    <button className="btn btn-info rollback-changes" onClick={onClick}>
+    <button className="btn btn-danger rollback-changes" onClick={onClick}>
       <XCircleFill className="icon" /> Rollback changes...
     </button>
   );

--- a/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
+++ b/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
@@ -76,10 +76,10 @@ export default function PerRecordDiffView({
       );
     default:
       return (
-        <>
+        <div>
           No changes to review, collection status is{" "}
           <code>{collectionData.status}</code>.
-        </>
+        </div>
       );
   }
 }
@@ -179,25 +179,30 @@ export function findChangeTypes(
 
   let result: Array<RecordChange> = [];
 
-  diffArrays(
+  const differences = diffArrays(
     oldItems.map(r => r.id).sort(),
     newItems.map(r => r.id).sort()
-  ).forEach(part => {
-    const id = part.value[0];
-    if (part.added) {
-      result.push({
-        id,
-        target: newItems.find(r => r.id === id),
-        changeType: ChangeType.ADD,
-      });
-    } else if (part.removed) {
-      result.push({
-        id,
-        source: oldItems.find(r => r.id === id),
-        changeType: ChangeType.REMOVE,
-      });
+  );
+
+  for (let d of differences) {
+    if (d.added) {
+      for (let id of d.value) {
+        result.push({
+          id,
+          target: newItems.find(r => r.id === id),
+          changeType: ChangeType.ADD,
+        });
+      }
+    } else if (d.removed) {
+      for (let id of d.value) {
+        result.push({
+          id,
+          source: oldItems.find(r => r.id === id),
+          changeType: ChangeType.REMOVE,
+        });
+      }
     }
-  });
+  }
 
   newItems.forEach(item => {
     const matchingOldItem = oldItems.find(r => r.id === item.id);

--- a/src/components/signoff/SimpleReview/SimpleReviewButtons.tsx
+++ b/src/components/signoff/SimpleReview/SimpleReviewButtons.tsx
@@ -35,11 +35,14 @@ export default function SimpleReviewButtons({
   return (
     <>
       <div className="simple-review-buttons">
-        {status === "to-review" && (
+        {status === "to-review" && canReview && (
           <>
             <button
               className="btn btn-success"
-              onClick={() => approveChanges()}
+              onClick={() => {
+                setShowSpinner(true);
+                approveChanges();
+              }}
             >
               <Check2 className="icon" /> Approve...
             </button>{" "}
@@ -61,7 +64,7 @@ export default function SimpleReviewButtons({
             <ChatLeft className="icon" /> Request review...
           </button>
         )}{" "}
-        {canReview &&
+        {canRequestReview &&
           ["work-in-progress", "to-review"].includes(status) &&
           !searchParams.hideRollback && (
             <button

--- a/src/components/signoff/SimpleReview/SimpleReviewHeader.tsx
+++ b/src/components/signoff/SimpleReview/SimpleReviewHeader.tsx
@@ -7,6 +7,8 @@ export default function SimpleReviewHeader({
   lastReviewRequestBy,
   lastReviewerComment,
   children,
+  lastEditDate,
+  lastReviewDate,
 }: SignoffSourceInfo & { children?: React.ReactElement }) {
   return (
     <div className="simple-review-header">
@@ -20,7 +22,9 @@ export default function SimpleReviewHeader({
         {status === "work-in-progress" && (
           <div className="card-header">
             Status is <code>{status}</code>.{" "}
-            {lastReviewerComment && "Most recent reviewer comment was:"}
+            {lastReviewerComment &&
+              lastEditDate < lastReviewDate &&
+              "Most recent reviewer comment was:"}
           </div>
         )}
         <div className="card-body">
@@ -29,7 +33,7 @@ export default function SimpleReviewHeader({
               {lastEditorComment || "(No comment was left by the author)"}
             </p>
           )}
-          {status === "work-in-progress" && (
+          {status === "work-in-progress" && lastEditDate < lastReviewDate && (
             <p className="card-text">
               {lastReviewerComment || "(No comment was left by a reviewer)"}
             </p>

--- a/src/components/signoff/utils.ts
+++ b/src/components/signoff/utils.ts
@@ -1,0 +1,25 @@
+import { SessionState, SignoffSourceInfo } from "../../types";
+
+export function isMember(
+  groupKey: string,
+  source: SignoffSourceInfo,
+  sessionState: SessionState
+) {
+  const {
+    serverInfo: { user, capabilities },
+  } = sessionState;
+  if (!source || !user?.principals) {
+    return false;
+  }
+  const { principals } = user;
+  const { bid, cid } = source;
+  const { signer = {} } = capabilities;
+  // @ts-ignore
+  const { [groupKey]: defaultGroupName } = signer;
+  // @ts-ignore
+  const { [groupKey]: groupName = defaultGroupName } = source;
+  const expectedGroup = groupName.replace("{collection_id}", cid);
+  const expectedPrincipal = `/buckets/${bid}/groups/${expectedGroup}`;
+
+  return principals.includes(expectedPrincipal);
+}

--- a/src/containers/signoff/SimpleReviewPage.ts
+++ b/src/containers/signoff/SimpleReviewPage.ts
@@ -25,6 +25,8 @@ function mapStateToProps(
   return {
     session: state.session,
     signoff: state.signoff,
+    collection: state.collection,
+    capabilities: state.session.serverInfo.capabilities,
     fetchRecords,
   };
 }

--- a/src/hooks/app.ts
+++ b/src/hooks/app.ts
@@ -1,5 +1,5 @@
 import { TypedUseSelectorHook, useSelector, useDispatch } from "react-redux";
-import type { AppDispatch, AppState } from "./types";
+import type { AppDispatch, AppState } from "../types";
 
 export const useAppSelector: TypedUseSelectorHook<AppState> = useSelector;
 export const useAppDispatch = () => useDispatch<AppDispatch>();

--- a/src/hooks/storage.ts
+++ b/src/hooks/storage.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from "react";
+
+export const storageKeys = {
+  useSimpleReview: "useSimpleReview",
+};
+
+export function useLocalStorage(key: string, initialValue: any) {
+  const [val, setVal] = useState(() => {
+    try {
+      return localStorage[key] ? JSON.parse(localStorage[key]) : initialValue;
+    } catch (ex) {
+      console.error("Error retrieving value from localStorage", ex);
+      return initialValue;
+    }
+  });
+
+  const setStoredVal = val => {
+    try {
+      localStorage[key] = JSON.stringify(val);
+      setVal(val);
+    } catch (ex) {
+      console.error("Error setting value in localStorage", ex);
+    }
+  };
+
+  useEffect(() => {
+    // will fire if localStorage is touched in another browser tab/window
+    const handleStorageChange = (evt: StorageEvent) => {
+      if (evt.key !== key) {
+        return;
+      }
+      setVal(evt.newValue ? JSON.parse(evt.newValue) : undefined);
+    };
+    window.addEventListener("storage", handleStorageChange);
+
+    return () => window.removeEventListener("storage", handleStorageChange);
+  }, [key]);
+
+  return [val, setStoredVal];
+}

--- a/src/permission.tsx
+++ b/src/permission.tsx
@@ -1,6 +1,5 @@
 import type {
   SessionState,
-  BucketState,
   CollectionState,
   GroupState,
   GroupData,
@@ -37,12 +36,12 @@ export function canCreateBucket(session: SessionState): boolean {
 
 export function canEditBucket(
   session: SessionState,
-  bucket: BucketState
+  bucketId: string
 ): boolean {
   return can(session, (perm: PermissionsListEntry) => {
     return (
       perm.resource_name == "bucket" &&
-      perm.bucket_id == bucket.data.id &&
+      perm.bucket_id == bucketId &&
       perm.permissions.includes("write")
     );
   });
@@ -50,12 +49,12 @@ export function canEditBucket(
 
 export function canCreateCollection(
   session: SessionState,
-  bucket: BucketState
+  bucketId: string
 ): boolean {
   return can(session, (perm: PermissionsListEntry) => {
     return (
       perm.resource_name == "bucket" &&
-      perm.bucket_id == bucket.data.id &&
+      perm.bucket_id == bucketId &&
       perm.permissions.includes("collection:create")
     );
   });
@@ -63,7 +62,7 @@ export function canCreateCollection(
 
 export function canEditCollection(
   session: SessionState,
-  bucket: BucketState,
+  bucketId: string,
   collection: CollectionState
 ): boolean {
   return can(session, (perm: PermissionsListEntry) => {
@@ -71,7 +70,7 @@ export function canEditCollection(
       (perm.resource_name == "bucket" ||
         (perm.resource_name == "collection" &&
           perm.collection_id == collection.data.id)) &&
-      perm.bucket_id == bucket.data.id &&
+      perm.bucket_id == bucketId &&
       perm.permissions.includes("write")
     );
   });
@@ -79,12 +78,12 @@ export function canEditCollection(
 
 export function canCreateGroup(
   session: SessionState,
-  bucket: BucketState
+  bucketId: string
 ): boolean {
   return can(session, (perm: PermissionsListEntry) => {
     return (
       perm.resource_name == "bucket" &&
-      perm.bucket_id == bucket.data.id &&
+      perm.bucket_id == bucketId &&
       perm.permissions.includes("group:create")
     );
   });
@@ -92,7 +91,7 @@ export function canCreateGroup(
 
 export function canEditGroup(
   session: SessionState,
-  bucket: BucketState,
+  bucketId: string,
   group: GroupState
 ): boolean {
   return can(session, (perm: PermissionsListEntry) => {
@@ -102,7 +101,7 @@ export function canEditGroup(
     return (
       (perm.resource_name == "bucket" ||
         (perm.resource_name == "group" && perm.group_id == group.data.id)) &&
-      perm.bucket_id == bucket.data.id &&
+      perm.bucket_id == bucketId &&
       perm.permissions.includes("write")
     );
   });
@@ -110,7 +109,7 @@ export function canEditGroup(
 
 export function canCreateRecord(
   session: SessionState,
-  bucket: BucketState,
+  bucketId: string,
   collection: CollectionState
 ): boolean {
   return can(session, (perm: PermissionsListEntry) => {
@@ -119,14 +118,14 @@ export function canCreateRecord(
         (perm.resource_name == "collection" &&
           perm.collection_id == collection.data.id &&
           perm.permissions.includes("record:create"))) &&
-      perm.bucket_id == bucket.data.id
+      perm.bucket_id == bucketId
     );
   });
 }
 
 export function canEditRecord(
   session: SessionState,
-  bucket: BucketState,
+  bucketId: string,
   collection: CollectionState,
   record: RecordState
 ): boolean {
@@ -139,7 +138,7 @@ export function canEditRecord(
           perm.collection_id == collection.data.id &&
           perm.record_id == record.data.id)) &&
       perm.permissions.includes("write") &&
-      perm.bucket_id == bucket.data.id
+      perm.bucket_id == bucketId
     );
   });
 }

--- a/src/url.ts
+++ b/src/url.ts
@@ -30,6 +30,8 @@ const URLS = {
     `/buckets/${bid}/collections/${cid}/history`,
   "collection:permissions": ({ bid, cid }) =>
     `/buckets/${bid}/collections/${cid}/permissions`,
+  "collection:simple-review": ({ bid, cid }) =>
+    `/buckets/${bid}/collections/${cid}/simple-review`,
   "collection:records": ({ bid, cid }) =>
     `/buckets/${bid}/collections/${cid}/records`,
 

--- a/test/components/BaseForm_test.js
+++ b/test/components/BaseForm_test.js
@@ -127,4 +127,49 @@ describe("BaseForm component", () => {
     expect(submit.disabled).toBe(true);
     expect(result.queryByTestId("spinner")).toBeDefined();
   });
+
+  it("Should scroll to the first property that fails validation", async () => {
+    const result = render(
+      <BaseForm
+        className="testClass"
+        schema={testSchema}
+        uiSchema={testUiSchema}
+        onSubmit={jest.fn()}
+        customValidate={(data, errors) => {
+          errors.title.addError("test error");
+          return errors;
+        }}
+      />
+    );
+    const testFn = jest.fn();
+
+    const submit = await result.findByText("Submit");
+    const titleLabel = await result.findByText("Title");
+    titleLabel.scrollIntoView = testFn;
+    fireEvent.click(submit);
+    expect(testFn).toHaveBeenCalledTimes(1);
+    expect(result.container.querySelector(`[for="root_title"]`)).not.toBeNull();
+  });
+
+  it("Should scroll to the top of the form if validation failed without a specific property", async () => {
+    const result = render(
+      <BaseForm
+        className="testClass"
+        schema={testSchema}
+        uiSchema={testUiSchema}
+        onSubmit={jest.fn()}
+        customValidate={(data, errors) => {
+          errors.addError("test error");
+          return errors;
+        }}
+      />
+    );
+    const testFn = jest.fn();
+
+    const submit = await result.findByText("Submit");
+    const formWrapper = await result.findByTestId("formWrapper");
+    formWrapper.scrollIntoView = testFn;
+    fireEvent.click(submit);
+    expect(testFn).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/components/signoff/SimpleReview/PerRecordDiffView_test.js
+++ b/test/components/signoff/SimpleReview/PerRecordDiffView_test.js
@@ -65,6 +65,19 @@ describe("findChangeTypes", () => {
     ]);
   });
 
+  it("should find multiple removed items", () => {
+    expect(
+      findChangeTypes(
+        [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }],
+        [{ id: "a" }]
+      )
+    ).eql([
+      { id: "b", changeType: ChangeType.REMOVE, source: { id: "b" } },
+      { id: "c", changeType: ChangeType.REMOVE, source: { id: "c" } },
+      { id: "d", changeType: ChangeType.REMOVE, source: { id: "d" } },
+    ]);
+  });
+
   it("should find updated items", () => {
     expect(
       findChangeTypes(

--- a/test/components/signoff/SimpleReview/SimpleReviewButtons_test.js
+++ b/test/components/signoff/SimpleReview/SimpleReviewButtons_test.js
@@ -48,6 +48,7 @@ describe("SimpleReviewHeader component", () => {
   it("should display rollback button when status is wip and call rollbackChanges from modal", async () => {
     const { rollbackChanges, node } = renderButtons({
       status: "work-in-progress",
+      canReview: true,
     });
     ReactDomTestUtils.act(() => {
       ReactDomTestUtils.Simulate.click(node.querySelector(".btn-danger"));

--- a/test/components/signoff/SimpleReview/SimpleReviewButtons_test.js
+++ b/test/components/signoff/SimpleReview/SimpleReviewButtons_test.js
@@ -22,18 +22,26 @@ function renderButtons(props = null) {
 }
 
 describe("SimpleReviewHeader component", () => {
-  it("should call approveChanges when approve button is clicked", () => {
-    const { approveChanges, node } = renderButtons({ status: "to-review" });
+  it("should call approveChanges when approve button is clicked", async () => {
+    const { approveChanges, node } = renderButtons({
+      status: "to-review",
+      canReview: true,
+    });
 
     fireEvent.click(node.getByText(/Approve/));
     expect(approveChanges).toHaveBeenCalled();
+    expect(await node.findByTestId("spinner")).toBeDefined();
   });
 
   it("should open CommentDialog when reject is clicked call declineChanges from modal", async () => {
-    const { declineChanges, node } = renderButtons({ status: "to-review" });
+    const { declineChanges, node } = renderButtons({
+      status: "to-review",
+      canReview: true,
+    });
     fireEvent.click(node.getByText(/Decline/));
     fireEvent.click(await node.findByText("Reject changes"));
     expect(declineChanges).toHaveBeenCalled();
+    expect(await node.findByTestId("spinner")).toBeDefined();
   });
 
   it("should open CommentDialog when request review is clicked and call requestReview from modal", async () => {
@@ -43,10 +51,11 @@ describe("SimpleReviewHeader component", () => {
   it("should display rollback button when status is wip and call rollbackChanges from modal", async () => {
     const { rollbackChanges, node } = renderButtons({
       status: "work-in-progress",
-      canReview: true,
+      canRequestReview: true,
     });
     fireEvent.click(node.getByText(/Rollback changes/));
     fireEvent.click(await node.findByText("Rollback"));
     expect(rollbackChanges).toHaveBeenCalled();
+    expect(await node.findByTestId("spinner")).toBeDefined();
   });
 });

--- a/test/components/signoff/SimpleReview/SimpleReviewButtons_test.js
+++ b/test/components/signoff/SimpleReview/SimpleReviewButtons_test.js
@@ -1,15 +1,13 @@
-import { expect } from "chai";
-import { createComponent } from "../../../test_utils";
-import ReactDomTestUtils from "react-dom/test-utils";
-import sinon from "sinon";
+import { renderWithProvider } from "../../../test_utils";
+import { fireEvent } from "@testing-library/react";
 import * as React from "react";
 
 import SimpleReviewButtons from "../../../../src/components/signoff/SimpleReview/SimpleReviewButtons";
 
 function renderButtons(props = null) {
-  const approveChanges = sinon.stub();
-  const declineChanges = sinon.stub();
-  const rollbackChanges = sinon.stub();
+  const approveChanges = jest.fn();
+  const declineChanges = jest.fn();
+  const rollbackChanges = jest.fn();
 
   const mergedProps = {
     status: "to-review",
@@ -19,7 +17,7 @@ function renderButtons(props = null) {
     ...props,
   };
 
-  const node = createComponent(<SimpleReviewButtons {...mergedProps} />);
+  const node = renderWithProvider(<SimpleReviewButtons {...mergedProps} />);
   return { approveChanges, declineChanges, rollbackChanges, node };
 }
 
@@ -27,22 +25,19 @@ describe("SimpleReviewHeader component", () => {
   it("should call approveChanges when approve button is clicked", () => {
     const { approveChanges, node } = renderButtons({ status: "to-review" });
 
-    ReactDomTestUtils.Simulate.click(node.querySelector(".btn-success"));
-    expect(approveChanges.firstCall).to.be.ok;
+    fireEvent.click(node.getByText(/Approve/));
+    expect(approveChanges).toHaveBeenCalled();
   });
 
   it("should open CommentDialog when reject is clicked call declineChanges from modal", async () => {
     const { declineChanges, node } = renderButtons({ status: "to-review" });
-    ReactDomTestUtils.act(() => {
-      ReactDomTestUtils.Simulate.click(node.querySelector(".btn-danger"));
-    });
-    expect(node.querySelector(".modal")).to.be.ok;
-    ReactDomTestUtils.act(() => {
-      ReactDomTestUtils.Simulate.click(
-        node.querySelector(".modal .btn-primary")
-      );
-    });
-    expect(declineChanges.firstCall).to.be.ok;
+    fireEvent.click(node.getByText(/Decline/));
+    fireEvent.click(await node.findByText("Reject changes"));
+    expect(declineChanges).toHaveBeenCalled();
+  });
+
+  it("should open CommentDialog when request review is clicked and call requestReview from modal", async () => {
+    const {} = renderButtons({ status: "work-in-progress" });
   });
 
   it("should display rollback button when status is wip and call rollbackChanges from modal", async () => {
@@ -50,15 +45,8 @@ describe("SimpleReviewHeader component", () => {
       status: "work-in-progress",
       canReview: true,
     });
-    ReactDomTestUtils.act(() => {
-      ReactDomTestUtils.Simulate.click(node.querySelector(".btn-danger"));
-    });
-    expect(node.querySelector(".modal")).to.be.ok;
-    ReactDomTestUtils.act(() => {
-      ReactDomTestUtils.Simulate.click(
-        node.querySelector(".modal .btn-primary")
-      );
-    });
-    expect(rollbackChanges.firstCall).to.be.ok;
+    fireEvent.click(node.getByText(/Rollback changes/));
+    fireEvent.click(await node.findByText("Rollback"));
+    expect(rollbackChanges).toHaveBeenCalled();
   });
 });

--- a/test/components/signoff/SimpleReview/SimpleReviewHeader_test.js
+++ b/test/components/signoff/SimpleReview/SimpleReviewHeader_test.js
@@ -1,6 +1,4 @@
-import { expect } from "chai";
 import { createComponent } from "../../../test_utils";
-
 import SimpleReviewHeader from "../../../../src/components/signoff/SimpleReview/SimpleReviewHeader";
 import * as React from "react";
 
@@ -22,24 +20,25 @@ const wipProps = {
 describe("SimpleReviewHeader component", () => {
   it("should render title when component is to-review", () => {
     const node = createComponent(<SimpleReviewHeader {...toReviewProps} />);
-    expect(node.querySelector(".card-header").textContent).to.equal(
+    expect(node.querySelector(".card-header").textContent).toBe(
       "Review requested by ana:"
     );
   });
   it("should render an editor comment when component is to-review", () => {
     const node = createComponent(<SimpleReviewHeader {...toReviewProps} />);
-    expect(node.querySelector(".card-text").textContent).to.equal(
-      "please review"
-    );
+    expect(node.querySelector(".card-text").textContent).toBe("please review");
   });
-  it("should render a wip header", () => {
-    const node = createComponent(<SimpleReviewHeader {...wipProps} />);
-    expect(node.querySelector(".card-header").textContent).to.equal(
+  it("should render a reviewer comments as expected when component is wip", () => {
+    const node = createComponent(
+      <SimpleReviewHeader
+        {...wipProps}
+        lastEditDate={123}
+        lastReviewDate={124}
+      />
+    );
+    expect(node.querySelector(".card-text").textContent).toBe("no thanks");
+    expect(node.querySelector(".card-header").textContent).toBe(
       "Status is work-in-progress. Most recent reviewer comment was:"
     );
-  });
-  it("should render a reviewer comment when component is wip", () => {
-    const node = createComponent(<SimpleReviewHeader {...wipProps} />);
-    expect(node.querySelector(".card-text").textContent).to.equal("no thanks");
   });
 });

--- a/test/components/signoff/components_test.js
+++ b/test/components/signoff/components_test.js
@@ -2,6 +2,25 @@ import SignoffToolBar from "../../../src/components/signoff/SignoffToolBar";
 import * as React from "react";
 import { render, fireEvent } from "@testing-library/react";
 
+// to avoid rendering a router around everything, allows for more focused testing
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Link: "a",
+  };
+});
+
+jest.mock("../../../src/hooks/storage", () => {
+  const originalModule = jest.requireActual("../../../src/hooks/storage");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useLocalStorage: jest.fn().mockReturnValue([false, jest.fn()]),
+  };
+});
+
 describe("SignoffToolBar component", () => {
   const props = {
     sessionState: {
@@ -121,7 +140,7 @@ describe("SignoffToolBar component", () => {
     expect(node.queryByTestId("spinner")).toBeNull();
     expect(propsOverride.approveChanges).toHaveBeenCalledTimes(0);
     fireEvent.click(await node.findByText("Approve"));
-    expect(node.queryByTestId("spinner")).toBeDefined();
+    expect(await node.findByTestId("spinner")).toBeDefined();
     expect(propsOverride.approveChanges).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/hooks/storage_test.js
+++ b/test/hooks/storage_test.js
@@ -1,0 +1,76 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useLocalStorage } from "../../src/hooks/storage";
+
+class localStorageClass {
+  isConstructor() {
+    this.store = {};
+  }
+
+  clear() {
+    this.store = {};
+  }
+
+  getItem(key) {
+    return this.store[key];
+  }
+
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+  }
+}
+
+global.localStorage = new localStorageClass();
+
+describe("useLocalStorage", () => {
+  it("should return default value if a value isn't set yet", () => {
+    const { result } = renderHook(() =>
+      useLocalStorage("testKey", "defaultValue")
+    );
+
+    expect(result.current[0]).toBe("defaultValue");
+  });
+
+  it("should get an existing value from localStorage if one exists", () => {
+    localStorage.setItem("testKey", JSON.stringify("storedValue"));
+    const { result } = renderHook(() =>
+      useLocalStorage("testKey", "defaultValue")
+    );
+
+    expect(result.current[0]).toBe("storedValue");
+  });
+
+  it("should set a new value in localStorage", () => {
+    const { result } = renderHook(() =>
+      useLocalStorage("testKey", "defaultValue")
+    );
+
+    act(() => {
+      result.current[1]("newValue");
+    });
+
+    expect(result.current[0]).toBe("newValue");
+    expect(localStorage.getItem("testKey")).toBe(JSON.stringify("newValue"));
+  });
+
+  it("should update the value when localStorage changes from another session", () => {
+    const { result } = renderHook(() =>
+      useLocalStorage("testKey", "defaultValue")
+    );
+
+    act(() => {
+      localStorage.setItem("testKey", JSON.stringify("externalChange"));
+      const event = new StorageEvent("storage", {
+        oldValue: JSON.stringify("defaultValue"),
+        newValue: JSON.stringify("externalChange"),
+        key: "testKey",
+      });
+      window.dispatchEvent(event);
+    });
+
+    expect(result.current[0]).toBe("externalChange");
+  });
+});

--- a/test/permission_test.js
+++ b/test/permission_test.js
@@ -44,14 +44,12 @@ describe("canCreateBucket", () => {
 describe("canEditBucket", () => {
   it("should always return true if no permissions list", () => {
     const session = { permissions: null };
-    const bucket = {};
-    expect(canEditBucket(session, bucket)).eql(true);
+    expect(canEditBucket(session, "")).eql(true);
   });
 
   it("should return false if object is not listed", () => {
     const session = { permissions: [{ bucket_id: "xyz" }] };
-    const bucket = { data: { id: "abc" } };
-    expect(canEditBucket(session, bucket)).eql(false);
+    expect(canEditBucket(session, "abc")).eql(false);
   });
 
   it("should return false if permission is not listed", () => {
@@ -64,8 +62,7 @@ describe("canEditBucket", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
-    expect(canEditBucket(session, bucket)).eql(false);
+    expect(canEditBucket(session, "xyz")).eql(false);
   });
 
   it("should return true if permission is listed", () => {
@@ -78,22 +75,19 @@ describe("canEditBucket", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
-    expect(canEditBucket(session, bucket)).eql(true);
+    expect(canEditBucket(session, "xyz")).eql(true);
   });
 });
 
 describe("canCreateCollection", () => {
   it("should always return true if no permisssions list", () => {
     const session = { permissions: null };
-    const bucket = {};
-    expect(canCreateCollection(session, bucket)).eql(true);
+    expect(canCreateCollection(session, "")).eql(true);
   });
 
   it("should return false if object is not listed", () => {
     const session = { permissions: [{ bucket_id: "xyz" }] };
-    const bucket = { data: { id: "abc" } };
-    expect(canCreateCollection(session, bucket)).eql(false);
+    expect(canCreateCollection(session, "abc")).eql(false);
   });
 
   it("should return false if permission is not listed", () => {
@@ -106,8 +100,7 @@ describe("canCreateCollection", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
-    expect(canCreateCollection(session, bucket)).eql(false);
+    expect(canCreateCollection(session, "xyz")).eql(false);
   });
 
   it("should return true if permission is listed", () => {
@@ -120,22 +113,19 @@ describe("canCreateCollection", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
-    expect(canCreateCollection(session, bucket)).eql(true);
+    expect(canCreateCollection(session, "xyz")).eql(true);
   });
 });
 
 describe("canCreateGroup", () => {
   it("should always return true if no permisssions list", () => {
     const session = { permissions: null };
-    const bucket = {};
-    expect(canCreateGroup(session, bucket)).eql(true);
+    expect(canCreateGroup(session, "")).eql(true);
   });
 
   it("should return false if object is not listed", () => {
     const session = { permissions: [{ bucket_id: "xyz" }] };
-    const bucket = { data: { id: "abc" } };
-    expect(canCreateGroup(session, bucket)).eql(false);
+    expect(canCreateGroup(session, "abc")).eql(false);
   });
 
   it("should return false if permission is not listed", () => {
@@ -148,8 +138,7 @@ describe("canCreateGroup", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
-    expect(canCreateGroup(session, bucket)).eql(false);
+    expect(canCreateGroup(session, "xyz")).eql(false);
   });
 
   it("should return true if permission is listed", () => {
@@ -162,26 +151,23 @@ describe("canCreateGroup", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
-    expect(canCreateGroup(session, bucket)).eql(true);
+    expect(canCreateGroup(session, "xyz")).eql(true);
   });
 });
 
 describe("canEditCollection", () => {
   it("should always return true if no permisssions list", () => {
     const session = { permissions: null };
-    const bucket = {};
     const collection = {};
-    expect(canEditCollection(session, bucket, collection)).eql(true);
+    expect(canEditCollection(session, "", collection)).eql(true);
   });
 
   it("should return false if object is not listed", () => {
     const session = {
       permissions: [{ bucket_id: "abc", collection_id: "foo" }],
     };
-    const bucket = { data: { id: "abc" } };
     const collection = { data: { id: "bar" } };
-    expect(canEditCollection(session, bucket, collection)).eql(false);
+    expect(canEditCollection(session, "abc", collection)).eql(false);
   });
 
   it("should return false if permission is not listed", () => {
@@ -195,9 +181,8 @@ describe("canEditCollection", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const collection = { data: { id: "foo" } };
-    expect(canEditCollection(session, bucket, collection)).eql(false);
+    expect(canEditCollection(session, "xyz", collection)).eql(false);
   });
 
   it("should return true if permission is listed", () => {
@@ -211,9 +196,8 @@ describe("canEditCollection", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const collection = { data: { id: "foo" } };
-    expect(canEditCollection(session, bucket, collection)).eql(true);
+    expect(canEditCollection(session, "xyz", collection)).eql(true);
   });
 
   it("should return true if permission on bucket is listed", () => {
@@ -226,25 +210,22 @@ describe("canEditCollection", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const collection = { data: { id: "foo" } };
-    expect(canEditCollection(session, bucket, collection)).eql(true);
+    expect(canEditCollection(session, "xyz", collection)).eql(true);
   });
 });
 
 describe("canEditGroup", () => {
   it("should always return true if no permisssions list", () => {
     const session = { permissions: null };
-    const bucket = {};
     const group = {};
-    expect(canEditGroup(session, bucket, group)).eql(true);
+    expect(canEditGroup(session, "", group)).eql(true);
   });
 
   it("should return false if object is not listed", () => {
     const session = { permissions: [{ bucket_id: "abc", group_id: "foo" }] };
-    const bucket = { data: { id: "abc" } };
     const group = { data: { id: "bar" } };
-    expect(canEditGroup(session, bucket, group)).eql(false);
+    expect(canEditGroup(session, "abc", group)).eql(false);
   });
 
   it("should return false if permission is not listed", () => {
@@ -258,9 +239,8 @@ describe("canEditGroup", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const group = { data: { id: "foo" } };
-    expect(canEditGroup(session, bucket, group)).eql(false);
+    expect(canEditGroup(session, "xyz", group)).eql(false);
   });
 
   it("should return true if permission is listed", () => {
@@ -274,9 +254,8 @@ describe("canEditGroup", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const group = { data: { id: "foo" } };
-    expect(canEditGroup(session, bucket, group)).eql(true);
+    expect(canEditGroup(session, "xyz", group)).eql(true);
   });
 
   it("should return true if permission on bucket is listed", () => {
@@ -289,27 +268,24 @@ describe("canEditGroup", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const group = { data: { id: "foo" } };
-    expect(canEditGroup(session, bucket, group)).eql(true);
+    expect(canEditGroup(session, "xyz", group)).eql(true);
   });
 });
 
 describe("canCreateRecord", () => {
   it("should always return true if no permisssions list", () => {
     const session = { permissions: null };
-    const bucket = {};
     const collection = {};
-    expect(canCreateRecord(session, bucket, collection)).eql(true);
+    expect(canCreateRecord(session, "", collection)).eql(true);
   });
 
   it("should return false if object is not listed", () => {
     const session = {
       permissions: [{ bucket_id: "abc", collection_id: "foo" }],
     };
-    const bucket = { data: { id: "abc" } };
     const collection = { data: { id: "bar" } };
-    expect(canCreateRecord(session, bucket, collection)).eql(false);
+    expect(canCreateRecord(session, "abc", collection)).eql(false);
   });
 
   it("should return false if permission is not listed", () => {
@@ -323,9 +299,8 @@ describe("canCreateRecord", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const collection = { data: { id: "foo" } };
-    expect(canCreateRecord(session, bucket, collection)).eql(false);
+    expect(canCreateRecord(session, "xyz", collection)).eql(false);
   });
 
   it("should return true if permission is listed", () => {
@@ -339,9 +314,8 @@ describe("canCreateRecord", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const collection = { data: { id: "foo" } };
-    expect(canCreateRecord(session, bucket, collection)).eql(true);
+    expect(canCreateRecord(session, "xyz", collection)).eql(true);
   });
 
   it("should return true if permission on bucket is listed", () => {
@@ -354,19 +328,17 @@ describe("canCreateRecord", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const collection = { data: { id: "foo" } };
-    expect(canCreateRecord(session, bucket, collection)).eql(true);
+    expect(canCreateRecord(session, "xyz", collection)).eql(true);
   });
 });
 
 describe("canEditRecord", () => {
   it("should always return true if no permisssions list", () => {
     const session = { permissions: null };
-    const bucket = {};
     const collection = {};
     const record = {};
-    expect(canEditRecord(session, bucket, collection, record)).eql(true);
+    expect(canEditRecord(session, "", collection, record)).eql(true);
   });
 
   it("should return false if object is not listed", () => {
@@ -379,10 +351,9 @@ describe("canEditRecord", () => {
         },
       ],
     };
-    const bucket = { data: { id: "abc" } };
     const collection = { data: { id: "bar" } };
     const record = { data: { id: "blah" } };
-    expect(canEditRecord(session, bucket, collection, record)).eql(false);
+    expect(canEditRecord(session, "abc", collection, record)).eql(false);
   });
 
   it("should return false if permission is not listed", () => {
@@ -397,10 +368,9 @@ describe("canEditRecord", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const collection = { data: { id: "foo" } };
     const record = { data: { id: "blah" } };
-    expect(canEditRecord(session, bucket, collection, record)).eql(false);
+    expect(canEditRecord(session, "xyz", collection, record)).eql(false);
   });
 
   it("should return true if permission is listed", () => {
@@ -415,10 +385,9 @@ describe("canEditRecord", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const collection = { data: { id: "foo" } };
     const record = { data: { id: "blah" } };
-    expect(canEditRecord(session, bucket, collection, record)).eql(true);
+    expect(canEditRecord(session, "xyz", collection, record)).eql(true);
   });
 
   it("should return true if permission on bucket is listed", () => {
@@ -431,10 +400,9 @@ describe("canEditRecord", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const collection = { data: { id: "foo" } };
     const record = { data: { id: "blah" } };
-    expect(canEditRecord(session, bucket, collection, record)).eql(true);
+    expect(canEditRecord(session, "xyz", collection, record)).eql(true);
   });
 
   it("should return true if permission on collection is listed", () => {
@@ -448,10 +416,9 @@ describe("canEditRecord", () => {
         },
       ],
     };
-    const bucket = { data: { id: "xyz" } };
     const collection = { data: { id: "foo" } };
     const record = { data: { id: "blah" } };
-    expect(canEditRecord(session, bucket, collection, record)).eql(true);
+    expect(canEditRecord(session, "xyz", collection, record)).eql(true);
   });
 });
 


### PR DESCRIPTION
This MR aims to resolve [issue #2269](https://github.com/Kinto/kinto-admin/issues/2269) and there is some light refactoring as well. See demo video for main functionality. We will be creating a demo site for users to test this and gather feedback.

Changes to note (for devs):

1. Sets up the new simple-review process to be the default signoff process
2. Creates a hook pattern that I'd like to carry forward for new development and code cleanup. The goal of this pattern is to decouple components and reduce the need to pass dependencies more than 1 layer.
3. Adds a few more unit tests
4. Does some light refactoring (ex: removing the need to pass in a whole bucket to permission functions that just use the id property)


[Demo video](https://github.com/Kinto/kinto-admin/assets/148472676/df4c34d8-d5e7-46ed-a440-af59371d6892)