### PR TITLE
Fixes #3079 - Adding display fields to diff view headers in review process

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -32,6 +32,12 @@ h1 {
 
 .card-header span {
   margin-right: 1em;
+  max-width: 26vw;
+  display: inline-block;
+  height: 1.5em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .card-header span label {

--- a/css/styles.css
+++ b/css/styles.css
@@ -32,7 +32,7 @@ h1 {
 
 .card-header span {
   margin-right: 1em;
-  max-width: 26vw;
+  max-width: 26em;
   display: inline-block;
   height: 1.5em;
   overflow: hidden;

--- a/css/styles.css
+++ b/css/styles.css
@@ -30,6 +30,14 @@ h1 {
   border-color: #b8daff;
 }
 
+.card-header span {
+  margin-right: 1em;
+}
+
+.card-header span label {
+  font-weight: bold;
+}
+
 .sidebar-filters > .card-body {
   padding: 15px 15px 0 15px;
 }

--- a/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
+++ b/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
@@ -178,12 +178,20 @@ export function formatDiffHeader({
   let fields = [];
 
   for (let f of displayFields) {
-    fields.push(`${f}: ${(target || source)[f] || "undefined"}`);
+    fields.push(
+      <span>
+        <label>{f}:</label> {(target || source)[f] || "undefined"}
+      </span>
+    );
   }
 
-  fields.push((target || source).id);
+  fields.push(
+    <span>
+      <label>id:</label> {(target || source).id}
+    </span>
+  );
 
-  return fields.join(" | ");
+  return <>{fields}</>;
 }
 
 function recordsAreDifferent(a: ValidRecord, b: ValidRecord): boolean {

--- a/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
+++ b/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
@@ -180,7 +180,7 @@ export function formatDiffHeader({
   for (let f of displayFields) {
     fields.push(
       <span>
-        <label>{f}:</label> { renderDisplayField(target || source, f) }
+        <label>{f}:</label> {renderDisplayField(target || source, f)}
       </span>
     );
   }

--- a/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
+++ b/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
@@ -102,7 +102,7 @@ function Diff({
   target?: ValidRecord;
   className?: string;
   allLines?: boolean;
-  displayFields?: string[]
+  displayFields?: string[];
 }) {
   let diff: string[];
 
@@ -124,7 +124,8 @@ function Diff({
       data-testid="record-diff"
     >
       <div className="card-header">
-        <DiffLabel changeType={changeType} /> {formatDiffHeader({ source, target, displayFields })}
+        <DiffLabel changeType={changeType} />{" "}
+        {formatDiffHeader({ source, target, displayFields })}
       </div>
       <div className="card-body p-0">
         <pre className="json-record json-record-simple-review mb-0">
@@ -166,22 +167,22 @@ function DiffLabel({ changeType }: { changeType: ChangeType }) {
 }
 
 export function formatDiffHeader({
-  source, 
-  target, 
-  displayFields = []
+  source,
+  target,
+  displayFields = [],
 }: {
-  source: ValidRecord, 
-  target: ValidRecord, 
-  displayFields: string[]
+  source: ValidRecord;
+  target: ValidRecord;
+  displayFields: string[];
 }) {
   let fields = [];
 
   for (let f of displayFields) {
-    fields.push(`${f}: ${(target || source)[f] || "undefined" }`);
+    fields.push(`${f}: ${(target || source)[f] || "undefined"}`);
   }
 
   fields.push((target || source).id);
-  
+
   return fields.join(" | ");
 }
 

--- a/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
+++ b/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
@@ -16,12 +16,14 @@ export interface PerRecordDiffViewProps {
   oldRecords: ValidRecord[];
   newRecords: ValidRecord[];
   collectionData: SignoffSourceInfo;
+  displayFields?: string[];
 }
 
 export default function PerRecordDiffView({
   oldRecords,
   newRecords,
   collectionData,
+  displayFields,
 }: PerRecordDiffViewProps) {
   const [showExtraFields, setShowExtraFields] = useState(false);
   const [showAllLines, setShowAllLines] = useState(false);
@@ -70,6 +72,7 @@ export default function PerRecordDiffView({
               source={source}
               target={target}
               allLines={showAllLines}
+              displayFields={displayFields}
             />
           ))}
         </div>
@@ -91,6 +94,7 @@ function Diff({
   target,
   className = "",
   allLines = false,
+  displayFields,
 }: {
   id: string;
   changeType: ChangeType;
@@ -98,6 +102,7 @@ function Diff({
   target?: ValidRecord;
   className?: string;
   allLines?: boolean;
+  displayFields?: string[]
 }) {
   let diff: string[];
 
@@ -119,7 +124,7 @@ function Diff({
       data-testid="record-diff"
     >
       <div className="card-header">
-        <DiffLabel changeType={changeType} /> {id}
+        <DiffLabel changeType={changeType} /> {formatDiffHeader({ source, target, displayFields })}
       </div>
       <div className="card-body p-0">
         <pre className="json-record json-record-simple-review mb-0">
@@ -158,6 +163,26 @@ function DiffLabel({ changeType }: { changeType: ChangeType }) {
     case ChangeType.EMPTY_UPDATE:
       return <span className={"text-secondary"}>[unchanged]</span>;
   }
+}
+
+export function formatDiffHeader({
+  source, 
+  target, 
+  displayFields = []
+}: {
+  source: ValidRecord, 
+  target: ValidRecord, 
+  displayFields: string[]
+}) {
+  let fields = [];
+
+  for (let f of displayFields) {
+    fields.push(`${f}: ${(target || source)[f] || "undefined" }`);
+  }
+
+  fields.push((target || source).id);
+  
+  return fields.join(" | ");
 }
 
 function recordsAreDifferent(a: ValidRecord, b: ValidRecord): boolean {

--- a/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
+++ b/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { omit, diffJson } from "../../../utils";
+import { omit, diffJson, renderDisplayField } from "../../../utils";
 import type { ValidRecord, SignoffSourceInfo } from "../../../types";
 import { diffArrays, diffJson as diff } from "diff";
 
@@ -180,7 +180,7 @@ export function formatDiffHeader({
   for (let f of displayFields) {
     fields.push(
       <span>
-        <label>{f}:</label> {(target || source)[f] || "undefined"}
+        <label>{f}:</label> { renderDisplayField(target || source, f) }
       </span>
     );
   }

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -178,7 +178,7 @@ export default function SimpleReview({
           oldRecords={records.oldRecords}
           newRecords={records.newRecords}
           collectionData={signoffSource}
-          displayFields={collection.data?.displayFields}
+          displayFields={collection?.data?.displayFields}
         />
         <button
           type="button"

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -158,7 +158,7 @@ export default function SimpleReview({
         </div>
       );
     }
-    
+
     return (
       <>
         {signoffSource.status !== "signed" && (

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -158,6 +158,7 @@ export default function SimpleReview({
         </div>
       );
     }
+    console.log(collection);
     return (
       <>
         {signoffSource.status !== "signed" && (
@@ -177,6 +178,7 @@ export default function SimpleReview({
           oldRecords={records.oldRecords}
           newRecords={records.newRecords}
           collectionData={signoffSource}
+          displayFields={collection.data?.displayFields}
         />
         <button
           type="button"

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -158,7 +158,7 @@ export default function SimpleReview({
         </div>
       );
     }
-    console.log(collection);
+    
     return (
       <>
         {signoffSource.status !== "signed" && (

--- a/test/components/signoff/SimpleReview/PerRecordDiffView_test.jsx
+++ b/test/components/signoff/SimpleReview/PerRecordDiffView_test.jsx
@@ -1,6 +1,7 @@
 import PerRecordDiffView, {
   findChangeTypes,
   ChangeType,
+  formatDiffHeader,
 } from "../../../../src/components/signoff/SimpleReview/PerRecordDiffView";
 import React from "react";
 import { render } from "@testing-library/react";
@@ -133,5 +134,46 @@ describe("findChangeTypes", () => {
       { id: "d", changeType: ChangeType.REMOVE, source: d },
       { id: "e", changeType: ChangeType.EMPTY_UPDATE, source: e, target: e2 },
     ]);
+  });
+});
+
+describe("formatDiffHeader", () => {
+  it("returns expected header based on provided records and displayFields", () => {
+    expect(formatDiffHeader({
+      target: { id: "foo"}
+    })).toStrictEqual("foo");
+
+    expect(formatDiffHeader({
+      source: { id: "foo"}
+    })).toStrictEqual("foo");
+
+    expect(formatDiffHeader({
+      source: { 
+        id: "foo",
+        prop1: "val1",
+        prop2: "val2",
+      },
+      target: { 
+        id: "foo",
+        prop1: "val3",
+        prop2: "val4",
+      }
+    })).toStrictEqual("foo");
+
+    expect(formatDiffHeader({
+      source: { 
+        id: "foo",
+        prop1: "val1",
+        prop2: "val2",
+        prop3: "prevVal",
+      },
+      target: { 
+        id: "foo",
+        prop1: "val3",
+        prop2: "val4",
+        // prop3 intentionally undefined
+      },
+      displayFields: [ "prop1", "prop2", "prop3"]
+    })).toStrictEqual("prop1: val3 | prop2: val4 | prop3: undefined | foo");
   });
 });

--- a/test/components/signoff/SimpleReview/PerRecordDiffView_test.jsx
+++ b/test/components/signoff/SimpleReview/PerRecordDiffView_test.jsx
@@ -139,15 +139,22 @@ describe("findChangeTypes", () => {
 
 describe("formatDiffHeader", () => {
   it("returns expected header based on provided records and displayFields", () => {
-    expect(formatDiffHeader({
+
+    let getTextContent = (props) => {
+      return render(
+        formatDiffHeader(props)
+      ).container.textContent;
+    };
+    
+    expect(getTextContent({
       target: { id: "foo"}
-    })).toStrictEqual("foo");
-
-    expect(formatDiffHeader({
+    })).toBe("id: foo");
+    
+    expect(getTextContent({
       source: { id: "foo"}
-    })).toStrictEqual("foo");
+    })).toBe("id: foo");
 
-    expect(formatDiffHeader({
+    expect(getTextContent({
       source: { 
         id: "foo",
         prop1: "val1",
@@ -158,9 +165,9 @@ describe("formatDiffHeader", () => {
         prop1: "val3",
         prop2: "val4",
       }
-    })).toStrictEqual("foo");
+    })).toBe("id: foo");
 
-    expect(formatDiffHeader({
+    expect(getTextContent({
       source: { 
         id: "foo",
         prop1: "val1",
@@ -174,6 +181,6 @@ describe("formatDiffHeader", () => {
         // prop3 intentionally undefined
       },
       displayFields: [ "prop1", "prop2", "prop3"]
-    })).toStrictEqual("prop1: val3 | prop2: val4 | prop3: undefined | foo");
+    })).toBe("prop1: val3prop2: val4prop3: undefinedid: foo");
   });
 });

--- a/test/components/signoff/SimpleReview/PerRecordDiffView_test.jsx
+++ b/test/components/signoff/SimpleReview/PerRecordDiffView_test.jsx
@@ -181,6 +181,16 @@ describe("formatDiffHeader", () => {
         // prop3 intentionally undefined
       },
       displayFields: [ "prop1", "prop2", "prop3"]
-    })).toBe("prop1: val3prop2: val4prop3: undefinedid: foo");
+    })).toBe("prop1: val3prop2: val4prop3: <unknown>id: foo");
+
+    expect(getTextContent({
+      target: { 
+        id: "foo",
+        prop: { 
+          nestedProp: "nestedVal"
+        },
+      },
+      displayFields: [ "prop.nestedProp"]
+    })).toBe("prop.nestedProp: nestedValid: foo");
   });
 });


### PR DESCRIPTION
Fixes #3079 - Adding displayFields properties and values to record headers in diff view.
Added unit test to check

![image](https://github.com/Kinto/kinto-admin/assets/148472676/adedb13d-ee4b-461c-9533-672c44d484ba)

**Note to reviewers:** I am very open to formatting suggestions for making this more readable.

Screenshot with long properties in the header bar:
![image](https://github.com/Kinto/kinto-admin/assets/148472676/bc5dc83b-0afb-4808-8b9b-ac77418f438e)
