### PR TITLE
Fix login screen notifications when token is expired

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "vite build",
     "build:readme": "toctoc README.md -w",
+    "build:kinto-single": "ASSET_PATH=/v1/admin KINTO_ADMIN_SINGLE_SERVER=1 vite build",
     "cs-check": "prettier -l \"{src,test}/**/*.{js,ts,tsx}\"",
     "cs-format": "prettier \"{src,test}/**/*.{js,ts,tsx}\" --write",
     "lint": "eslint \"src/**/*.{js,ts,tsx}\" \"test/**/*.{js,ts,tsx}\"",

--- a/src/types.ts
+++ b/src/types.ts
@@ -351,72 +351,63 @@ export type AuthMethod =
   | "portier"
   | "openid";
 
-export type AuthData =
-  | AnonymousAuth
-  | LDAPAuth
-  | AccountAuth
-  | BasicAuth
-  | PortierAuth
-  | TokenAuth
-  | OpenIDAuth;
+export type AuthData = {
+  authType: AuthMethod;
+  server: string;
+  expiresAt?: number;
+};
 
 export type AnonymousAuth = {
   authType: "anonymous";
-  server: string;
-};
+} & AuthData;
 
 export type LDAPAuth = {
   authType: "ldap";
-  server: string;
   credentials: {
     username: string;
     password: string;
   };
-};
+} & AuthData;
 
 export type AccountAuth = {
   authType: "account";
-  server: string;
   credentials: {
     username: string;
     password: string;
   };
-};
+} & AuthData;
 
 export type BasicAuth = {
   authType: "basicauth";
-  server: string;
   credentials: {
     username: string;
     password: string;
   };
-};
+} & AuthData;
 
 export type PortierAuth = {
   authType: "portier";
-  server: string;
   credentials: {
     token: string;
   };
-};
+} & AuthData;
 
 export type TokenAuth = {
   authType: "fxa";
-  server: string;
   credentials: {
     token: string;
   };
-};
+} & AuthData;
 
 export type OpenIDAuth = {
   authType: "openid";
-  server: string;
   provider: string;
   tokenType: string;
   credentials: {
     token: string;
+    expiresAt?: number;
   };
-};
+} & AuthData;
 
 export type SagaGen = Generator<any, void, any>;
 

--- a/test/components/Homepage_test.jsx
+++ b/test/components/Homepage_test.jsx
@@ -47,6 +47,11 @@ describe("HomePage component", () => {
     describe("After OpenID redirection", () => {
       it("should setup session when component is mounted", () => {
         const setupSession = vi.spyOn(SessionActions, "setupSession");
+        
+        vi.useFakeTimers();
+        let fakeDate = new Date(2024, 1, 2, 3, 4, 5, 6);
+        vi.setSystemTime(fakeDate);
+        
         const payload =
           "eyJzZXJ2ZXIiOiJodHRwczovL2RlbW8ua2ludG8tc3RvcmFnZS5vcmcvdjEvIiwiYXV0aFR5cGUiOiJvcGVuaWQtYXV0aDAiLCJyZWRpcmVjdFVSTCI6bnVsbH0";
         const token =
@@ -65,7 +70,10 @@ describe("HomePage component", () => {
           tokenType: "Bearer",
           credentials: { token: "oXJNgbNayWPKF" },
           server: "https://demo.kinto-storage.org/v1/",
+          expiresAt: fakeDate.getTime() + 86400 * 1000,
         });
+
+        vi.useRealTimers();
       });
     });
   });

--- a/test/components/Homepage_test.jsx
+++ b/test/components/Homepage_test.jsx
@@ -42,6 +42,25 @@ describe("HomePage component", () => {
           server: expect.stringMatching(/./),
         });
       });
+
+      it("should call getServerInfo if expiresAt is in the past", () => {
+        vi.useFakeTimers();
+        let fakeDate = new Date(2024, 1, 2, 3, 4, 5, 6);
+        vi.setSystemTime(fakeDate);
+        
+        const auth = {
+          authType: "anonymous",
+          server: "http://server.test/v1",
+          expiresAt: new Date(2024, 1, 2, 3, 4, 5, 0).getTime(),
+        };
+        const getServerInfo = vi.spyOn(SessionActions, "getServerInfo");
+        localStore.saveSession({ auth });
+        renderWithProvider(<HomePage />);
+
+        expect(getServerInfo).toHaveBeenCalled();
+
+        vi.useRealTimers();
+      });
     });
 
     describe("After OpenID redirection", () => {


### PR DESCRIPTION
Resolves https://github.com/Kinto/kinto-admin/issues/3123 . Adding logic to re-authenticate when users land on the home page with an expired open-id token. Adjusted tests.

This would also be easy to expand and handle other auth types if we want.