### PR TITLE
Removing error noise from tests with some better mocks

### DIFF
--- a/__mocks__/kinto-http.ts
+++ b/__mocks__/kinto-http.ts
@@ -7,6 +7,14 @@ const mock = vi.fn().mockImplementation(server => {
   return {
     fetchServerInfo: mockFetchServerInfo,
     remote: server,
+    listBuckets: () => {
+      return {
+        data: []
+      };
+    },
+    batch: () => {
+      return [];
+    },
   };
 });
 

--- a/src/sagas/session.ts
+++ b/src/sagas/session.ts
@@ -268,7 +268,7 @@ export function* listBuckets(
 
     // Retrieve and build the list of buckets
     const client = getClient();
-    let data;
+    let data = [];
     try {
       data = (yield call([client, client.listBuckets])).data;
     } catch (error) {
@@ -277,7 +277,6 @@ export function* listBuckets(
       if (!/HTTP 40[13]/.test(error.message)) {
         throw error;
       }
-      data = [];
     }
 
     // If the default_bucket plugin is enabled, show the Default bucket first in the list.

--- a/test/components/Layout_test.tsx
+++ b/test/components/Layout_test.tsx
@@ -12,10 +12,6 @@ describe("App component", () => {
     store = app.store;
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   describe("Session top bar", () => {
     it("should not render a session top bar when not authenticated", () => {
       expect(app.queryByTestId("sessionInfo-bar")).toBeNull();

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -3,4 +3,4 @@ import { vi } from "vitest";
 
 vi.mock("kinto-http");
 
-Object.defineProperty(window, 'scrollTo', { value: vi.fn(), writable: true });
+Object.defineProperty(window, "scrollTo", { value: vi.fn(), writable: true });

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -2,3 +2,5 @@ import "@testing-library/jest-dom";
 import { vi } from "vitest";
 
 vi.mock("kinto-http");
+
+Object.defineProperty(window, 'scrollTo', { value: vi.fn(), writable: true });


### PR DESCRIPTION
Tests currently have a lot of noise in them from errors being thrown and caught. Making our mocks slightly better removes much of that, making reading the test output easier.


<details closed>
  <summary>Before output</summary>

```
stderr | test/sagas/signoff_test.ts > Signoff sagas > list hook > onCollectionRecordsRequest() > Should catch and log a warning if a 401 response is received
Error: Test error
    at Module.<anonymous> (/kinto-admin/test/sagas/signoff_test.ts:211:23)
    at Module.mockCall (file:///kinto-admin/node_modules/@vitest/spy/dist/index.js:50:17)
    at Module.workflowInfo (file:///kinto-admin/node_modules/tinyspy/dist/index.js:42:80)
    at Module.onCollectionRecordsRequest (/kinto-admin/src/sagas/signoff.ts:72:30)
    at onCollectionRecordsRequest.next (<anonymous>)
    at /kinto-admin/test/sagas/signoff_test.ts:226:23
    at file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:128:14
    at file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:59:26
    at runTest (file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:675:17)
    at runSuite (file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:793:15) {
  data: { code: 401 }
}

stderr | test/sagas/signoff_test.ts > Signoff sagas > list hook > onCollectionRecordsRequest() > Should catch and log an error if an error (not 401) response is received
Error: Test error
    at Module.<anonymous> (/kinto-admin/test/sagas/signoff_test.ts:234:23)
    at Module.mockCall (file:///kinto-admin/node_modules/@vitest/spy/dist/index.js:50:17)
    at Module.workflowInfo (file:///kinto-admin/node_modules/tinyspy/dist/index.js:42:80)
    at Module.onCollectionRecordsRequest (/kinto-admin/src/sagas/signoff.ts:72:30)
    at onCollectionRecordsRequest.next (<anonymous>)
    at /kinto-admin/test/sagas/signoff_test.ts:249:23
    at file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:128:14
    at file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:59:26
    at runTest (file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:675:17)
    at runSuite (file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:793:15) {
  data: { code: 500 }
}
undefined

stderr | test/components/signoff/SimpleReview/PerRecordDiffView_test.tsx > PerRecordDiffView component > should render diffs
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `Diff`. See https://reactjs.org/link/warning-keys for more information.
    at span
    at Diff (/kinto-admin/src/components/signoff/SimpleReview/PerRecordDiffView.tsx:136:3)
    at div
    at PerRecordDiffView (/kinto-admin/src/components/signoff/SimpleReview/PerRecordDiffView.tsx:20:3)

stderr | test/components/signoff/SimpleReview/PerRecordDiffView_test.tsx > formatDiffHeader > returns expected header based on provided records and displayFields
Warning: Each child in a list should have a unique "key" prop. See https://reactjs.org/link/warning-keys for more information.
    at span

stderr | test/components/BaseForm_test.tsx > BaseForm component > Should scroll to the first property that fails validation
Form validation failed [
  {
    property: '.title',
    message: 'test error',
    stack: '.title test error'
  }
]

stderr | test/components/BaseForm_test.tsx > BaseForm component > Should scroll to the top of the form if validation failed without a specific property
Form validation failed [ { property: '.', message: 'test error', stack: '. test error' } ]

stderr | test/components/Homepage_test.tsx > HomePage component > Not authenticated > Session setup > should call setupSession if localStorage session available
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at listBuckets (/kinto-admin/src/sagas/session.ts:273:21)
    at listBuckets.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at listBuckets (/kinto-admin/src/sagas/session.ts:273:21)
    at listBuckets.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at listBuckets (/kinto-admin/src/sagas/session.ts:273:21)
    at listBuckets.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at listBuckets (/kinto-admin/src/sagas/session.ts:273:21)
    at listBuckets.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at listBuckets (/kinto-admin/src/sagas/session.ts:273:21)
    at listBuckets.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at listBuckets (/kinto-admin/src/sagas/session.ts:273:21)
    at listBuckets.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at listBuckets (/kinto-admin/src/sagas/session.ts:273:21)
    at listBuckets.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at listBuckets (/kinto-admin/src/sagas/session.ts:273:21)
    at listBuckets.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at listBuckets (/kinto-admin/src/sagas/session.ts:273:21)
    at listBuckets.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)

stderr | test/components/Homepage_test.tsx > HomePage component > Not authenticated > After OpenID redirection > should setup session when component is mounted
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }

stderr | test/components/Layout_test.tsx > App component > Session top bar > should not render a session top bar when not authenticated
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined

stderr | test/components/Layout_test.tsx > App component > Session top bar > should render a session top bar when anonymous
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined

stderr | test/components/Layout_test.tsx > App component > Session top bar > should display a link to the server docs
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined

stderr | test/components/Layout_test.tsx > App component > Session top bar > should render a session top bar when authenticated
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: call: argument of type [context, fn] has undefined or null `fn`
    at check (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:37:11)
    at validateFnDescriptor (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:502:5)
    at Module.call (/kinto-admin/node_modules/@redux-saga/core/dist/io-22ea0cf9.js:559:5)
    at getServerInfo (/kinto-admin/src/sagas/session.ts:58:28)
    at getServerInfo.next (<anonymous>)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1169:29)
    at proc (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1120:3)
    at /kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:597:17
    at immediately (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:68:12)
    at runForkEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:596:3)
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined
Error: Not implemented: window.scrollTo
    at module.exports (/kinto-admin/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
    at /kinto-admin/node_modules/jsdom/lib/jsdom/browser/Window.js:898:7
    at scrollToTop (/kinto-admin/src/utils.tsx:260:10)
    at runCallEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:536:21)
    at runEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1216:7)
    at digestEffect (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1283:5)
    at next (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1173:9)
    at Object.currCb [as cont] (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1263:7)
    at end (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:1024:10)
    at Object.task.cont (/kinto-admin/node_modules/@redux-saga/core/dist/redux-saga-core.esm.js:848:11) undefined

```
</details>


<details closed>
  <summary>After output</summary>

```
stderr | test/sagas/signoff_test.ts > Signoff sagas > list hook > onCollectionRecordsRequest() > Should catch and log a warning if a 401 response is received
Error: Test error
    at Module.<anonymous> (/kinto-admin/test/sagas/signoff_test.ts:211:23)
    at Module.mockCall (file:///kinto-admin/node_modules/@vitest/spy/dist/index.js:50:17)
    at Module.workflowInfo (file:///kinto-admin/node_modules/tinyspy/dist/index.js:42:80)
    at Module.onCollectionRecordsRequest (/kinto-admin/src/sagas/signoff.ts:72:30)
    at onCollectionRecordsRequest.next (<anonymous>)
    at /kinto-admin/test/sagas/signoff_test.ts:226:23
    at file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:128:14
    at file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:59:26
    at runTest (file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:675:17)
    at runSuite (file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:793:15) {
  data: { code: 401 }
}

stderr | test/sagas/signoff_test.ts > Signoff sagas > list hook > onCollectionRecordsRequest() > Should catch and log an error if an error (not 401) response is received
Error: Test error
    at Module.<anonymous> (/kinto-admin/test/sagas/signoff_test.ts:234:23)
    at Module.mockCall (file:///kinto-admin/node_modules/@vitest/spy/dist/index.js:50:17)
    at Module.workflowInfo (file:///kinto-admin/node_modules/tinyspy/dist/index.js:42:80)
    at Module.onCollectionRecordsRequest (/kinto-admin/src/sagas/signoff.ts:72:30)
    at onCollectionRecordsRequest.next (<anonymous>)
    at /kinto-admin/test/sagas/signoff_test.ts:249:23
    at file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:128:14
    at file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:59:26
    at runTest (file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:675:17)
    at runSuite (file:///kinto-admin/node_modules/@vitest/runner/dist/index.js:793:15) {
  data: { code: 500 }
}
undefined

stderr | test/components/signoff/SimpleReview/PerRecordDiffView_test.tsx > PerRecordDiffView component > should render diffs
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `Diff`. See https://reactjs.org/link/warning-keys for more information.
    at span
    at Diff (/kinto-admin/src/components/signoff/SimpleReview/PerRecordDiffView.tsx:136:3)
    at div
    at PerRecordDiffView (/kinto-admin/src/components/signoff/SimpleReview/PerRecordDiffView.tsx:20:3)

stderr | test/components/signoff/SimpleReview/PerRecordDiffView_test.tsx > formatDiffHeader > returns expected header based on provided records and displayFields
Warning: Each child in a list should have a unique "key" prop. See https://reactjs.org/link/warning-keys for more information.
    at span

stderr | test/components/BaseForm_test.tsx > BaseForm component > Should scroll to the first property that fails validation
Form validation failed [
  {
    property: '.title',
    message: 'test error',
    stack: '.title test error'
  }
]

stderr | test/components/BaseForm_test.tsx > BaseForm component > Should scroll to the top of the form if validation failed without a specific property
Form validation failed [ { property: '.', message: 'test error', stack: '. test error' } ]

stderr | test/components/Homepage_test.tsx > HomePage component > Not authenticated > After OpenID redirection > should setup session when component is mounted
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
{ message: 'Could not authenticate with OpenID Connect (Auth0)' }
```

</details>
