### PR TITLE
Resolves #3088 - Updated functions that call permission checks to use correct bucket id

### DIFF
--- a/src/components/bucket/BucketForm.tsx
+++ b/src/components/bucket/BucketForm.tsx
@@ -53,7 +53,7 @@ export default function BucketForm({
   onSubmit,
 }: Props) {
   const creation = !formData.id;
-  const hasWriteAccess = canEditBucket(session, bid);
+  const hasWriteAccess = canEditBucket(session, bucket.data.id);
   const formIsEditable = creation || hasWriteAccess;
   const showDeleteForm = !creation && hasWriteAccess;
 

--- a/src/components/bucket/BucketPermissions.tsx
+++ b/src/components/bucket/BucketPermissions.tsx
@@ -38,7 +38,7 @@ export function BucketPermissions() {
         <PermissionsForm
           permissions={permissions}
           acls={acls}
-          readonly={!canEditBucket(session, bid)}
+          readonly={!canEditBucket(session, bucket.data.id)}
           onSubmit={onSubmit}
         />
       </BucketTabs>

--- a/src/components/bucket/CollectionDataList.tsx
+++ b/src/components/bucket/CollectionDataList.tsx
@@ -9,7 +9,11 @@ import { canCreateCollection } from "../../permission";
 
 export function ListActions(props) {
   const { bid, session, bucket } = props;
-  if (session.busy || bucket.busy || !canCreateCollection(session, bucket.data.id)) {
+  if (
+    session.busy ||
+    bucket.busy ||
+    !canCreateCollection(session, bucket.data.id)
+  ) {
     return null;
   }
   return (

--- a/src/components/bucket/CollectionDataList.tsx
+++ b/src/components/bucket/CollectionDataList.tsx
@@ -9,7 +9,7 @@ import { canCreateCollection } from "../../permission";
 
 export function ListActions(props) {
   const { bid, session, bucket } = props;
-  if (session.busy || bucket.busy || !canCreateCollection(session, bid)) {
+  if (session.busy || bucket.busy || !canCreateCollection(session, bucket.data.id)) {
     return null;
   }
   return (

--- a/src/components/bucket/GroupDataList.tsx
+++ b/src/components/bucket/GroupDataList.tsx
@@ -67,7 +67,7 @@ export function DataList(props) {
 }
 
 export function ListActions({ bid, session, bucket }) {
-  if (session.busy || bucket.busy || !canCreateGroup(session, bid)) {
+  if (session.busy || bucket.busy || !canCreateGroup(session, bucket.data.id)) {
     return null;
   }
   return (

--- a/src/components/collection/CollectionPermissions.tsx
+++ b/src/components/collection/CollectionPermissions.tsx
@@ -17,6 +17,7 @@ interface RouteParams {
 export function CollectionPermissions() {
   const { bid, cid } = useParams<RouteParams>();
   const session = useAppSelector(state => state.session);
+  const bucket = useAppSelector(state => state.bucket);
   const collection = useAppSelector(state => state.collection);
   const { busy, permissions } = collection;
   const acls = ["read", "write", "record:create"];
@@ -49,7 +50,7 @@ export function CollectionPermissions() {
         <PermissionsForm
           permissions={permissions}
           acls={acls}
-          readonly={!canEditCollection(session, bid, collection)}
+          readonly={!canEditCollection(session, bucket.data.id, collection)}
           onSubmit={onSubmit}
         />
       </CollectionTabs>

--- a/src/components/collection/RecordTable.tsx
+++ b/src/components/collection/RecordTable.tsx
@@ -17,13 +17,13 @@ import SignoffContainer from "../../containers/signoff/SignoffToolBar";
 import { CommonProps } from "./commonPropTypes";
 
 export function ListActions(props) {
-  const { bid, cid, session, collection } = props;
+  const { bid, cid, session, collection, bucket } = props;
   if (session.busy || collection.busy) {
     return null;
   }
   return (
     <div className="list-actions">
-      {canCreateRecord(session, bid, collection) && (
+      {canCreateRecord(session, bucket.data.id, collection) && (
         <>
           <AdminLink
             key="__1"

--- a/src/components/group/GroupPermissions.tsx
+++ b/src/components/group/GroupPermissions.tsx
@@ -15,6 +15,7 @@ import { useParams } from "react-router";
 
 export function GroupPermissions() {
   const group = useAppSelector(state => state.group);
+  const bucket = useAppSelector(state => state.bucket);
   const { busy, permissions } = group;
   const session = useAppSelector(state => state.session);
   const { bid, gid } = useParams<GroupPermissionsRouteMatchParams>();
@@ -44,7 +45,7 @@ export function GroupPermissions() {
         <PermissionsForm
           permissions={permissions}
           acls={["read", "write"]}
-          readonly={!canEditGroup(session, bid, group)}
+          readonly={!canEditGroup(session, bucket.data.id, group)}
           onSubmit={onSubmit}
         />
       </GroupTabs>

--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import type {
+  BucketState,
   SessionState,
   CollectionState,
   RecordState,
@@ -48,6 +49,7 @@ export function extendUiSchemaWhenDisabled(uiSchema: any, disabled: boolean) {
 
 type Props = {
   bid: string;
+  bucket: BucketState;
   cid: string;
   rid?: string;
   session: SessionState;
@@ -71,11 +73,12 @@ export default function RecordForm(props: Props) {
     deleteRecord,
     onSubmit,
     capabilities,
+    bucket,
   } = props;
 
   const allowEditing = record
-    ? canEditRecord(session, bid, collection, record)
-    : canCreateRecord(session, bid, collection);
+    ? canEditRecord(session, bucket.data.id, collection, record)
+    : canCreateRecord(session, bucket.data.id, collection);
 
   const handleDeleteRecord = () => {
     const { rid } = props;

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -85,7 +85,7 @@ export default function SimpleReview({
     params: { bid, cid },
   } = match;
   const canRequestReview =
-    canEditCollection(session, bid, collection) &&
+    canEditCollection(session, destBid, collection) &&
     isMember("editors_group", signoffSource, session);
 
   useEffect(() => {

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -85,7 +85,7 @@ export default function SimpleReview({
     params: { bid, cid },
   } = match;
   const canRequestReview =
-    canEditCollection(session, destBid, collection) &&
+    canEditCollection(session, bid, collection) &&
     isMember("editors_group", signoffSource, session);
 
   useEffect(() => {

--- a/test/components/bucket/CollectionDataList_test.js
+++ b/test/components/bucket/CollectionDataList_test.js
@@ -83,8 +83,8 @@ describe("Bucket CollectionListActions", () => {
     bucket: {
       busy: false,
       data: {
-        id: "test"
-      }
+        id: "test",
+      },
     },
   };
 

--- a/test/components/bucket/CollectionDataList_test.js
+++ b/test/components/bucket/CollectionDataList_test.js
@@ -82,6 +82,9 @@ describe("Bucket CollectionListActions", () => {
     },
     bucket: {
       busy: false,
+      data: {
+        id: "test"
+      }
     },
   };
 

--- a/test/components/bucket/GroupDataList_test.js
+++ b/test/components/bucket/GroupDataList_test.js
@@ -58,6 +58,9 @@ describe("Bucket GroupListActions", () => {
     },
     bucket: {
       busy: false,
+      data: {
+        id: "test-bucket"
+      }
     },
   };
 

--- a/test/components/bucket/GroupDataList_test.js
+++ b/test/components/bucket/GroupDataList_test.js
@@ -59,8 +59,8 @@ describe("Bucket GroupListActions", () => {
     bucket: {
       busy: false,
       data: {
-        id: "test-bucket"
-      }
+        id: "test-bucket",
+      },
     },
   };
 


### PR DESCRIPTION
Resolves https://github.com/Kinto/kinto-admin/issues/3088 . `bid` != `bucket.data.id` in all servers.

Note to reviewers: This will (should) have zero impact on remote-settings because bid always equals bucket.data.id on our servers. I found this when running kinto locally for simpler testing, where we generate uuid's for the id field.