### PR TITLE
Fixes github action that could create duplicate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,11 @@ jobs:
 
       - name: Create release if one doesn't exist yet
         run: |
-          EXISTING_RELEASE=$(gh release view $GITHUB_REF --json="id" || echo '')
+          EXISTING_RELEASE=$(gh release view $GITHUB_REF_NAME --json="id" || echo '')
           if [[ -z $EXISTING_RELEASE ]]; then
-              gh release create $GITHUB_REF --generate-notes -d
+              gh release create $GITHUB_REF_NAME --generate-notes -d
           fi
       
       - name: Upload built package to release
         run: |
-          gh release upload $GITHUB_REF "$RUNNER_TEMP/kinto-admin-release.tar" --clobber
+          gh release upload $GITHUB_REF_NAME "$RUNNER_TEMP/kinto-admin-release.tar" --clobber


### PR DESCRIPTION
This corrects an issue we saw with the v3.0.4 release where a duplicate release draft was made and the artifact was uploaded to the wrong release. When a tag was created from a github release, the `$GITHUB_REF` variable used the long name, causing the release to not be found. Switched to `$GITHUB_REF_NAME`.

[Example release](https://github.com/alexcottner/kinto-admin/releases/tag/v3.0.4-action-fix)