### PR TITLE
Fixes #3158 - adjusts notification styling to not block toolbar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -502,8 +502,8 @@ form button[type="submit"].btn-primary {
   }
 }
 
-.notifications .alert {
-  margin-top: 3em;
+.notifications > div {
+  top: 3em;
 }
 /*
  * react-bs-notifier uses Font Awesome: alias the classes to bootstrap icons instead.


### PR DESCRIPTION
Switched from using `margin-top` to `top` so we don't block the toolbar.

![image](https://github.com/Kinto/kinto-admin/assets/148472676/e16435c2-b64f-4128-a9ce-bd8e2c0325a9)
