### PR TITLE
Fixes #301 - Added "copy to clipboard" option to record rows

### DIFF
--- a/src/components/collection/RecordRow.tsx
+++ b/src/components/collection/RecordRow.tsx
@@ -82,7 +82,7 @@ export default function RecordRow({
           params={{ bid, cid, rid }}
           className="btn btn-sm btn-info"
           style={{
-            margin: "1pt"
+            margin: "1pt",
           }}
           title="Edit record"
         >
@@ -92,21 +92,23 @@ export default function RecordRow({
           type="button"
           className="btn btn-sm btn-danger"
           style={{
-            margin: "1pt"
+            margin: "1pt",
           }}
           onClick={onDeleteClick}
           title="Delete record"
         >
           <Trash className="icon" />
         </button>
-        <Dropdown style={{
-          display: "inline"
-        }}>
+        <Dropdown
+          style={{
+            display: "inline",
+          }}
+        >
           <Dropdown.Toggle
             variant="secondary"
             className="btn-sm"
             style={{
-              margin: "1pt"
+              margin: "1pt",
             }}
           />
           <Dropdown.Menu>

--- a/src/components/collection/RecordRow.tsx
+++ b/src/components/collection/RecordRow.tsx
@@ -77,63 +77,68 @@ export default function RecordRow({
       ))}
       <td className="lastmod">{lastModified()}</td>
       <td className="actions text-right">
-        <div className="btn-group">
-          <AdminLink
-            name="record:attributes"
-            params={{ bid, cid, rid }}
-            className="btn btn-sm btn-info"
-            title="Edit record"
-          >
-            <Pencil className="icon" />
-          </AdminLink>
-          <button
-            type="button"
-            className="btn btn-sm btn-danger"
-            onClick={onDeleteClick}
-            title="Delete record"
-          >
-            <Trash className="icon" />
-          </button>
-
-          <Dropdown>
-            <Dropdown.Toggle
-              variant="secondary"
-              style={{
-                borderTopLeftRadius: 0,
-                borderBottomLeftRadius: 0,
-              }}
-            />
-            <Dropdown.Menu>
-              {attachmentUrl && (
-                <a
-                  href={attachmentUrl}
-                  className="dropdown-item"
-                  title="The record has an attachment"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Paperclip className="icon" /> View Attachment
-                </a>
-              )}
-              <AdminLink
-                name="record:permissions"
-                params={{ bid, cid, rid }}
+        <AdminLink
+          name="record:attributes"
+          params={{ bid, cid, rid }}
+          className="btn btn-sm btn-info"
+          style={{
+            margin: "1pt"
+          }}
+          title="Edit record"
+        >
+          <Pencil className="icon" />
+        </AdminLink>
+        <button
+          type="button"
+          className="btn btn-sm btn-danger"
+          style={{
+            margin: "1pt"
+          }}
+          onClick={onDeleteClick}
+          title="Delete record"
+        >
+          <Trash className="icon" />
+        </button>
+        <Dropdown style={{
+          display: "inline"
+        }}>
+          <Dropdown.Toggle
+            variant="secondary"
+            className="btn-sm"
+            style={{
+              margin: "1pt"
+            }}
+          />
+          <Dropdown.Menu>
+            {attachmentUrl && (
+              <a
+                href={attachmentUrl}
                 className="dropdown-item"
+                title="The record has an attachment"
+                target="_blank"
+                rel="noopener noreferrer"
               >
-                <Lock className="icon" /> Record Permissions
-              </AdminLink>
-              <Dropdown.Item
-                onClick={() => {
-                  navigator.clipboard.writeText(
-                    `${session.auth.server}buckets/${bid}/collections/${cid}/records/${record.id}`
-                  );
-                }}
-              >
-                <ClipboardCheck className="icon" /> Copy link to clipboard
-              </Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
-        </div>
+                <Paperclip className="icon" /> View Attachment
+              </a>
+            )}
+            <AdminLink
+              name="record:permissions"
+              params={{ bid, cid, rid }}
+              className="dropdown-item"
+            >
+              <Lock className="icon" /> Edit Permissions
+            </AdminLink>
+            <Dropdown.Item
+              onClick={() => {
+                navigator.clipboard.writeText(
+                  `${session.auth.server}buckets/${bid}/collections/${cid}/records/${record.id}`
+                );
+              }}
+            >
+              <ClipboardCheck className="icon" /> Copy Link to Clipboard
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
       </td>
     </tr>
   );

--- a/src/components/collection/RecordRow.tsx
+++ b/src/components/collection/RecordRow.tsx
@@ -2,10 +2,19 @@ import React from "react";
 
 import type { RecordData } from "../../types";
 
-import { Paperclip, Pencil, Lock, Trash } from "react-bootstrap-icons";
+import { Dropdown } from "react-bootstrap";
+
+import {
+  ClipboardCheck,
+  Paperclip,
+  Pencil,
+  Lock,
+  Trash,
+} from "react-bootstrap-icons";
 import { renderDisplayField, timeago, buildAttachmentUrl } from "../../utils";
 import AdminLink from "../AdminLink";
 import { CommonProps } from "./commonPropTypes";
+import { useAppSelector } from "../../hooks/app";
 
 type RecordsViewProps = CommonProps & {
   bid: string;
@@ -28,6 +37,8 @@ export default function RecordRow({
   deleteRecord,
   schema = {},
 }: RowProps) {
+  const session = useAppSelector(state => state.session);
+
   const lastModified = () => {
     const lastModified = record.last_modified;
     if (!lastModified) {
@@ -67,17 +78,6 @@ export default function RecordRow({
       <td className="lastmod">{lastModified()}</td>
       <td className="actions text-right">
         <div className="btn-group">
-          {attachmentUrl && (
-            <a
-              href={attachmentUrl}
-              className="btn btn-sm btn-secondary"
-              title="The record has an attachment"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Paperclip className="icon" />
-            </a>
-          )}
           <AdminLink
             name="record:attributes"
             params={{ bid, cid, rid }}
@@ -85,14 +85,6 @@ export default function RecordRow({
             title="Edit record"
           >
             <Pencil className="icon" />
-          </AdminLink>
-          <AdminLink
-            name="record:permissions"
-            params={{ bid, cid, rid }}
-            className="btn btn-sm btn-warning"
-            title="Record permissions"
-          >
-            <Lock className="icon" />
           </AdminLink>
           <button
             type="button"
@@ -102,6 +94,45 @@ export default function RecordRow({
           >
             <Trash className="icon" />
           </button>
+
+          <Dropdown>
+            <Dropdown.Toggle
+              variant="secondary"
+              style={{
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+              }}
+            />
+            <Dropdown.Menu>
+              {attachmentUrl && (
+                <a
+                  href={attachmentUrl}
+                  className="dropdown-item"
+                  title="The record has an attachment"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Paperclip className="icon" /> View Attachment
+                </a>
+              )}
+              <AdminLink
+                name="record:permissions"
+                params={{ bid, cid, rid }}
+                className="dropdown-item"
+              >
+                <Lock className="icon" /> Record Permissions
+              </AdminLink>
+              <Dropdown.Item
+                onClick={() => {
+                  navigator.clipboard.writeText(
+                    `${session.auth.server}buckets/${bid}/collections/${cid}/records/${record.id}`
+                  );
+                }}
+              >
+                <ClipboardCheck className="icon" /> Copy link to clipboard
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
         </div>
       </td>
     </tr>


### PR DESCRIPTION
Fixes #301 by adding a "Copy link to clipboard" option. Also moved secondary row actions under a dropdown menu to reduce clutter and make things more intuitive.

No test changes, I don't really think this is considered business logic. Open to adding something if anybody has a suggestion though.

![image](https://github.com/Kinto/kinto-admin/assets/148472676/07b14e54-af7f-4b74-a63c-528bfd565db4)

