### PR TITLE
Fix #571: Move switch to default review UI button to top

### DIFF
--- a/src/components/collection/CollectionRecords.tsx
+++ b/src/components/collection/CollectionRecords.tsx
@@ -108,6 +108,22 @@ export default function CollectionRecords(props: Props) {
         capabilities={capabilities}
         totalRecords={totalRecords}
       >
+        {capabilities.signer && !useSimpleReview && (
+          <AdminLink
+            className="btn btn-secondary"
+            params={{ bid, cid }}
+            name="collection:simple-review"
+            onClick={() => {
+              setUseSimpleReview(true);
+            }}
+            style={{
+              float: "right",
+              marginTop: "0em",
+            }}
+          >
+            <Shuffle className="icon" /> Switch to Default Review UI
+          </AdminLink>
+        )}
         {listActions}
         {busy ? (
           <Spinner />
@@ -131,22 +147,6 @@ export default function CollectionRecords(props: Props) {
           />
         )}
         {listActions}
-        {capabilities.signer && !useSimpleReview && (
-          <AdminLink
-            className="btn btn-secondary"
-            params={{ bid, cid }}
-            name="collection:simple-review"
-            onClick={() => {
-              setUseSimpleReview(true);
-            }}
-            style={{
-              float: "right",
-              marginTop: "1.5em",
-            }}
-          >
-            <Shuffle className="icon" /> Switch to Default Review UI
-          </AdminLink>
-        )}
       </CollectionTabs>
     </div>
   );


### PR DESCRIPTION
Resolves [remote-settings issue 571](https://github.com/mozilla/remote-settings/issues/571). Moving the "Switch to Default Review UI" button to an easier to find location above the records list.

![image](https://github.com/Kinto/kinto-admin/assets/148472676/87e4906c-87d3-46c1-8652-ee0127953dfc)
