### PR TITLE
Rename build directory from `dist` to `build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cs-format": "prettier \"{src,test}/**/*.{js,ts,tsx}\" --write",
     "lint": "eslint \"src/**/*.{js,ts,tsx}\" \"test/**/*.{js,ts,tsx}\"",
     "preview": "vite preview",
-    "publish-to-gh-pages": "cross-env ASSET_PATH=/kinto-admin/ npm run build && gh-pages --add --dist dist/",
+    "publish-to-gh-pages": "cross-env ASSET_PATH=/kinto-admin/ npm run build && gh-pages --add --dist build/",
     "start": "vite",
     "tdd": "vitest",
     "test": "vitest --watch=false",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
   define: {
     KINTO_ADMIN_VERSION: JSON.stringify(process.env.npm_package_version),
   },
+  build: {
+    outDir: "build"
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
Goes from a vite default to our old directory name, with the intention of being more backwards-compatible