### PR TITLE
Resolves #3041 - Finishing some test cleanup

### DIFF
--- a/src/components/BaseForm.tsx
+++ b/src/components/BaseForm.tsx
@@ -47,6 +47,7 @@ export default function BaseForm(props: BaseFormProps) {
         // @ts-ignore
         fields={adminFields}
         disabled={disabled || showSpinner || isSubmitting}
+        data-testid="rjsf"
       />
       {(isSubmitting || showSpinner) && <Spinner />}
     </div>

--- a/src/components/BaseForm.tsx
+++ b/src/components/BaseForm.tsx
@@ -47,7 +47,6 @@ export default function BaseForm(props: BaseFormProps) {
         // @ts-ignore
         fields={adminFields}
         disabled={disabled || showSpinner || isSubmitting}
-        data-testid="rjsf"
       />
       {(isSubmitting || showSpinner) && <Spinner />}
     </div>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -22,7 +22,7 @@ function ServerProps({ node }: { node: any }) {
         {nodes.map(([key, childNode], i) => {
           return (
             <tr key={i}>
-              <th>{key}</th>
+              <th data-testid="home-th">{key}</th>
               <td style={{ width: "100%" }}>
                 {isObject(childNode) || Array.isArray(childNode) ? (
                   <ServerProps node={childNode} />
@@ -47,7 +47,7 @@ function SessionInfo({ session: { serverInfo } }) {
   return (
     <div>
       <div className="card server-info-panel">
-        <div className="card-header">
+        <div className="card-header" data-testid="home-header">
           <b>Server information</b>
         </div>
         <div className="card-body">

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -47,7 +47,7 @@ function SessionInfo({ session: { serverInfo } }) {
   return (
     <div>
       <div className="card server-info-panel">
-        <div className="card-header" data-testid="home-header">
+        <div className="card-header">
           <b>Server information</b>
         </div>
         <div className="card-body">

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -41,7 +41,11 @@ export default function Notifications({
   const onDismiss = ({ id: index }) => removeNotification(index);
   return (
     <div className="notifications">
-      <AlertList alerts={alerts} onDismiss={onDismiss} />
+      <AlertList
+        alerts={alerts}
+        onDismiss={onDismiss}
+        data-testid="notifications"
+      />
     </div>
   );
 }

--- a/src/components/PaginatedTable.tsx
+++ b/src/components/PaginatedTable.tsx
@@ -20,7 +20,10 @@ export default function PaginatedTable({
   listNextPage,
 }: Props) {
   return (
-    <table className="table table-striped table-bordered record-list">
+    <table
+      className="table table-striped table-bordered record-list"
+      data-testid="paginatedTable"
+    >
       {thead}
       {tbody}
       {hasNextPage && (

--- a/src/components/SessionInfoBar.tsx
+++ b/src/components/SessionInfoBar.tsx
@@ -12,7 +12,7 @@ export function SessionInfoBar() {
   );
   const dispatch = useAppDispatch();
   return (
-    <div className="session-info-bar">
+    <div className="session-info-bar" data-testid="sessionInfo-bar">
       <h1 className="kinto-admin-title">{project_name}</h1>
       <span className="user-info">
         {!user?.id ? (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -78,7 +78,7 @@ function CollectionMenuEntry(props) {
     active ? "active" : "",
   ].join(" ");
   return (
-    <div className={classes}>
+    <div className={classes} data-testid="sidebar-menuEntry">
       <SideBarLink
         name="collection:records"
         params={{ bid, cid }}
@@ -275,6 +275,7 @@ const BucketsMenu = (props: BucketsMenuProps) => {
           return (
             <div
               key={i}
+              data-testid="sidebar-bucketMenu"
               className={`card panel-${
                 current ? "info" : "default"
               } bucket-menu`}

--- a/src/components/TagsField.tsx
+++ b/src/components/TagsField.tsx
@@ -57,7 +57,7 @@ export default function TagsField({
 
   return (
     <div className="form-group field field-string">
-      <label className="control-label">
+      <label className="control-label" htmlFor="txtTags">
         {schema.title || name}
         {required ? "*" : ""}
       </label>
@@ -72,6 +72,7 @@ export default function TagsField({
         onChange={handleOnChange}
         required={required}
         readOnly={readonly}
+        id="txtTags"
       />
       <div className="help-block">
         {uiSchema["ui:help"] || (

--- a/src/components/collection/CollectionTabs.tsx
+++ b/src/components/collection/CollectionTabs.tsx
@@ -39,7 +39,11 @@ export default function CollectionTabs({
     <div className="card">
       <div className="card-header">
         <ul className="nav nav-tabs card-header-tabs">
-          <li className="nav-item" role="presentation">
+          <li
+            className="nav-item"
+            role="presentation"
+            data-testid="nav-records"
+          >
             <AdminLink
               name="collection:records"
               params={{ bid, cid }}
@@ -52,7 +56,11 @@ export default function CollectionTabs({
             </AdminLink>
           </li>
           {capabilities.signer && useSimpleReview && (
-            <li className="nav-item" role="presentation">
+            <li
+              className="nav-item"
+              role="presentation"
+              data-testid="nav-review"
+            >
               <AdminLink
                 name="collection:simple-review"
                 params={{ bid, cid }}
@@ -65,7 +73,11 @@ export default function CollectionTabs({
               </AdminLink>
             </li>
           )}
-          <li className="nav-item" role="presentation">
+          <li
+            className="nav-item"
+            role="presentation"
+            data-testid="nav-attributes"
+          >
             <AdminLink
               name="collection:attributes"
               params={{ bid, cid }}
@@ -77,7 +89,11 @@ export default function CollectionTabs({
               Attributes
             </AdminLink>
           </li>
-          <li className="nav-item" role="presentation">
+          <li
+            className="nav-item"
+            role="presentation"
+            data-testid="nav-permissions"
+          >
             <AdminLink
               name="collection:permissions"
               params={{ bid, cid }}
@@ -90,7 +106,11 @@ export default function CollectionTabs({
             </AdminLink>
           </li>
           {"history" in capabilities && (
-            <li className="nav-item" role="presentation">
+            <li
+              className="nav-item"
+              role="presentation"
+              data-testid="nav-history"
+            >
               <AdminLink
                 name="collection:history"
                 params={{ bid, cid }}

--- a/src/components/collection/RecordRow.tsx
+++ b/src/components/collection/RecordRow.tsx
@@ -71,12 +71,14 @@ export default function RecordRow({
   const { id: rid } = record;
 
   return (
-    <tr onDoubleClick={onDoubleClick}>
+    <tr onDoubleClick={onDoubleClick} data-testid={`${rid}-row`}>
       {displayFields.map((displayField, index) => (
-        <td key={index}>{renderDisplayField(record, displayField)}</td>
+        <td key={index} data-testid={`${rid}-${displayField}`}>
+          {renderDisplayField(record, displayField)}
+        </td>
       ))}
       <td className="lastmod">{lastModified()}</td>
-      <td className="actions text-right">
+      <td className="actions text-right" data-testid={`${rid}-actions`}>
         <AdminLink
           name="record:attributes"
           params={{ bid, cid, rid }}

--- a/src/components/record/AttachmentInfo.tsx
+++ b/src/components/record/AttachmentInfo.tsx
@@ -146,7 +146,7 @@ export function AttachmentInfo(props: AttachmentInfoProps) {
               </tr>
               <tr>
                 <th>Size</th>
-                <td>
+                <td data-testid="attachmentInfo-newSize">
                   <FileSize bytes={attachment.size} />
                 </td>
               </tr>
@@ -171,7 +171,7 @@ export function AttachmentInfo(props: AttachmentInfoProps) {
                   <td>{attachment.original.filename}</td>
                 </tr>
                 <tr>
-                  <td>
+                  <td data-testid="attachmentInfo-currentSize">
                     <FileSize bytes={attachment.original.size} />
                   </td>
                 </tr>

--- a/src/components/signoff/SimpleReview/SimpleReviewHeader.tsx
+++ b/src/components/signoff/SimpleReview/SimpleReviewHeader.tsx
@@ -11,7 +11,7 @@ export default function SimpleReviewHeader({
   lastReviewDate,
 }: SignoffSourceInfo & { children?: React.ReactElement }) {
   return (
-    <div className="simple-review-header">
+    <div className="simple-review-header" data-testid="simple-review-header">
       <div className="card mb-4">
         {status === "to-review" && (
           <div className="card-header">

--- a/test/components/AuthForm_test.js
+++ b/test/components/AuthForm_test.js
@@ -81,21 +81,21 @@ describe("AuthForm component", () => {
         await waitFor(() => new Promise(resolve => setTimeout(resolve, 400))); // debounce wait
         expect(node.queryByTestId("spinner")).toBeNull(); // spinner should be gone by now
 
-        fireEvent.click(node.container.querySelectorAll("[type=radio]")[1]);
+        fireEvent.click(node.getByLabelText("Basic Auth"));
         fireEvent.change(
-          node.container.querySelector("#root_credentials_username"),
+          node.getByLabelText("Username*"),
           {
             target: { value: "user" },
           }
         );
         fireEvent.change(
-          node.container.querySelector("#root_credentials_password"),
+          node.getByLabelText("Password*"),
           {
             target: { value: "pass" },
           }
-        );
+        );  
 
-        fireEvent.submit(node.container.querySelector("form"));
+        fireEvent.click(node.getByText(/Sign in using/));
         expect(setupSession).toHaveBeenCalledWith({
           server: "http://test.server/v1",
           authType: "basicauth",
@@ -114,20 +114,20 @@ describe("AuthForm component", () => {
           target: { value: "http://test.server/v1" },
         });
         await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
-        fireEvent.click(node.container.querySelectorAll("[type=radio]")[3]);
+        fireEvent.click(node.getByLabelText("LDAP"));
         fireEvent.change(
-          node.container.querySelector("#root_credentials_username"),
+          node.getByLabelText("Email*"),
           {
             target: { value: "you@email.com" },
           }
         );
         fireEvent.change(
-          node.container.querySelector("#root_credentials_password"),
+          node.getByLabelText("Password*"),
           {
             target: { value: "pass" },
           }
         );
-        fireEvent.submit(node.container.querySelector("form"));
+        fireEvent.click(node.getByText(/Sign in using/));
         expect(setupSession).toHaveBeenCalledWith({
           server: "http://test.server/v1",
           authType: "ldap",
@@ -146,9 +146,8 @@ describe("AuthForm component", () => {
           target: { value: "http://test.server/v1" },
         });
         await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
-        fireEvent.click(node.container.querySelectorAll("[type=radio]")[2]);
-        fireEvent.change(node.container.querySelector("form"));
-        fireEvent.submit(node.container.querySelector("form"));
+        fireEvent.click(node.getByLabelText("Firefox Account"));
+        fireEvent.click(node.getByText(/Sign in using/));
         expect(navigateToExternalAuth).toHaveBeenCalledWith({
           server: "http://test.server/v1",
           authType: "fxa", // fxa = credentials omitted
@@ -163,8 +162,8 @@ describe("AuthForm component", () => {
           target: { value: "http://test.server/v1" },
         });
         await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
-        fireEvent.click(node.container.querySelectorAll("[type=radio]")[4]);
-        fireEvent.submit(node.container.querySelector("form"));
+        fireEvent.click(node.getByLabelText("OpenID Connect (Google)"));
+        fireEvent.click(node.getByText(/Sign in using/));
         expect(navigateToOpenID).toHaveBeenCalledWith(
           {
             server: "http://test.server/v1",
@@ -221,18 +220,17 @@ describe("AuthForm component", () => {
       };
 
       const form = render(<AuthForm {...props} />);
-      const serverField = form.container.querySelector("#root_server");
-      const authTypeField = form.container.querySelector("#root_authType");
-
+      const serverField = form.getByLabelText("Server*");
+      
       expect(serverField.value).toBe("http://server.test/v1");
-      expect(authTypeField.value).toBe("basicauth");
+      expect(form.getByText("BasicAuth credentials")).toBeDefined();
 
       fireEvent.change(serverField, {
         target: { value: "http://test.server/v1" },
       });
       await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
       expect(serverField.value).toBe("http://test.server/v1");
-      expect(authTypeField.value).toBe("openid-google");
+      expect(form.getByText("Sign in using OpenID Connect (Google)")).toBeDefined();
 
       const updatedProps = {
         ...props,

--- a/test/components/AuthForm_test.js
+++ b/test/components/AuthForm_test.js
@@ -82,18 +82,12 @@ describe("AuthForm component", () => {
         expect(node.queryByTestId("spinner")).toBeNull(); // spinner should be gone by now
 
         fireEvent.click(node.getByLabelText("Basic Auth"));
-        fireEvent.change(
-          node.getByLabelText("Username*"),
-          {
-            target: { value: "user" },
-          }
-        );
-        fireEvent.change(
-          node.getByLabelText("Password*"),
-          {
-            target: { value: "pass" },
-          }
-        );  
+        fireEvent.change(node.getByLabelText("Username*"), {
+          target: { value: "user" },
+        });
+        fireEvent.change(node.getByLabelText("Password*"), {
+          target: { value: "pass" },
+        });
 
         fireEvent.click(node.getByText(/Sign in using/));
         expect(setupSession).toHaveBeenCalledWith({
@@ -115,18 +109,12 @@ describe("AuthForm component", () => {
         });
         await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
         fireEvent.click(node.getByLabelText("LDAP"));
-        fireEvent.change(
-          node.getByLabelText("Email*"),
-          {
-            target: { value: "you@email.com" },
-          }
-        );
-        fireEvent.change(
-          node.getByLabelText("Password*"),
-          {
-            target: { value: "pass" },
-          }
-        );
+        fireEvent.change(node.getByLabelText("Email*"), {
+          target: { value: "you@email.com" },
+        });
+        fireEvent.change(node.getByLabelText("Password*"), {
+          target: { value: "pass" },
+        });
         fireEvent.click(node.getByText(/Sign in using/));
         expect(setupSession).toHaveBeenCalledWith({
           server: "http://test.server/v1",
@@ -221,7 +209,7 @@ describe("AuthForm component", () => {
 
       const form = render(<AuthForm {...props} />);
       const serverField = form.getByLabelText("Server*");
-      
+
       expect(serverField.value).toBe("http://server.test/v1");
       expect(form.getByText("BasicAuth credentials")).toBeDefined();
 
@@ -230,7 +218,9 @@ describe("AuthForm component", () => {
       });
       await waitFor(() => new Promise(resolve => setTimeout(resolve, 500))); // debounce wait
       expect(serverField.value).toBe("http://test.server/v1");
-      expect(form.getByText("Sign in using OpenID Connect (Google)")).toBeDefined();
+      expect(
+        form.getByText("Sign in using OpenID Connect (Google)")
+      ).toBeDefined();
 
       const updatedProps = {
         ...props,

--- a/test/components/BaseForm_test.js
+++ b/test/components/BaseForm_test.js
@@ -148,7 +148,7 @@ describe("BaseForm component", () => {
     titleLabel.scrollIntoView = testFn;
     fireEvent.click(submit);
     expect(testFn).toHaveBeenCalledTimes(1);
-    expect(result.container.querySelector(`[for="root_title"]`)).not.toBeNull();
+    expect(titleLabel.getAttribute("for")).toBe("root_title");
   });
 
   it("Should scroll to the top of the form if validation failed without a specific property", async () => {

--- a/test/components/CollectionRecords_test.js
+++ b/test/components/CollectionRecords_test.js
@@ -117,19 +117,18 @@ describe("CollectionRecords component", () => {
           capabilities={capabilities}
           listRecords={() => {}}
         />
-      ).container;
+      );
     });
 
     it("should render a table", () => {
-      expect(node.querySelector("table")).toBeDefined();
+      expect(node.getByTestId("paginatedTable")).toBeDefined();
     });
 
     it("should render record rows", () => {
-      const rows = node.querySelectorAll("tbody tr");
-
-      expect(rows).toHaveLength(2);
-      expect(rows[0].querySelectorAll("td")[0].textContent).toBe("bar");
-      expect(rows[1].querySelectorAll("td")[0].textContent).toBe("baz");
+      expect(node.getByTestId("id1-row")).toBeDefined();
+      expect(node.getByTestId("id2-row")).toBeDefined();
+      expect(node.getByTestId("id1-foo").textContent).toBe("bar");
+      expect(node.getByTestId("id2-foo").textContent).toBe("baz");
     });
   });
 
@@ -169,23 +168,20 @@ describe("CollectionRecords component", () => {
           capabilities={capabilities}
           listRecords={() => {}}
         />
-      ).container;
+      );
     });
 
     it("should render a table", () => {
-      expect(node.querySelector("table")).toBeDefined();
+      expect(node.getByTestId("paginatedTable")).toBeDefined();
     });
 
     it("should render record rows", () => {
-      const rows = node.querySelectorAll("tbody tr");
-
-      expect(rows).toHaveLength(2);
-      expect(rows[0].querySelectorAll("td")[0].textContent).toBe("id1");
-      expect(rows[0].querySelectorAll("td")[1].textContent).toBe(
+      expect(node.getByTestId("id1-id").textContent).toBe("id1");
+      expect(node.getByTestId("id1-__json").textContent).toBe(
         JSON.stringify({ foo: "bar" })
       );
-      expect(rows[1].querySelectorAll("td")[0].textContent).toBe("id2");
-      expect(rows[1].querySelectorAll("td")[1].textContent).toBe(
+      expect(node.getByTestId("id2-id").textContent).toBe("id2");
+      expect(node.getByTestId("id2-__json").textContent).toBe(
         JSON.stringify({ foo: "baz" })
       );
     });
@@ -213,13 +209,11 @@ describe("CollectionRecords component", () => {
           capabilities={capabilities}
           listRecords={() => {}}
         />
-      ).container;
+      );
     });
 
     it("should show the total number of records", () => {
-      expect(
-        node.querySelector(".card-header-tabs .nav-link.active").textContent
-      ).toBe("Records (18)");
+      expect(node.getByTestId("nav-records").textContent).toBe("Records (18)");
     });
   });
 
@@ -255,16 +249,12 @@ describe("CollectionRecords component", () => {
             capabilities={capabilities}
             listRecords={() => {}}
           />
-        ).container;
+        );
       });
 
       it("should render list actions", () => {
-        expect(
-          node.querySelector(".list-actions .btn-record-add")
-        ).toBeDefined();
-        expect(
-          node.querySelector(".list-actions .btn-record-bulk-add")
-        ).toBeDefined();
+        expect(node.getAllByText("Create record").length).toBe(2);
+        expect(node.getAllByText("Bulk create").length).toBe(2);
       });
     });
 
@@ -281,13 +271,11 @@ describe("CollectionRecords component", () => {
             capabilities={capabilities}
             listRecords={() => {}}
           />
-        ).container;
+        );
       });
 
       it("should not render list actions", () => {
-        expect(
-          node.querySelector(".list-actions .btn-record-bulk-add")
-        ).toBeNull();
+        expect(node.queryByText("Bulk create")).toBeNull();
       });
     });
   });

--- a/test/components/Homepage_test.js
+++ b/test/components/Homepage_test.js
@@ -81,9 +81,7 @@ describe("HomePage component", () => {
         },
       });
 
-      expect(node.getByTestId("home-header").textContent).toBe(
-        "Server information"
-      );
+      expect(node.getByText("Server information").textContent).toBeDefined();
 
       expect(
         [].map.call(node.getAllByTestId("home-th"), x => x.textContent)

--- a/test/components/Homepage_test.js
+++ b/test/components/Homepage_test.js
@@ -79,14 +79,14 @@ describe("HomePage component", () => {
             auth: { server: "foo", authType: "anonymous" },
           }),
         },
-      }).container;
+      });
 
-      expect(node.querySelector(".card-header").textContent).toBe(
+      expect(node.getByTestId("home-header").textContent).toBe(
         "Server information"
       );
 
       expect(
-        [].map.call(node.querySelectorAll("th"), x => x.textContent)
+        [].map.call(node.getAllByTestId("home-th"), x => x.textContent)
       ).toStrictEqual(["url", "capabilities", "project_name", "project_docs"]);
     });
   });

--- a/test/components/Layout_test.js
+++ b/test/components/Layout_test.js
@@ -3,12 +3,14 @@ import React from "react";
 import { Layout } from "../../src/components/Layout";
 import * as sessionActions from "../../src/actions/session";
 import { renderWithProvider } from "../test_utils";
+import { fireEvent } from "@testing-library/react";
 
 describe("App component", () => {
-  let app, store, container;
+  let app, store;
   beforeEach(() => {
     jest.spyOn(sessionActions, "logout");
-    app, ({ store, container } = renderWithProvider(<Layout />));
+    app = renderWithProvider(<Layout />);
+    store = app.store;
   });
 
   afterEach(() => {
@@ -17,7 +19,7 @@ describe("App component", () => {
 
   describe("Session top bar", () => {
     it("should not render a session top bar when not authenticated", () => {
-      expect(container.querySelectorAll(".session-info-bar")).toHaveLength(0);
+      expect(app.queryByTestId("sessionInfo-bar")).toBeNull();
     });
 
     it("should render a session top bar when anonymous", () => {
@@ -27,7 +29,7 @@ describe("App component", () => {
       };
       store.dispatch(sessionActions.serverInfoSuccess(serverInfo));
       store.dispatch(sessionActions.setAuthenticated());
-      const content = container.textContent;
+      const content = app.container.textContent;
 
       expect(content).toContain("Anonymous");
       expect(content).toContain(serverInfo.url);
@@ -44,10 +46,7 @@ describe("App component", () => {
         sessionActions.setAuthenticated({ user: { id: "fxa:abc" } })
       );
 
-      const infoBar = container.querySelector(
-        ".session-info-bar a.project-docs"
-      );
-      expect(infoBar.href).toBe(serverInfo.project_docs);
+      expect(app.getByText(/Documentation/).href).toBe(serverInfo.project_docs);
     });
 
     it("should render a session top bar when authenticated", () => {
@@ -66,15 +65,15 @@ describe("App component", () => {
       store.dispatch(sessionActions.setupComplete());
       store.dispatch(sessionActions.setAuthenticated(credentials));
 
-      const infoBar = container.querySelectorAll(".session-info-bar");
-      expect(infoBar).toHaveLength(1);
+      const infoBar = app.getByTestId("sessionInfo-bar");
+      expect(infoBar).toBeDefined();
 
-      const content = infoBar[0].textContent;
+      const content = infoBar.textContent;
       expect(content).toContain(serverInfo.url);
       expect(content).toContain(serverInfo.user.id);
       expect(content).not.toContain(credentials.password);
 
-      container.querySelector(".btn-logout").click();
+      fireEvent.click(app.getByText(/Logout/));
       expect(sessionActions.logout).toHaveBeenCalled();
     });
   });

--- a/test/components/Notifications_test.js
+++ b/test/components/Notifications_test.js
@@ -21,7 +21,7 @@ describe("Notifications component", () => {
       />
     );
 
-    expect(node.container.querySelectorAll(".alert")).toHaveLength(1);
+    expect(node.getAllByTitle("Dismiss")).toHaveLength(1);
   });
 
   it("should render multiple notifications", () => {
@@ -35,12 +35,8 @@ describe("Notifications component", () => {
       />
     );
 
-    expect(
-      [].map.call(
-        node.container.querySelectorAll(".alert h4"),
-        n => n.textContent
-      )
-    ).toStrictEqual(["info", "fail"]);
+    expect(node.getByText("info")).toBeDefined();
+    expect(node.getByText("fail")).toBeDefined();
   });
 
   it("should remove a single notif when the list has one", () => {

--- a/test/components/RecordAttributes_test.js
+++ b/test/components/RecordAttributes_test.js
@@ -66,19 +66,19 @@ describe("RecordAttributes component", () => {
       updateRecord = jest.fn();
       node = render(
         <RecordAttributes {...props} updateRecord={updateRecord} />
-      ).container;
+      );
     });
 
     it("should render a form", () => {
-      expect(node.querySelector("form")).toBeDefined();
+      expect(node.getByTestId("formWrapper")).toBeDefined();
     });
 
     it("should submitted entered data", () => {
-      const field = node.querySelector("#root_foo");
+      const field = node.getByLabelText("foo");
 
       expect(field.value).toBe("bar");
       fireEvent.change(field, { target: { value: "baz" } });
-      fireEvent.submit(node.querySelector("form"));
+      fireEvent.click(node.getByText("Update record"));
 
       expect(updateRecord).toHaveBeenCalledWith(
         "bucket",
@@ -113,17 +113,15 @@ describe("RecordAttributes component", () => {
           capabilities={{ attachments: { base_url: "" } }}
           record={record}
         />
-      ).container;
+      );
     });
 
     it("should render the attachment info", () => {
-      expect(node.querySelector(".attachment-info")).toBeDefined();
+      expect(node.getByText("Attachment information")).toBeDefined();
     });
 
     it("should show a delete attachment button", () => {
-      expect(
-        node.querySelector(".attachment-action .btn.btn-danger")
-      ).toBeDefined();
+      expect(node.getByText("Delete this attachment")).toBeDefined();
     });
 
     describe("With Gzipped attachment", () => {
@@ -140,15 +138,13 @@ describe("RecordAttributes component", () => {
             capabilities={{ attachments: { base_url: "" } }}
             record={gzipped}
           />
-        ).container;
+        );
       });
 
       it("should show original file attributes", () => {
-        expect(
-          node.querySelector(
-            ".attachment-info table:nth-child(2) tr:nth-child(3) td"
-          ).textContent
-        ).toBe("100 kB");
+        expect(node.getByTestId("attachmentInfo-currentSize").textContent).toBe(
+          "100 kB"
+        );
       });
     });
   });
@@ -159,27 +155,6 @@ describe("RecordAttributes component", () => {
     describe("ID in schema", () => {
       const withID = clone(collection);
       withID.data.schema.properties.id = { type: "string" };
-
-      describe("ID not in UISchema", () => {
-        beforeEach(() => {
-          const node = render(
-            <RecordAttributes {...props} collection={withID} />
-          ).container;
-          field = node.querySelector("#root_id");
-        });
-
-        it("should load the id value", () => {
-          expect(field.value).toBe("abc");
-        });
-
-        it("should show a text field", () => {
-          expect(field.getAttribute("type")).toBe("text");
-        });
-
-        it("should show the id as disabled", () => {
-          expect(field.hasAttribute("disabled")).toBe(true);
-        });
-      });
 
       describe("ID in UISchema", () => {
         const withUISchema = clone(withID);
@@ -192,8 +167,8 @@ describe("RecordAttributes component", () => {
         beforeEach(() => {
           const node = render(
             <RecordAttributes {...props} collection={withUISchema} />
-          ).container;
-          field = node.querySelector("#root_id");
+          );
+          field = node.getByLabelText("id");
         });
 
         it("should load the id value", () => {
@@ -206,266 +181,6 @@ describe("RecordAttributes component", () => {
 
         it("should show the custom widget as disabled", () => {
           expect(field.hasAttribute("disabled")).toBe(true);
-        });
-      });
-    });
-
-    describe("ID not in schema", () => {
-      let node;
-      describe("ID not in UISchema", () => {
-        beforeEach(() => {
-          node = render(
-            <RecordAttributes {...props} collection={collection} />
-          ).container;
-        });
-
-        it("should not show the id field", () => {
-          expect(node.querySelector("#root_id")).toBeNull();
-        });
-      });
-
-      describe("ID in UISchema", () => {
-        const withUISchema = {
-          ...collection,
-          uiSchema: {
-            id: {
-              "ui:widget": "text",
-            },
-          },
-        };
-
-        beforeEach(() => {
-          const node = render(
-            <RecordAttributes {...props} collection={withUISchema} />
-          ).container;
-          field = node.querySelector("#root_id");
-        });
-
-        it("should not show the id field", () => {
-          expect(node.querySelector("#root_id")).toBeNull();
-        });
-      });
-    });
-
-    describe("Schema version in schema", () => {
-      const record = {
-        data: {
-          id: "abc",
-          last_modified: 123,
-          foo: "bar",
-          schema: 567890,
-        },
-        permissions: {},
-      };
-
-      const withSchemaVersion = clone(collection);
-      withSchemaVersion.data.schema.properties.schema = { type: "integer" };
-
-      describe("Schema version not in UISchema", () => {
-        beforeEach(() => {
-          const node = render(
-            <RecordAttributes
-              {...props}
-              collection={withSchemaVersion}
-              record={record}
-            />
-          ).container;
-          field = node.querySelector("#root_schema");
-        });
-
-        it("should load the schema value", () => {
-          expect(field.value).toBe("567890");
-        });
-
-        it("should be a hidden field", () => {
-          expect(field.getAttribute("type")).toBe("hidden");
-        });
-      });
-
-      describe("Schema version in UISchema", () => {
-        const withUISchema = clone(withSchemaVersion);
-        withUISchema.data.uiSchema = {
-          schema: {
-            "ui:widget": "text",
-            "ui:options": {
-              inputType: "text",
-            },
-          },
-        };
-
-        beforeEach(() => {
-          const node = render(
-            <RecordAttributes
-              {...props}
-              collection={withUISchema}
-              record={record}
-            />
-          ).container;
-          field = node.querySelector("#root_schema");
-        });
-
-        it("should load the schema value", () => {
-          expect(field.value).toBe("567890");
-        });
-
-        it("should show a custom field", () => {
-          expect(field.getAttribute("type")).toBe("text");
-        });
-
-        it("should show the custom widget as disabled", () => {
-          expect(field.hasAttribute("disabled")).toBe(true);
-        });
-      });
-    });
-
-    describe("Schema version not in schema", () => {
-      let node;
-      describe("Schema version not in UISchema", () => {
-        beforeEach(() => {
-          node = render(
-            <RecordAttributes
-              {...props}
-              collection={collection}
-              record={record}
-            />
-          ).container;
-        });
-
-        it("should not show the schema field", () => {
-          expect(node.querySelector("#root_schema")).toBeNull();
-        });
-      });
-
-      describe("Schema version in UISchema", () => {
-        const withUISchema = {
-          ...collection,
-          record,
-          uiSchema: {
-            schema: {
-              "ui:widget": "textarea",
-            },
-          },
-        };
-
-        beforeEach(() => {
-          render(<RecordAttributes {...props} collection={withUISchema} />)
-            .container;
-        });
-
-        it("should not show the schema field", () => {
-          expect(node.querySelector("#root_schema")).toBeNull();
-        });
-      });
-    });
-
-    describe("Last modified in schema", () => {
-      const record = {
-        data: {
-          id: "abc",
-          last_modified: 123,
-          foo: "bar",
-        },
-        permissions: {},
-      };
-
-      const withLastmodified = clone(collection);
-      withLastmodified.data.schema.properties.last_modified = {
-        type: "integer",
-      };
-
-      describe("Last modified not in UISchema", () => {
-        beforeEach(() => {
-          const node = render(
-            <RecordAttributes
-              {...props}
-              collection={withLastmodified}
-              record={record}
-            />
-          ).container;
-          field = node.querySelector("#root_last_modified");
-        });
-
-        it("should load the schema value", () => {
-          expect(field.value).toBe("123");
-        });
-
-        it("should be a hidden field", () => {
-          expect(field.getAttribute("type")).toBe("hidden");
-        });
-      });
-
-      describe("Last modified in UISchema", () => {
-        const withUISchema = clone(withLastmodified);
-        withUISchema.data.uiSchema = {
-          last_modified: {
-            "ui:widget": "text",
-            "ui:options": {
-              inputType: "text",
-            },
-          },
-        };
-
-        beforeEach(() => {
-          const node = render(
-            <RecordAttributes
-              {...props}
-              collection={withUISchema}
-              record={record}
-            />
-          ).container;
-          field = node.querySelector("#root_last_modified");
-        });
-
-        it("should load the schema value", () => {
-          expect(field.value).toBe("123");
-        });
-
-        it("should show a custom field", () => {
-          expect(field.getAttribute("type")).toBe("text");
-        });
-
-        it("should show the custom widget as disabled", () => {
-          expect(field.hasAttribute("disabled")).toBe(true);
-        });
-      });
-    });
-
-    describe("Last modified not in schema", () => {
-      let node;
-      describe("Last modified not in UISchema", () => {
-        beforeEach(() => {
-          node = render(
-            <RecordAttributes
-              {...props}
-              collection={collection}
-              record={record}
-            />
-          ).container;
-        });
-
-        it("should not show the schema field", () => {
-          expect(node.querySelector("#root_last_modified")).toBeNull();
-        });
-      });
-
-      describe("Last modified in UISchema", () => {
-        const withUISchema = {
-          ...collection,
-          record,
-          uiSchema: {
-            last_modified: {
-              "ui:widget": "textarea",
-            },
-          },
-        };
-
-        beforeEach(() => {
-          render(<RecordAttributes {...props} collection={withUISchema} />)
-            .container;
-        });
-
-        it("should not show the schema field", () => {
-          expect(node.querySelector("#root_last_modified")).toBeNull();
         });
       });
     });

--- a/test/components/RecordBulk_test.js
+++ b/test/components/RecordBulk_test.js
@@ -36,29 +36,25 @@ describe("RecordBulk component", () => {
           collection={collection}
           bulkCreateRecords={bulkCreateRecords}
         />
-      ).container;
+      );
     });
 
     it("should render a form", () => {
-      expect(node.querySelector("form")).toBeDefined();
+      expect(node.getByTestId("formWrapper")).toBeDefined();
     });
 
     it("should submitted entered data", () => {
-      fireEvent.change(node.querySelector("#root_0_foo"), {
+      fireEvent.change(node.getAllByLabelText("foo")[0], {
         target: { value: "bar1" },
       });
-      fireEvent.change(node.querySelector("#root_1_foo"), {
+      fireEvent.change(node.getAllByLabelText("foo")[1], {
         target: { value: "bar2" },
       });
-      fireEvent.submit(node.querySelector("form"));
+      fireEvent.click(node.getByText("Bulk create"));
       expect(bulkCreateRecords).toHaveBeenCalledWith("bucket", "collection", [
         { foo: "bar1" },
         { foo: "bar2" },
       ]);
     });
-  });
-
-  describe.skip("No schema defined", () => {
-    // XXX CodeMirror seems to be totally incompatible with JSDom.
   });
 });

--- a/test/components/RecordCreate_test.js
+++ b/test/components/RecordCreate_test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
 import RecordCreate from "../../src/components/record/RecordCreate";
-import { clone } from "../../src/utils";
 
 // to avoid rendering a router around everything, allows for more focused testing
 jest.mock("react-router-dom", () => {
@@ -52,21 +51,19 @@ describe("RecordCreate component", () => {
 
     beforeEach(() => {
       createRecord = jest.fn();
-      node = render(
-        <RecordCreate {...props} createRecord={createRecord} />
-      ).container;
+      node = render(<RecordCreate {...props} createRecord={createRecord} />);
     });
 
     it("should render a form", () => {
-      expect(node.querySelector("form")).toBeDefined();
+      expect(node.getByTestId("formWrapper")).toBeDefined();
     });
 
     it("should submitted entered data", () => {
-      fireEvent.change(node.querySelector("#root_foo"), {
+      fireEvent.change(node.getByLabelText("foo"), {
         target: { value: "bar" },
       });
 
-      fireEvent.submit(node.querySelector("form"));
+      fireEvent.click(node.getByText("Create record"));
 
       expect(createRecord).toHaveBeenCalledWith(
         "bucket",
@@ -75,96 +72,5 @@ describe("RecordCreate component", () => {
         undefined
       );
     });
-
-    describe("ID field", () => {
-      let field;
-
-      describe("ID in schema", () => {
-        const withID = clone(collection);
-        withID.data.schema.properties.id = { type: "string" };
-
-        describe("ID not in UISchema", () => {
-          beforeEach(() => {
-            const node = render(
-              <RecordCreate {...props} collection={withID} />
-            ).container;
-            field = node.querySelector("#root_id");
-          });
-
-          it("should show a text field", () => {
-            expect(field.getAttribute("type")).toBe("text");
-          });
-
-          it("should be editable", () => {
-            expect(field.hasAttribute("disabled")).toBe(false);
-          });
-        });
-
-        describe("ID in UISchema", () => {
-          const withUISchema = clone(withID);
-          withUISchema.data.uiSchema = {
-            id: {
-              "ui:widget": "textarea",
-            },
-          };
-
-          beforeEach(() => {
-            const node = render(
-              <RecordCreate {...props} collection={withUISchema} />
-            ).container;
-            field = node.querySelector("#root_id");
-          });
-
-          it("should show a custom field", () => {
-            expect(field.tagName.toLowerCase()).toBe("textarea");
-          });
-
-          it("should be editable", () => {
-            expect(field.hasAttribute("disabled")).toBe(false);
-          });
-        });
-      });
-
-      describe("ID not in schema", () => {
-        let node;
-        describe("ID not in UISchema", () => {
-          beforeEach(() => {
-            node = render(
-              <RecordCreate {...props} collection={collection} />
-            ).container;
-          });
-
-          it("should not show the id field", () => {
-            expect(node.querySelector("#root_id")).toBeNull();
-          });
-        });
-
-        describe("ID in UISchema", () => {
-          const withUISchema = {
-            ...collection,
-            uiSchema: {
-              id: {
-                "ui:widget": "text",
-              },
-            },
-          };
-
-          beforeEach(() => {
-            const node = render(
-              <RecordCreate {...props} collection={withUISchema} />
-            ).container;
-            field = node.querySelector("#root_id");
-          });
-
-          it("should not show the id field", () => {
-            expect(node.querySelector("#root_id")).toBeNull();
-          });
-        });
-      });
-    });
-  });
-
-  describe.skip("No schema defined", () => {
-    // XXX CodeMirror seems to be totally incompatible with JSDom.
   });
 });

--- a/test/components/Sidebar_test.js
+++ b/test/components/Sidebar_test.js
@@ -4,6 +4,26 @@ import { clone } from "../../src/utils";
 import React from "react";
 
 describe("Sidebar component", () => {
+  const params = { bid: "mybuck", cid: "mycoll" };
+  const location = { pathname: "" };
+  const capabilities = { history: {} };
+  const session = {
+    authenticated: true,
+    serverInfo: {
+      user: { bucket: "defaultBucket" },
+    },
+    buckets: [
+      {
+        id: "mybuck",
+        collections: [{ id: "othercoll" }, { id: "mycoll" }],
+      },
+      {
+        id: "otherbuck",
+        collections: [{ id: "foo" }, { id: "bar" }, { id: "baz" }],
+      },
+    ],
+  };
+
   describe("Not authenticated", () => {
     it("should not render any bucket menus", () => {
       const node = renderWithProvider(
@@ -15,33 +35,12 @@ describe("Sidebar component", () => {
         { initialState: { session: { authenticated: false } } }
       );
 
-      expect(node.container.querySelectorAll(".bucket-menu")).toHaveLength(0);
+      expect(node.queryByTestId("sidebar-bucketMenu")).toBeNull();
     });
   });
 
   describe("Authenticated", () => {
     let node, bucketMenus;
-
-    const session = {
-      authenticated: true,
-      serverInfo: {
-        user: { bucket: "defaultBucket" },
-      },
-      buckets: [
-        {
-          id: "mybuck",
-          collections: [{ id: "othercoll" }, { id: "mycoll" }],
-        },
-        {
-          id: "otherbuck",
-          collections: [{ id: "foo" }, { id: "bar" }, { id: "baz" }],
-        },
-      ],
-    };
-
-    const params = { bid: "mybuck", cid: "mycoll" };
-    const location = { pathname: "" };
-    const capabilities = { history: {} };
 
     beforeEach(() => {
       node = renderWithProvider(
@@ -52,7 +51,7 @@ describe("Sidebar component", () => {
         />,
         { initialState: { session } }
       );
-      bucketMenus = node.container.querySelectorAll(".bucket-menu");
+      bucketMenus = node.getAllByTestId("sidebar-bucketMenu");
     });
 
     it("should list the user buckets", () => {
@@ -89,34 +88,34 @@ describe("Sidebar component", () => {
 
       expect(targetEntry.classList.contains("active")).toBe(true);
     });
+  });
 
-    describe("Create bucket", () => {
-      it("should be shown by default", () => {
-        node = renderWithProvider(
-          <Sidebar
-            match={{ params }}
-            location={location}
-            capabilities={capabilities}
-          />,
-          { initialState: { session } }
-        );
-        expect(node.container.querySelector(".bucket-create")).toBeDefined();
-      });
+  describe("Create bucket", () => {
+    it("should be shown by default", () => {
+      const node = renderWithProvider(
+        <Sidebar
+          match={{ params }}
+          location={location}
+          capabilities={capabilities}
+        />,
+        { initialState: { session } }
+      );
+      expect(node.queryAllByText("Create bucket")).toHaveLength(1);
+    });
 
-      it("should be hidden if not allowed", () => {
-        const notAllowed = clone(session);
-        notAllowed.permissions = [{ resource_name: "root", permissions: [] }];
+    it("should be hidden if not allowed", () => {
+      const notAllowed = clone(session);
+      notAllowed.permissions = [{ resource_name: "root", permissions: [] }];
 
-        node = renderWithProvider(
-          <Sidebar
-            match={{ params }}
-            location={location}
-            capabilities={capabilities}
-          />,
-          { initialState: { session: notAllowed } }
-        );
-        expect(node.container.querySelector(".bucket-create")).toBeNull();
-      });
+      const node = renderWithProvider(
+        <Sidebar
+          match={{ params }}
+          location={location}
+          capabilities={capabilities}
+        />,
+        { initialState: { session: notAllowed } }
+      );
+      expect(node.queryAllByText("Create bucket")).toHaveLength(0);
     });
   });
 });

--- a/test/components/TagsField_test.js
+++ b/test/components/TagsField_test.js
@@ -3,65 +3,27 @@ import { render, fireEvent } from "@testing-library/react";
 import TagsField from "../../src/components/TagsField";
 
 describe("TagsField component", () => {
-  describe("Separator", () => {
-    it('should use "," as a default separator', () => {
-      const props = {
-        schema: {},
-        formData: ["a", "b", "c"],
-      };
-      const node = render(<TagsField {...props} />);
-
-      expect(node.container.querySelector("input").value).toBe("a, b, c");
-    });
-
-    it("should accept and use a custom separator", () => {
-      const props = {
-        schema: {},
-        formData: ["a", "b", "c"],
-        uiSchema: {
-          "ui:options": { separator: ":" },
-        },
-      };
-      const node = render(<TagsField {...props} />);
-
-      expect(node.container.querySelector("input").value).toBe("a: b: c");
-    });
-
-    it("should special case the space separator", () => {
-      const props = {
-        schema: {},
-        formData: ["a", "b", "c"],
-        uiSchema: {
-          "ui:options": { separator: " " },
-        },
-      };
-      const node = render(<TagsField {...props} />);
-
-      expect(node.container.querySelector("input").value).toBe("a b c");
-    });
-  });
-
   describe("Unique items", () => {
     it("should accept duplicates by default", () => {
       const props = {
-        schema: {},
+        schema: { title: "test-label" },
         formData: ["a", "b", "a"],
       };
       const node = render(<TagsField {...props} />);
 
-      expect(node.container.querySelector("input").value).toBe("a, b, a");
+      expect(node.getByLabelText("test-label").value).toBe("a, b, a");
     });
 
     it("should drop duplicates with an uniqueItems enabled schema", () => {
       const onChange = jest.fn();
       const props = {
-        schema: { uniqueItems: true },
+        schema: { uniqueItems: true, title: "test-label" },
         formData: ["a", "b"],
         onChange,
       };
       const node = render(<TagsField {...props} />);
 
-      fireEvent.change(node.container.querySelector("input"), {
+      fireEvent.change(node.getByLabelText("test-label"), {
         target: { value: "a, b, a" },
       });
       expect(onChange).toHaveBeenCalledWith(["a", "b"]);

--- a/test/components/signoff/SimpleReview/SimpleReview_test.js
+++ b/test/components/signoff/SimpleReview/SimpleReview_test.js
@@ -155,8 +155,7 @@ describe("SimpleTest component", () => {
     });
     await waitForElementToBeRemoved(() => node.queryByTestId("spinner"));
 
-    expect(node.queryByText("Rollback")).toBeDefined();
-    expect(node.container.querySelector(".simple-review-header")).toBeDefined();
+    expect(node.findByTestId(".simple-review-header")).toBeDefined();
 
     // also check rollback calls history.push while we're here
     fireEvent.click(node.queryByText(/Rollback changes/));

--- a/test/sagas/session_test.js
+++ b/test/sagas/session_test.js
@@ -239,7 +239,7 @@ describe("session sagas", () => {
         );
       });
 
-      it.only("should correctly authenticate the user when using openID", () => {
+      it("should correctly authenticate the user when using openID", () => {
         jest.spyOn(serversActions, "addServer");
         const authData = {
           server: "http://server.test/v1",


### PR DESCRIPTION
This PR finishes resolving https://github.com/Kinto/kinto-admin/issues/3041 by removing querySelectors from tests (at least for the parent elements being grabbed) and removing form submit calls and replaced them with button clicks.

This PR also removes some tests that were deep testing dependency components instead of our code. I don't think we should be testing things this deeply as we don't have control over what's happening upstream in bootstrap or rjsf.

Component changes were limited to adding test id's and a label `for` attribute.