### PR TITLE
Fixes #703 - fallback to default sort order only if we don't have one set

### DIFF
--- a/src/reducers/collection.ts
+++ b/src/reducers/collection.ts
@@ -25,7 +25,7 @@ export const INITIAL_STATE: CollectionState = {
     write: [],
     "record:create": [],
   },
-  currentSort: DEFAULT_SORT,
+  currentSort: undefined,
   records: [],
   recordsLoaded: false,
   hasNextRecords: false,

--- a/test/sagas/collection_test.ts
+++ b/test/sagas/collection_test.ts
@@ -44,7 +44,7 @@ describe("collection sagas", () => {
         beforeAll(() => {
           const action = actions.listRecords("bucket", "collection");
           const getState = () => ({
-            collection: { data: { sort: "-last_modified" } },
+            collection: { data: { sort: "last_modified" } },
           });
           listRecords = saga.listRecords(getState, action);
         });
@@ -52,7 +52,7 @@ describe("collection sagas", () => {
         it("should list collection records", () => {
           expect(listRecords.next().value).toStrictEqual(
             call([collection, collection.listRecords], {
-              sort: "-last_modified",
+              sort: "last_modified",
               limit: 200,
             })
           );


### PR DESCRIPTION
Resolves #703 . Setting initial state for currentSort to `undefined` allows us to fall back to the actual default sort order for a collection first and the fallback to default if we have nothing.

Adjusted unit tests slightly to ensure this is working as expected.