### PR TITLE
Allow records to be updated without inserting new attachments

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -30,6 +30,14 @@ h1 {
   border-color: #b8daff;
 }
 
+.card-header span {
+  margin-right: 1em;
+}
+
+.card-header span label {
+  font-weight: bold;
+}
+
 .sidebar-filters > .card-body {
   padding: 15px 15px 0 15px;
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "cs-format": "prettier \"{src,test}/**/*.{js,ts,tsx}\" --write",
     "lint": "eslint \"src/**/*.{js,ts,tsx}\" \"test/**/*.{js,ts,tsx}\"",
     "preview": "vite preview",
-    "publish-to-gh-pages": "cross-env ASSET_PATH=/kinto-admin/ npm run build && gh-pages --add --dist build/",
+    "publish-to-gh-pages": "ASSET_PATH=/kinto-admin/ npm run build && gh-pages --add --dist build/",
     "start": "vite",
     "tdd": "vitest",
     "test": "vitest --watch=false",

--- a/src/components/record/JSONRecordForm.tsx
+++ b/src/components/record/JSONRecordForm.tsx
@@ -53,7 +53,7 @@ type Props = {
 
 function splitAttachment(record: string) {
   let jsRecord = JSON.parse(record);
-  const attachment = jsRecord.attachment || {};
+  const attachment = jsRecord.attachment;
   jsRecord = omit(jsRecord, ["attachment"]);
   return {
     attachment: attachment,
@@ -69,16 +69,6 @@ export default function JSONRecordForm({
   attachmentEnabled,
   attachmentRequired,
 }: Props) {
-  const handleOnSubmit = data => {
-    const formData = attachmentEnabled
-      ? {
-          ...JSON.parse(data.formData.jsonContent),
-          __attachment__: data.formData.__attachment__,
-        }
-      : JSON.parse(data.formData);
-    onSubmit({ ...data, formData });
-  };
-
   const _uiSchema = attachmentEnabled ? uiSchemaWithUpload : uiSchema;
   const _record: any | string = attachmentEnabled
     ? splitAttachment(record)
@@ -87,6 +77,17 @@ export default function JSONRecordForm({
   if (attachmentEnabled && attachmentRequired) {
     _schema.required.push("__attachment__");
   }
+
+  const handleOnSubmit = data => {
+    const formData = attachmentEnabled
+      ? {
+          ...JSON.parse(data.formData.jsonContent),
+          attachment: _record?.attachment,
+          __attachment__: data.formData.__attachment__,
+        }
+      : JSON.parse(data.formData);
+    onSubmit({ ...data, formData });
+  };
 
   return (
     <div>

--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -215,8 +215,6 @@ export default function RecordForm(props: Props) {
       </div>
     );
 
-  console.log(record);
-
   return (
     <div>
       {alert}

--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -76,6 +76,14 @@ export default function RecordForm(props: Props) {
     bucket,
   } = props;
 
+  const {
+    data: { schema = {}, uiSchema = {}, attachment },
+  } = collection;
+  const attachmentConfig = {
+    enabled: attachment?.enabled,
+    required: attachment?.required && !record?.data?.attachment
+  };
+
   const allowEditing = record
     ? canEditRecord(session, bucket.data.id, collection, record)
     : canCreateRecord(session, bucket.data.id, collection);
@@ -106,10 +114,6 @@ export default function RecordForm(props: Props) {
   };
 
   const getForm = () => {
-    const { collection, record } = props;
-    const {
-      data: { schema = {}, uiSchema = {}, attachment },
-    } = collection;
     const emptySchema = Object.keys(schema).length === 0;
     const recordData = record ? record.data : {};
 
@@ -180,9 +184,9 @@ export default function RecordForm(props: Props) {
       );
     }
 
-    const _schema = extendSchemaWithAttachment(schema, attachment, recordData);
+    const _schema = extendSchemaWithAttachment(schema, attachmentConfig, recordData);
     let _uiSchema = extendUIWithKintoFields(uiSchema, !record);
-    _uiSchema = extendUiSchemaWithAttachment(_uiSchema, attachment);
+    _uiSchema = extendUiSchemaWithAttachment(_uiSchema, attachmentConfig);
     _uiSchema = extendUiSchemaWhenDisabled(_uiSchema, !allowEditing);
 
     return (
@@ -197,12 +201,8 @@ export default function RecordForm(props: Props) {
     );
   };
 
-  const {
-    data: { attachment: attachmentConfig },
-  } = collection;
-  const attachmentRequired = attachmentConfig && attachmentConfig.required;
   const isUpdate = !!record;
-
+  
   const alert =
     allowEditing || collection.busy ? null : (
       <div className="alert alert-warning">
@@ -219,7 +219,7 @@ export default function RecordForm(props: Props) {
           allowEditing={allowEditing}
           capabilities={capabilities}
           record={record}
-          attachmentRequired={attachmentRequired}
+          attachmentRequired={attachment?.required}
           deleteAttachment={handleDeleteAttachment}
         />
       )}

--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -81,7 +81,7 @@ export default function RecordForm(props: Props) {
   } = collection;
   const attachmentConfig = {
     enabled: attachment?.enabled,
-    required: attachment?.required && !record?.data?.attachment,
+    required: attachment?.required && !record?.data?.attachment, // allows records to be edited without requiring a new attachment to be uploaded
   };
 
   const allowEditing = record
@@ -214,6 +214,8 @@ export default function RecordForm(props: Props) {
         {isUpdate ? " edit this" : " create a"} record.
       </div>
     );
+  
+  console.log(record);
 
   return (
     <div>

--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -81,7 +81,7 @@ export default function RecordForm(props: Props) {
   } = collection;
   const attachmentConfig = {
     enabled: attachment?.enabled,
-    required: attachment?.required && !record?.data?.attachment
+    required: attachment?.required && !record?.data?.attachment,
   };
 
   const allowEditing = record
@@ -184,7 +184,11 @@ export default function RecordForm(props: Props) {
       );
     }
 
-    const _schema = extendSchemaWithAttachment(schema, attachmentConfig, recordData);
+    const _schema = extendSchemaWithAttachment(
+      schema,
+      attachmentConfig,
+      recordData
+    );
     let _uiSchema = extendUIWithKintoFields(uiSchema, !record);
     _uiSchema = extendUiSchemaWithAttachment(_uiSchema, attachmentConfig);
     _uiSchema = extendUiSchemaWhenDisabled(_uiSchema, !allowEditing);
@@ -202,7 +206,7 @@ export default function RecordForm(props: Props) {
   };
 
   const isUpdate = !!record;
-  
+
   const alert =
     allowEditing || collection.busy ? null : (
       <div className="alert alert-warning">
@@ -214,7 +218,7 @@ export default function RecordForm(props: Props) {
   return (
     <div>
       {alert}
-      {isUpdate && (
+      {isUpdate && attachmentConfig.enabled && (
         <AttachmentInfo
           allowEditing={allowEditing}
           capabilities={capabilities}

--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -214,7 +214,7 @@ export default function RecordForm(props: Props) {
         {isUpdate ? " edit this" : " create a"} record.
       </div>
     );
-  
+
   console.log(record);
 
   return (

--- a/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
+++ b/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
@@ -178,12 +178,20 @@ export function formatDiffHeader({
   let fields = [];
 
   for (let f of displayFields) {
-    fields.push(`${f}: ${(target || source)[f] || "undefined"}`);
+    fields.push(
+      <span>
+        <label>{f}:</label> {(target || source)[f] || "undefined"}
+      </span>
+    );
   }
 
-  fields.push((target || source).id);
+  fields.push(
+    <span>
+      <label>id:</label> {(target || source).id}
+    </span>
+  );
 
-  return fields.join(" | ");
+  return <>{fields}</>;
 }
 
 function recordsAreDifferent(a: ValidRecord, b: ValidRecord): boolean {

--- a/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
+++ b/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
@@ -102,7 +102,7 @@ function Diff({
   target?: ValidRecord;
   className?: string;
   allLines?: boolean;
-  displayFields?: string[]
+  displayFields?: string[];
 }) {
   let diff: string[];
 
@@ -124,7 +124,8 @@ function Diff({
       data-testid="record-diff"
     >
       <div className="card-header">
-        <DiffLabel changeType={changeType} /> {formatDiffHeader({ source, target, displayFields })}
+        <DiffLabel changeType={changeType} />{" "}
+        {formatDiffHeader({ source, target, displayFields })}
       </div>
       <div className="card-body p-0">
         <pre className="json-record json-record-simple-review mb-0">
@@ -166,22 +167,22 @@ function DiffLabel({ changeType }: { changeType: ChangeType }) {
 }
 
 export function formatDiffHeader({
-  source, 
-  target, 
-  displayFields = []
+  source,
+  target,
+  displayFields = [],
 }: {
-  source: ValidRecord, 
-  target: ValidRecord, 
-  displayFields: string[]
+  source: ValidRecord;
+  target: ValidRecord;
+  displayFields: string[];
 }) {
   let fields = [];
 
   for (let f of displayFields) {
-    fields.push(`${f}: ${(target || source)[f] || "undefined" }`);
+    fields.push(`${f}: ${(target || source)[f] || "undefined"}`);
   }
 
   fields.push((target || source).id);
-  
+
   return fields.join(" | ");
 }
 

--- a/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
+++ b/src/components/signoff/SimpleReview/PerRecordDiffView.tsx
@@ -16,12 +16,14 @@ export interface PerRecordDiffViewProps {
   oldRecords: ValidRecord[];
   newRecords: ValidRecord[];
   collectionData: SignoffSourceInfo;
+  displayFields?: string[];
 }
 
 export default function PerRecordDiffView({
   oldRecords,
   newRecords,
   collectionData,
+  displayFields,
 }: PerRecordDiffViewProps) {
   const [showExtraFields, setShowExtraFields] = useState(false);
   const [showAllLines, setShowAllLines] = useState(false);
@@ -70,6 +72,7 @@ export default function PerRecordDiffView({
               source={source}
               target={target}
               allLines={showAllLines}
+              displayFields={displayFields}
             />
           ))}
         </div>
@@ -91,6 +94,7 @@ function Diff({
   target,
   className = "",
   allLines = false,
+  displayFields,
 }: {
   id: string;
   changeType: ChangeType;
@@ -98,6 +102,7 @@ function Diff({
   target?: ValidRecord;
   className?: string;
   allLines?: boolean;
+  displayFields?: string[]
 }) {
   let diff: string[];
 
@@ -119,7 +124,7 @@ function Diff({
       data-testid="record-diff"
     >
       <div className="card-header">
-        <DiffLabel changeType={changeType} /> {id}
+        <DiffLabel changeType={changeType} /> {formatDiffHeader({ source, target, displayFields })}
       </div>
       <div className="card-body p-0">
         <pre className="json-record json-record-simple-review mb-0">
@@ -158,6 +163,26 @@ function DiffLabel({ changeType }: { changeType: ChangeType }) {
     case ChangeType.EMPTY_UPDATE:
       return <span className={"text-secondary"}>[unchanged]</span>;
   }
+}
+
+export function formatDiffHeader({
+  source, 
+  target, 
+  displayFields = []
+}: {
+  source: ValidRecord, 
+  target: ValidRecord, 
+  displayFields: string[]
+}) {
+  let fields = [];
+
+  for (let f of displayFields) {
+    fields.push(`${f}: ${(target || source)[f] || "undefined" }`);
+  }
+
+  fields.push((target || source).id);
+  
+  return fields.join(" | ");
 }
 
 function recordsAreDifferent(a: ValidRecord, b: ValidRecord): boolean {

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -178,7 +178,7 @@ export default function SimpleReview({
           oldRecords={records.oldRecords}
           newRecords={records.newRecords}
           collectionData={signoffSource}
-          displayFields={collection.data?.displayFields}
+          displayFields={collection?.data?.displayFields}
         />
         <button
           type="button"

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -158,7 +158,7 @@ export default function SimpleReview({
         </div>
       );
     }
-    
+
     return (
       <>
         {signoffSource.status !== "signed" && (

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -158,6 +158,7 @@ export default function SimpleReview({
         </div>
       );
     }
+    console.log(collection);
     return (
       <>
         {signoffSource.status !== "signed" && (
@@ -177,6 +178,7 @@ export default function SimpleReview({
           oldRecords={records.oldRecords}
           newRecords={records.newRecords}
           collectionData={signoffSource}
+          displayFields={collection.data?.displayFields}
         />
         <button
           type="button"

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -158,7 +158,7 @@ export default function SimpleReview({
         </div>
       );
     }
-    console.log(collection);
+    
     return (
       <>
         {signoffSource.status !== "signed" && (

--- a/test/components/RecordAttributes_test.jsx
+++ b/test/components/RecordAttributes_test.jsx
@@ -24,6 +24,10 @@ describe("RecordAttributes component", () => {
           },
         },
       },
+      attachment: {
+        enabled: true,
+        required: false,
+      }
     },
     permissions: {
       write: [],

--- a/test/components/record/JSONRecordForm_test.jsx
+++ b/test/components/record/JSONRecordForm_test.jsx
@@ -45,6 +45,7 @@ describe("JSONRecordForm", () => {
     expect(result.queryByLabelText("File attachment")).toBeDefined();
     fireEvent.click(result.queryByText("Submit"));
     expect(lastSubmittedData.formData).toStrictEqual({
+      attachment: undefined,
       __attachment__: undefined,
     });
   });
@@ -63,6 +64,7 @@ describe("JSONRecordForm", () => {
     fireEvent.click(result.queryByText("Submit"));
     expect(lastSubmittedData.formData).toStrictEqual({
       foo: "bar",
+      attachment: undefined,
       __attachment__: undefined,
     });
   });

--- a/test/components/record/JSONRecordForm_test.jsx
+++ b/test/components/record/JSONRecordForm_test.jsx
@@ -2,6 +2,14 @@ import React from "react";
 import { render, fireEvent } from "@testing-library/react";
 import JSONRecordForm from "../../../src/components/record/JSONRecordForm";
 
+const testAttachment = {
+  "hash": "efcea498c4bed6cac0076d91bf4f5df67fa875b3676248e5a6ae2ef4ed1bcef1",
+  "size": 5475,
+  "filename": "z.jpg",
+  "location": "test/test/03adc61f-9070-4e6c-a6ef-e94f5e17245f.jpg",
+  "mimetype": "image/jpeg"
+};
+
 describe("JSONRecordForm", () => {
   let lastSubmittedData = null;
   const submitMock = data => {
@@ -65,6 +73,28 @@ describe("JSONRecordForm", () => {
     expect(lastSubmittedData.formData).toStrictEqual({
       foo: "bar",
       attachment: undefined,
+      __attachment__: undefined,
+    });
+  });
+
+  it("Returns the previous attachment data when updating an existing record and not changing the attachment", async () => {
+    const result = render(
+      <JSONRecordForm
+        disabled={false}
+        record={JSON.stringify({
+          "foo": "bar",
+          attachment: testAttachment
+        })}
+        onSubmit={submitMock}
+        attachmentEnabled={true}
+      />
+    );
+    expect(result.queryByLabelText("JSON record*").value).toBe('{"foo":"bar"}');
+    expect(result.queryByLabelText("File attachment")).toBeDefined();
+    fireEvent.click(result.queryByText("Submit"));
+    expect(lastSubmittedData.formData).toStrictEqual({
+      foo: "bar",
+      attachment: testAttachment,
       __attachment__: undefined,
     });
   });

--- a/test/components/record/RecordForm_test.jsx
+++ b/test/components/record/RecordForm_test.jsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { fireEvent } from "@testing-library/react";
+import RecordForm from "../../../src/components/record/RecordForm";
+import { canCreateRecord, canEditRecord } from "../../../src/permission";
+import { renderWithProvider } from "../../test_utils";
+
+vi.mock("../../../src/permission", () => {
+  return {
+    __esModule: true,
+    canCreateRecord: vi.fn(),
+    canEditRecord: vi.fn(),
+  };
+});
+
+describe("RecordForm", () => {
+  beforeEach(() => {
+    canCreateRecord.mockReturnValue(true);
+    canEditRecord.mockReturnValue(true);
+  });
+  let lastSubmittedData = null;
+
+  const submitMock = data => {
+    lastSubmittedData = data;
+  }
+
+  const defaultProps = {
+    bid: "test",
+    cid: "test",
+    bucket: { data: { id: "test" }},
+    collection: {
+      data: {
+        schema: {
+          type: "object",
+          properties: {
+            title: {
+              type: "string",
+              title: "TestTitle",
+              description: "Title description..."
+            },
+            content: {
+              type: "string",
+              title: "TestContent",
+              description: "Content description..."
+            }
+          }
+        },
+        uiSchema: {
+          content: {
+            "ui:widget": "textarea"
+          },
+          "ui:order": ["title", "content"]
+        },
+        attachment: {
+          enabled: false,
+          required: false
+        }
+      }
+    },
+    deleteRecord: vi.fn(),
+    deleteAttachment: vi.fn(),
+    onSubmit: submitMock,
+    capabilities: {}
+  };
+
+  const attachProps = {
+    ...defaultProps,
+    collection: {
+      data: {
+        ...defaultProps.collection.data,
+        attachment: {
+          enabled: true,
+          required: true
+        }
+      } 
+    }
+  };
+
+  it("Renders an empty form for a new record (attachments disabled)", async () => {
+    const result = renderWithProvider(<RecordForm {...defaultProps} />);
+    fireEvent.change(result.queryByLabelText("TestTitle"), { target: { value: "test title" }});
+    fireEvent.change(result.queryByLabelText("TestContent"), { target: { value: "test content" }});
+    fireEvent.click(result.queryByText("Create record"));
+    expect(lastSubmittedData).toStrictEqual({
+      title: "test title",
+      content: "test content"
+    });
+  });
+
+  it("Renders the expected form for an existing record (attachments disabled)", async () => {
+    const result = renderWithProvider(<RecordForm {...defaultProps} record={{
+      data: {
+        title: "test title",
+        content: "test content",
+      }
+    }} />);
+    expect(result.queryByLabelText("TestTitle").value).toBe("test title");
+    expect(result.queryByLabelText("TestContent").value).toBe("test content");
+  });
+
+  it("Renders an empty form for a new record (attachments enabled)", async () => {
+    const result = renderWithProvider(<RecordForm {...attachProps} />);
+    expect(result.queryByLabelText("TestTitle").value).toBe("");
+    expect(result.queryByLabelText("TestContent").value).toBe("");
+    expect(result.findByLabelText("File attachment")).toBeDefined();
+  });
+
+  it("Renders the expected form for an existing record (attachments enabled)", async () => {
+    const result = renderWithProvider(<RecordForm {...attachProps} record={{
+      data: {
+        title: "test title",
+        content: "test content",
+      }
+    }} />);
+    expect(result.queryByLabelText("TestTitle").value).toBe("test title");
+    expect(result.queryByLabelText("TestContent").value).toBe("test content");
+    expect(result.findByLabelText("File attachment")).toBeDefined();
+  });
+
+  it.only("Requires an attachment to submit when it's a new record and attachments are required", async () => {
+    lastSubmittedData = null;
+    const result = renderWithProvider(<RecordForm {...attachProps} />);
+    fireEvent.change(result.queryByLabelText("TestTitle"), { target: { value: "test title" }});
+    fireEvent.change(result.queryByLabelText("TestContent"), { target: { value: "test content" }});
+    fireEvent.click(result.queryByText("Create record"));
+    expect(lastSubmittedData).toBeNull();
+  });
+
+  it("Disables the form when user cannot edit", async () => {
+    canEditRecord.mockReturnValue(false);
+    const result = renderWithProvider(<RecordForm {...defaultProps} record={{
+      data: {
+        title: "test title",
+        content: "test content",
+      }
+    }} />);
+    expect(result.queryByLabelText("TestTitle").disabled).toBe(true);
+    expect(result.queryByLabelText("TestContent").disabled).toBe(true);
+  });
+});

--- a/test/components/record/RecordForm_test.jsx
+++ b/test/components/record/RecordForm_test.jsx
@@ -75,6 +75,14 @@ describe("RecordForm", () => {
     }
   };
 
+  const testAttachment = {
+    "hash": "efcea498c4bed6cac0076d91bf4f5df67fa875b3676248e5a6ae2ef4ed1bcef1",
+    "size": 5475,
+    "filename": "z.jpg",
+    "location": "test/test/03adc61f-9070-4e6c-a6ef-e94f5e17245f.jpg",
+    "mimetype": "image/jpeg"
+  };
+
   it("Renders an empty form for a new record (attachments disabled)", async () => {
     const result = renderWithProvider(<RecordForm {...defaultProps} />);
     fireEvent.change(result.queryByLabelText("TestTitle"), { target: { value: "test title" }});
@@ -104,16 +112,24 @@ describe("RecordForm", () => {
     expect(result.findByLabelText("File attachment")).toBeDefined();
   });
 
-  it("Renders the expected form for an existing record (attachments enabled)", async () => {
+  it("Renders the expected form for an existing record (attachments enabled) and allows user to save without updating attachment", async () => {
     const result = renderWithProvider(<RecordForm {...attachProps} record={{
       data: {
         title: "test title",
         content: "test content",
+        attachment: testAttachment
       }
     }} />);
     expect(result.queryByLabelText("TestTitle").value).toBe("test title");
     expect(result.queryByLabelText("TestContent").value).toBe("test content");
     expect(result.findByLabelText("File attachment")).toBeDefined();
+    fireEvent.change(result.queryByLabelText("TestTitle"), { target: { value: "updated title" }});
+    fireEvent.click(result.queryByText("Update record"));
+    expect(lastSubmittedData).toStrictEqual({
+      title: "updated title",
+      content: "test content",
+      attachment: testAttachment
+    });
   });
 
   it("Requires an attachment to submit when it's a new record and attachments are required", async () => {
@@ -127,7 +143,7 @@ describe("RecordForm", () => {
 
   it("Disables the form when user cannot edit", async () => {
     canEditRecord.mockReturnValue(false);
-    const result = renderWithProvider(<RecordForm {...defaultProps} record={{
+    const result = renderWithProvider(<RecordForm {...attachProps} record={{
       data: {
         title: "test title",
         content: "test content",
@@ -135,5 +151,6 @@ describe("RecordForm", () => {
     }} />);
     expect(result.queryByLabelText("TestTitle").disabled).toBe(true);
     expect(result.queryByLabelText("TestContent").disabled).toBe(true);
+    expect(result.queryByLabelText("File attachment*").disabled).toBe(true);
   });
 });

--- a/test/components/record/RecordForm_test.jsx
+++ b/test/components/record/RecordForm_test.jsx
@@ -116,7 +116,7 @@ describe("RecordForm", () => {
     expect(result.findByLabelText("File attachment")).toBeDefined();
   });
 
-  it.only("Requires an attachment to submit when it's a new record and attachments are required", async () => {
+  it("Requires an attachment to submit when it's a new record and attachments are required", async () => {
     lastSubmittedData = null;
     const result = renderWithProvider(<RecordForm {...attachProps} />);
     fireEvent.change(result.queryByLabelText("TestTitle"), { target: { value: "test title" }});

--- a/test/components/signoff/SimpleReview/PerRecordDiffView_test.jsx
+++ b/test/components/signoff/SimpleReview/PerRecordDiffView_test.jsx
@@ -1,6 +1,7 @@
 import PerRecordDiffView, {
   findChangeTypes,
   ChangeType,
+  formatDiffHeader,
 } from "../../../../src/components/signoff/SimpleReview/PerRecordDiffView";
 import React from "react";
 import { render } from "@testing-library/react";
@@ -133,5 +134,46 @@ describe("findChangeTypes", () => {
       { id: "d", changeType: ChangeType.REMOVE, source: d },
       { id: "e", changeType: ChangeType.EMPTY_UPDATE, source: e, target: e2 },
     ]);
+  });
+});
+
+describe("formatDiffHeader", () => {
+  it("returns expected header based on provided records and displayFields", () => {
+    expect(formatDiffHeader({
+      target: { id: "foo"}
+    })).toStrictEqual("foo");
+
+    expect(formatDiffHeader({
+      source: { id: "foo"}
+    })).toStrictEqual("foo");
+
+    expect(formatDiffHeader({
+      source: { 
+        id: "foo",
+        prop1: "val1",
+        prop2: "val2",
+      },
+      target: { 
+        id: "foo",
+        prop1: "val3",
+        prop2: "val4",
+      }
+    })).toStrictEqual("foo");
+
+    expect(formatDiffHeader({
+      source: { 
+        id: "foo",
+        prop1: "val1",
+        prop2: "val2",
+        prop3: "prevVal",
+      },
+      target: { 
+        id: "foo",
+        prop1: "val3",
+        prop2: "val4",
+        // prop3 intentionally undefined
+      },
+      displayFields: [ "prop1", "prop2", "prop3"]
+    })).toStrictEqual("prop1: val3 | prop2: val4 | prop3: undefined | foo");
   });
 });

--- a/test/components/signoff/SimpleReview/PerRecordDiffView_test.jsx
+++ b/test/components/signoff/SimpleReview/PerRecordDiffView_test.jsx
@@ -139,15 +139,22 @@ describe("findChangeTypes", () => {
 
 describe("formatDiffHeader", () => {
   it("returns expected header based on provided records and displayFields", () => {
-    expect(formatDiffHeader({
+
+    let getTextContent = (props) => {
+      return render(
+        formatDiffHeader(props)
+      ).container.textContent;
+    };
+    
+    expect(getTextContent({
       target: { id: "foo"}
-    })).toStrictEqual("foo");
-
-    expect(formatDiffHeader({
+    })).toBe("id: foo");
+    
+    expect(getTextContent({
       source: { id: "foo"}
-    })).toStrictEqual("foo");
+    })).toBe("id: foo");
 
-    expect(formatDiffHeader({
+    expect(getTextContent({
       source: { 
         id: "foo",
         prop1: "val1",
@@ -158,9 +165,9 @@ describe("formatDiffHeader", () => {
         prop1: "val3",
         prop2: "val4",
       }
-    })).toStrictEqual("foo");
+    })).toBe("id: foo");
 
-    expect(formatDiffHeader({
+    expect(getTextContent({
       source: { 
         id: "foo",
         prop1: "val1",
@@ -174,6 +181,6 @@ describe("formatDiffHeader", () => {
         // prop3 intentionally undefined
       },
       displayFields: [ "prop1", "prop2", "prop3"]
-    })).toStrictEqual("prop1: val3 | prop2: val4 | prop3: undefined | foo");
+    })).toBe("prop1: val3prop2: val4prop3: undefinedid: foo");
   });
 });


### PR DESCRIPTION
Fixes #3128 by allowing records to be updated (via JSON or normal form) without requiring attachments to be updated.

**Logic changes**

- Users can now change properties without having to upload a new file when editing records.
- Users will not longer accidentally delete an attachment when editing the JSON data.

**Test changes**

- Several new tests for `RecordForm`, as we only had basic testing through `RecordAttributes_test` before.  
    - I considered refactoring these components and tests to be cleaner. 
    - That feels excessive for this PR and it feels okay to have basic tests at the higher level component and more aggressive tests at the lower level component.
- Added a new test to verify that `JSONRecordForm` returns the previous attachment data when saving.

Note: This is forked from https://github.com/Kinto/kinto-admin/pull/3127 .
