### PR TITLE
Fixes #3202: allowing self review when `to_review_enabled` is false

### DIFF
--- a/src/components/signoff/SignoffToolBar.tsx
+++ b/src/components/signoff/SignoffToolBar.tsx
@@ -110,10 +110,12 @@ export default function SignoffToolBar({
   const { status } = source;
 
   const canRequestReview = canEdit && isEditor(source, sessionState);
+
   const canReview =
     canEdit &&
-    isReviewer(source, sessionState) &&
-    !hasRequestedReview(source, sessionState);
+    ((isReviewer(source, sessionState) &&
+      !hasRequestedReview(source, sessionState)) ||
+      !sessionState.serverInfo?.capabilities?.signer?.to_review_enabled);
   const canRollback = canEdit;
   const hasHistory = "history" in sessionState.serverInfo.capabilities;
 

--- a/src/components/signoff/SignoffToolBar.tsx
+++ b/src/components/signoff/SignoffToolBar.tsx
@@ -111,11 +111,26 @@ export default function SignoffToolBar({
 
   const canRequestReview = canEdit && isEditor(source, sessionState);
 
+  let toReviewEnabled =
+    sessionState.serverInfo?.capabilities?.signer?.to_review_enabled === true;
+  if (toReviewEnabled) {
+    const resourceMatch =
+      sessionState.serverInfo?.capabilities?.signer?.resources?.find(
+        x =>
+          x.source.bucket === source.bid &&
+          x.source.collection === source.cid &&
+          x.destination.bucket === destination.bid &&
+          x.destination.collection === destination.cid
+      );
+    toReviewEnabled =
+      !resourceMatch || resourceMatch.to_review_enabled !== false;
+  }
+
   const canReview =
     canEdit &&
     ((isReviewer(source, sessionState) &&
       !hasRequestedReview(source, sessionState)) ||
-      !sessionState.serverInfo?.capabilities?.signer?.to_review_enabled);
+      !toReviewEnabled);
   const canRollback = canEdit;
   const hasHistory = "history" in sessionState.serverInfo.capabilities;
 

--- a/src/components/signoff/SignoffToolBar.tsx
+++ b/src/components/signoff/SignoffToolBar.tsx
@@ -5,7 +5,7 @@ import HumanDate from "./HumanDate";
 import { ProgressBar, ProgressStep } from "./ProgressBar";
 import { DiffInfo, Review } from "./Review";
 import { Signed } from "./Signed";
-import { isMember } from "./utils";
+import { isMember, toReviewEnabled } from "./utils";
 import { canEditCollection } from "@src/permission";
 import type {
   BucketState,
@@ -111,26 +111,11 @@ export default function SignoffToolBar({
 
   const canRequestReview = canEdit && isEditor(source, sessionState);
 
-  let toReviewEnabled =
-    sessionState.serverInfo?.capabilities?.signer?.to_review_enabled === true;
-  if (toReviewEnabled) {
-    const resourceMatch =
-      sessionState.serverInfo?.capabilities?.signer?.resources?.find(
-        x =>
-          x.source.bucket === source.bid &&
-          x.source.collection === source.cid &&
-          x.destination.bucket === destination.bid &&
-          x.destination.collection === destination.cid
-      );
-    toReviewEnabled =
-      !resourceMatch || resourceMatch.to_review_enabled !== false;
-  }
-
   const canReview =
     canEdit &&
     ((isReviewer(source, sessionState) &&
       !hasRequestedReview(source, sessionState)) ||
-      !toReviewEnabled);
+      !toReviewEnabled(sessionState, source, destination));
   const canRollback = canEdit;
   const hasHistory = "history" in sessionState.serverInfo.capabilities;
 

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -65,12 +65,25 @@ export default function SimpleReview({
   const destBid = signoffDest?.bid;
   const destCid = signoffDest?.cid;
 
-  console.log(signoffSource)
+  let toReviewEnabled =
+    session.serverInfo?.capabilities?.signer?.to_review_enabled === true;
+  if (toReviewEnabled) {
+    const resourceMatch =
+      session.serverInfo?.capabilities?.signer?.resources?.find(
+        x =>
+          x.source.bucket === sourceBid &&
+          x.source.collection === sourceCid &&
+          x.destination.bucket === destBid &&
+          x.destination.collection === destCid
+      );
+    toReviewEnabled =
+      !resourceMatch || resourceMatch.to_review_enabled !== false;
+  }
+
   const canReview = signoffSource
     ? (isReviewer(signoffSource, session) &&
         session.serverInfo?.user?.id !== signoffSource.lastReviewRequestBy) ||
-        session.serverInfo?.capabilities?.signer?.to_review_enabled === false
-        
+      !toReviewEnabled
     : false;
 
   const [records, setRecords] = useState<{

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -66,8 +66,9 @@ export default function SimpleReview({
   const destCid = signoffDest?.cid;
 
   const canReview = signoffSource
-    ? isReviewer(signoffSource, session) &&
-      session.serverInfo?.user?.id !== signoffSource.lastReviewRequestBy
+    ? (isReviewer(signoffSource, session) &&
+        session.serverInfo?.user?.id !== signoffSource.lastReviewRequestBy) ||
+      !session.serverInfo?.capabilities?.signer?.to_review_enabled
     : false;
 
   const [records, setRecords] = useState<{

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -1,5 +1,5 @@
 import { isReviewer } from "../SignoffToolBar";
-import { isMember } from "../utils";
+import { isMember, toReviewEnabled } from "../utils";
 import PerRecordDiffView from "./PerRecordDiffView";
 import SimpleReviewButtons from "./SimpleReviewButtons";
 import SimpleReviewHeader from "./SimpleReviewHeader";
@@ -65,25 +65,10 @@ export default function SimpleReview({
   const destBid = signoffDest?.bid;
   const destCid = signoffDest?.cid;
 
-  let toReviewEnabled =
-    session.serverInfo?.capabilities?.signer?.to_review_enabled === true;
-  if (toReviewEnabled) {
-    const resourceMatch =
-      session.serverInfo?.capabilities?.signer?.resources?.find(
-        x =>
-          x.source.bucket === sourceBid &&
-          x.source.collection === sourceCid &&
-          x.destination.bucket === destBid &&
-          x.destination.collection === destCid
-      );
-    toReviewEnabled =
-      !resourceMatch || resourceMatch.to_review_enabled !== false;
-  }
-
   const canReview = signoffSource
     ? (isReviewer(signoffSource, session) &&
         session.serverInfo?.user?.id !== signoffSource.lastReviewRequestBy) ||
-      !toReviewEnabled
+      !toReviewEnabled(session, signoffSource, signoffDest)
     : false;
 
   const [records, setRecords] = useState<{

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -65,10 +65,12 @@ export default function SimpleReview({
   const destBid = signoffDest?.bid;
   const destCid = signoffDest?.cid;
 
+  console.log(signoffSource)
   const canReview = signoffSource
     ? (isReviewer(signoffSource, session) &&
         session.serverInfo?.user?.id !== signoffSource.lastReviewRequestBy) ||
-      !session.serverInfo?.capabilities?.signer?.to_review_enabled
+        session.serverInfo?.capabilities?.signer?.to_review_enabled === false
+        
     : false;
 
   const [records, setRecords] = useState<{

--- a/src/components/signoff/utils.ts
+++ b/src/components/signoff/utils.ts
@@ -1,4 +1,4 @@
-import { SessionState, SignoffSourceInfo } from "@src/types";
+import { DestinationInfo, SessionState, SignoffSourceInfo } from "@src/types";
 
 export function isMember(
   groupKey: string,
@@ -22,4 +22,29 @@ export function isMember(
   const expectedPrincipal = `/buckets/${bid}/groups/${expectedGroup}`;
 
   return principals.includes(expectedPrincipal);
+}
+
+export function toReviewEnabled(
+  sessionState: SessionState,
+  source: SignoffSourceInfo,
+  destination: DestinationInfo
+) {
+  let enabled =
+    sessionState.serverInfo?.capabilities?.signer?.to_review_enabled === true;
+
+  if (enabled) {
+    const resourceMatch =
+      sessionState.serverInfo?.capabilities?.signer?.resources?.find(
+        x =>
+          x.source.bucket === source.bid &&
+          x.source.collection === source.cid &&
+          x.destination.bucket === destination.bid &&
+          x.destination.collection === destination.cid
+      );
+    if (resourceMatch && "to_review_enabled" in resourceMatch) {
+      enabled = resourceMatch.to_review_enabled;
+    }
+  }
+
+  return enabled;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export type Capabilities = {
     resources: any[];
     editors_group: string;
     reviewers_group: string;
+    to_review_enabled: boolean;
   };
 };
 

--- a/test/components/signoff/SimpleReview/SimpleReview_test.tsx
+++ b/test/components/signoff/SimpleReview/SimpleReview_test.tsx
@@ -215,4 +215,57 @@ describe("SimpleTest component", () => {
     // Since Simple Review is the default, this means we're in the legacy UI
     expect(screen.queryByText("Switch to Default Review UI")).toBeDefined();
   });
+
+  describe("to_review_enabled checks", () => {
+    const signoff = {
+      collectionsInfo: {
+        source: {
+          bid: "stage",
+          cid: "certs",
+          lastEditDate: 1524063083971,
+          lastReviewRequestBy: "user1",
+          changes: {
+            lastUpdated: 42,
+          },
+          status: "to-review",
+        },
+        destination: {
+          bid: "prod",
+          cid: "certs",
+        },
+      },
+    };
+
+    it("should show the review buttons if signer.to_review_enabled is falsy", async () => {
+      renderSimpleReview({
+        session: sessionFactory(
+          {},
+          {
+            signer: {
+              to_review_enabled: false,
+            },
+          }
+        ),
+        signoff,
+      });
+      await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
+      expect(await screen.findByText(/Approve/)).toBeDefined();
+    });
+
+    it("should not show the review buttons if signer.to_review_enabled is true and the current user requested review", async () => {
+      renderSimpleReview({
+        session: sessionFactory(
+          {},
+          {
+            signer: {
+              to_review_enabled: true,
+            },
+          }
+        ),
+        signoff,
+      });
+      await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
+      expect(screen.queryByText(/Approve/)).toBeNull();
+    });
+  });
 });

--- a/test/components/signoff/SimpleReview/SimpleReview_test.tsx
+++ b/test/components/signoff/SimpleReview/SimpleReview_test.tsx
@@ -74,7 +74,14 @@ function renderSimpleReview(props = null, renderProps = {}) {
       },
     },
     listRecords() {},
-    session: sessionFactory(),
+    session: sessionFactory(
+      {},
+      {
+        signer: {
+          to_review_enabled: true,
+        },
+      }
+    ),
     signoff: signoffFactory(),
     async fetchRecords() {
       return [];

--- a/test/components/signoff/SimpleReview/SimpleReview_test.tsx
+++ b/test/components/signoff/SimpleReview/SimpleReview_test.tsx
@@ -236,13 +236,42 @@ describe("SimpleTest component", () => {
       },
     };
 
-    it("should show the review buttons if signer.to_review_enabled is falsy", async () => {
+    it("should show the review buttons if signer.to_review_enabled is false", async () => {
       renderSimpleReview({
         session: sessionFactory(
           {},
           {
             signer: {
               to_review_enabled: false,
+            },
+          }
+        ),
+        signoff,
+      });
+      await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
+      expect(await screen.findByText(/Approve/)).toBeDefined();
+    });
+
+    it("should show the review buttons if signer.resources.to_review_enabled is false", async () => {
+      renderSimpleReview({
+        session: sessionFactory(
+          {},
+          {
+            signer: {
+              to_review_enabled: true,
+              resources: [
+                {
+                  source: {
+                    bucket: signoff.collectionsInfo.source.bid,
+                    collection: signoff.collectionsInfo.source.cid,
+                  },
+                  destination: {
+                    bucket: signoff.collectionsInfo.destination.bid,
+                    collection: signoff.collectionsInfo.destination.cid,
+                  },
+                  to_review_enabled: false,
+                },
+              ],
             },
           }
         ),

--- a/test/components/signoff/SimpleReview/SimpleReview_test.tsx
+++ b/test/components/signoff/SimpleReview/SimpleReview_test.tsx
@@ -1,4 +1,5 @@
 import SimpleReview from "@src/components/signoff/SimpleReview";
+import { toReviewEnabled } from "@src/components/signoff/utils";
 import { renderWithProvider, sessionFactory } from "@test/testUtils";
 import {
   fireEvent,
@@ -23,6 +24,7 @@ vi.mock("../../../../src/components/signoff/utils", () => {
     isMember: () => {
       return true;
     },
+    toReviewEnabled: vi.fn(),
   };
 });
 
@@ -74,14 +76,7 @@ function renderSimpleReview(props = null, renderProps = {}) {
       },
     },
     listRecords() {},
-    session: sessionFactory(
-      {},
-      {
-        signer: {
-          to_review_enabled: true,
-        },
-      }
-    ),
+    session: sessionFactory(),
     signoff: signoffFactory(),
     async fetchRecords() {
       return [];
@@ -236,61 +231,20 @@ describe("SimpleTest component", () => {
       },
     };
 
-    it("should show the review buttons if signer.to_review_enabled is false", async () => {
+    it("should show the review buttons if to_review_enabled is false", async () => {
       renderSimpleReview({
-        session: sessionFactory(
-          {},
-          {
-            signer: {
-              to_review_enabled: false,
-            },
-          }
-        ),
+        session: sessionFactory(),
         signoff,
       });
-      await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
-      expect(await screen.findByText(/Approve/)).toBeDefined();
-    });
-
-    it("should show the review buttons if signer.resources.to_review_enabled is false", async () => {
-      renderSimpleReview({
-        session: sessionFactory(
-          {},
-          {
-            signer: {
-              to_review_enabled: true,
-              resources: [
-                {
-                  source: {
-                    bucket: signoff.collectionsInfo.source.bid,
-                    collection: signoff.collectionsInfo.source.cid,
-                  },
-                  destination: {
-                    bucket: signoff.collectionsInfo.destination.bid,
-                    collection: signoff.collectionsInfo.destination.cid,
-                  },
-                  to_review_enabled: false,
-                },
-              ],
-            },
-          }
-        ),
-        signoff,
-      });
+      toReviewEnabled.mockReturnValue(false);
       await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));
       expect(await screen.findByText(/Approve/)).toBeDefined();
     });
 
     it("should not show the review buttons if signer.to_review_enabled is true and the current user requested review", async () => {
+      toReviewEnabled.mockReturnValue(true);
       renderSimpleReview({
-        session: sessionFactory(
-          {},
-          {
-            signer: {
-              to_review_enabled: true,
-            },
-          }
-        ),
+        session: sessionFactory(),
         signoff,
       });
       await waitForElementToBeRemoved(() => screen.queryByTestId("spinner"));

--- a/test/components/signoff/components_test.tsx
+++ b/test/components/signoff/components_test.tsx
@@ -19,6 +19,7 @@ describe("SignoffToolBar component", () => {
           signer: {
             reviewers_group: "reviewers",
             editors_group: "{collection_id}_editors",
+            to_review_enabled: true,
           },
         },
       },
@@ -131,4 +132,8 @@ describe("SignoffToolBar component", () => {
     expect(await screen.findByTestId("spinner")).toBeDefined();
     expect(propsOverride.approveChanges).toHaveBeenCalledTimes(1);
   });
+
+  it("should hide the review buttons if the current user cannot review", async () => {});
+
+  it("should show the review buttons if signer.to_review_enabled is falsy", async () => {});
 });

--- a/test/components/signoff/components_test.tsx
+++ b/test/components/signoff/components_test.tsx
@@ -161,6 +161,7 @@ describe("SignoffToolBar component", () => {
             signer: {
               ...props.sessionState.serverInfo.capabilities.signer,
               to_review_enabled: false,
+              resources: [],
             },
           },
           user: {
@@ -194,7 +195,7 @@ describe("SignoffToolBar component", () => {
       },
     };
 
-    it("should show the review buttons if signer.to_review_enabled is falsy", async () => {
+    it("should show the review buttons if signer.to_review_enabled is false", async () => {
       renderWithProvider(<SignoffToolBar {...propsOverride} />);
       expect(await screen.findByText("Approve")).toBeDefined();
     });
@@ -205,6 +206,24 @@ describe("SignoffToolBar component", () => {
 
       renderWithProvider(<SignoffToolBar {...propsOverride} />);
       expect(screen.queryByText("Approve")).toBeNull();
+    });
+
+    it("should show the review buttons if signer.resources.to_review_enabled is false", async () => {
+      propsOverride.sessionState.serverInfo.capabilities.signer.resources = [
+        {
+          source: {
+            bucket: propsOverride.signoff.collectionsInfo.source.bid,
+            collection: propsOverride.signoff.collectionsInfo.source.cid,
+          },
+          destination: {
+            bucket: propsOverride.signoff.collectionsInfo.destination.bid,
+            collection: propsOverride.signoff.collectionsInfo.destination.cid,
+          },
+          to_review_enabled: false,
+        },
+      ];
+      renderWithProvider(<SignoffToolBar {...propsOverride} />);
+      expect(await screen.findByText("Approve")).toBeDefined();
     });
   });
 });

--- a/test/components/signoff/components_test.tsx
+++ b/test/components/signoff/components_test.tsx
@@ -1,4 +1,5 @@
 import SignoffToolBar from "@src/components/signoff/SignoffToolBar";
+import { toReviewEnabled } from "@src/components/signoff/utils";
 import { renderWithProvider } from "@test/testUtils";
 import { fireEvent, screen } from "@testing-library/react";
 import React from "react";
@@ -16,6 +17,7 @@ vi.mock("../../../src/components/signoff/utils", () => {
     isMember: () => {
       return true;
     },
+    toReviewEnabled: vi.fn(),
   };
 });
 
@@ -160,7 +162,6 @@ describe("SignoffToolBar component", () => {
             ...props.sessionState.serverInfo.capabilities,
             signer: {
               ...props.sessionState.serverInfo.capabilities.signer,
-              to_review_enabled: false,
               resources: [],
             },
           },
@@ -196,34 +197,15 @@ describe("SignoffToolBar component", () => {
     };
 
     it("should show the review buttons if signer.to_review_enabled is false", async () => {
+      toReviewEnabled.mockReturnValue(false);
       renderWithProvider(<SignoffToolBar {...propsOverride} />);
       expect(await screen.findByText("Approve")).toBeDefined();
     });
 
     it("should not show the review buttons if signer.to_review_enabled is true and the current user requested review", async () => {
-      propsOverride.sessionState.serverInfo.capabilities.signer.to_review_enabled =
-        true;
-
+      toReviewEnabled.mockReturnValue(true);
       renderWithProvider(<SignoffToolBar {...propsOverride} />);
       expect(screen.queryByText("Approve")).toBeNull();
-    });
-
-    it("should show the review buttons if signer.resources.to_review_enabled is false", async () => {
-      propsOverride.sessionState.serverInfo.capabilities.signer.resources = [
-        {
-          source: {
-            bucket: propsOverride.signoff.collectionsInfo.source.bid,
-            collection: propsOverride.signoff.collectionsInfo.source.cid,
-          },
-          destination: {
-            bucket: propsOverride.signoff.collectionsInfo.destination.bid,
-            collection: propsOverride.signoff.collectionsInfo.destination.cid,
-          },
-          to_review_enabled: false,
-        },
-      ];
-      renderWithProvider(<SignoffToolBar {...propsOverride} />);
-      expect(await screen.findByText("Approve")).toBeDefined();
     });
   });
 });

--- a/test/components/signoff/utils_test.ts
+++ b/test/components/signoff/utils_test.ts
@@ -1,0 +1,157 @@
+import { isMember, toReviewEnabled } from "@src/components/signoff/utils";
+
+const source = {
+  bid: "sourceBucket",
+  cid: "sourceCol",
+};
+const destination = {
+  bid: "destBucket",
+  cid: "destCol",
+};
+const signerResource = {
+  source: {
+    bucket: source.bid,
+    collection: source.cid,
+  },
+  destination: {
+    bucket: destination.bid,
+    collection: destination.cid,
+  },
+};
+
+describe("toReviewEnabled", () => {
+  it("returns false with all empty objs", () => {
+    expect(toReviewEnabled({}, {}, {})).toBe(false);
+  });
+
+  it("returns true when server is true and no collection override", () => {
+    expect(
+      toReviewEnabled(
+        {
+          serverInfo: {
+            capabilities: {
+              signer: {
+                to_review_enabled: true,
+              },
+            },
+          },
+        },
+        {},
+        {}
+      )
+    ).toBe(true);
+  });
+
+  it("returns true when server is true and collection override is true", () => {
+    expect(
+      toReviewEnabled(
+        {
+          serverInfo: {
+            capabilities: {
+              signer: {
+                to_review_enabled: true,
+                resources: [
+                  {
+                    ...signerResource,
+                    to_review_enabled: true,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        source,
+        destination
+      )
+    ).toBe(true);
+  });
+
+  it("returns false when server is false", () => {
+    expect(
+      toReviewEnabled(
+        {
+          serverInfo: {
+            capabilities: {
+              signer: {
+                to_review_enabled: false,
+                resources: [
+                  {
+                    ...signerResource,
+                    to_review_enabled: true,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        source,
+        destination
+      )
+    ).toBe(false);
+
+    expect(
+      toReviewEnabled(
+        {
+          serverInfo: {
+            capabilities: {
+              signer: {
+                to_review_enabled: false,
+                resources: [signerResource],
+              },
+            },
+          },
+        },
+        source,
+        destination
+      )
+    ).toBe(false);
+  });
+
+  it("returns false when server is true and collection override is false", () => {
+    expect(
+      toReviewEnabled(
+        {
+          serverInfo: {
+            capabilities: {
+              signer: {
+                to_review_enabled: true,
+                resources: [
+                  {
+                    ...signerResource,
+                    to_review_enabled: false,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        source,
+        destination
+      )
+    ).toBe(false);
+  });
+});
+
+describe("isMember", () => {
+  const testSession = {
+    serverInfo: {
+      user: {
+        principals: ["/buckets/sourceBucket/groups/sourceCol-editors"],
+      },
+      capabilities: {
+        signer: {
+          editors_group: "{collection_id}-editors",
+          reviewers_group: "{collection_id}-reviewers",
+        },
+      },
+    },
+  };
+
+  it("Returns true if user is a member of the group", () => {
+    expect(isMember("editors_group", source, testSession)).toBe(true);
+  });
+
+  it("Returns false if user is not a member of the group", () => {
+    expect(isMember("reviewers_group", source, testSession)).toBe(false);
+  });
+});

--- a/test/testUtils.tsx
+++ b/test/testUtils.tsx
@@ -16,7 +16,7 @@ export function mockNotifyError() {
     });
 }
 
-export function sessionFactory(props) {
+export function sessionFactory(props = {}, capabilities = {}) {
   return {
     busy: false,
     authenticating: false,
@@ -35,7 +35,9 @@ export function sessionFactory(props) {
       url: "",
       project_name: "foo",
       project_docs: "foo",
-      capabilities: {},
+      capabilities: {
+        ...capabilities,
+      },
       user: {
         id: "user1",
         principals: [`/buckets/main-workspace/groups/my-collection-reviewers`],


### PR DESCRIPTION
Resolves #3202 - allowing for self review when `to_review_enabled` is false on either the signer plugin level or the specific resource mapping. 

Added unit tests to simple-review and legacy review toolbar to ensure consistent behavior.