### PR TITLE
Standardizing spinner placement and adding missing spinners, Fixes #689

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -44,6 +44,10 @@ h1 {
   font-weight: bold;
 }
 
+.card > .card-body {
+  position: relative;
+}
+
 .sidebar-filters > .card-body {
   padding: 15px 15px 0 15px;
 }

--- a/src/components/bucket/BucketAttributes.tsx
+++ b/src/components/bucket/BucketAttributes.tsx
@@ -66,15 +66,18 @@ export default function BucketAttributes({
         Edit <b>{bid}</b> bucket attributes
       </h1>
       <BucketTabs bid={bid} capabilities={capabilities} selected="attributes">
-        {busy ? <Spinner /> :
-        <BucketForm
-          session={session}
-          bid={bid}
-          bucket={bucket}
-          formData={formData}
-          deleteBucket={handleDeleteBucket}
-          onSubmit={handleSubmit}
-        />}
+        {busy ? (
+          <Spinner />
+        ) : (
+          <BucketForm
+            session={session}
+            bid={bid}
+            bucket={bucket}
+            formData={formData}
+            deleteBucket={handleDeleteBucket}
+            onSubmit={handleSubmit}
+          />
+        )}
       </BucketTabs>
     </div>
   );

--- a/src/components/bucket/BucketAttributes.tsx
+++ b/src/components/bucket/BucketAttributes.tsx
@@ -60,16 +60,13 @@ export default function BucketAttributes({
     [bid, updateBucket]
   );
 
-  if (busy) {
-    return <Spinner />;
-  }
-
   return (
     <div>
       <h1>
         Edit <b>{bid}</b> bucket attributes
       </h1>
       <BucketTabs bid={bid} capabilities={capabilities} selected="attributes">
+        {busy ? <Spinner /> :
         <BucketForm
           session={session}
           bid={bid}
@@ -77,7 +74,7 @@ export default function BucketAttributes({
           formData={formData}
           deleteBucket={handleDeleteBucket}
           onSubmit={handleSubmit}
-        />
+        />}
       </BucketTabs>
     </div>
   );

--- a/src/components/bucket/BucketCollections.tsx
+++ b/src/components/bucket/BucketCollections.tsx
@@ -76,6 +76,7 @@ export default function BucketCollections({
             collections={collections}
             listBucketNextCollections={listBucketNextCollections}
             capabilities={capabilities}
+            showSpinner={!collections.loaded}
           />
         )}
         {listActions}

--- a/src/components/bucket/BucketGroups.tsx
+++ b/src/components/bucket/BucketGroups.tsx
@@ -30,7 +30,7 @@ export default function BucketCollections({
     params: { bid },
   } = match;
   const { groups } = bucket;
-  
+
   const listActions = (
     <ListActions bid={bid} session={session} bucket={bucket} />
   );
@@ -47,7 +47,12 @@ export default function BucketCollections({
             <p>This bucket has no groups.</p>
           </div>
         ) : (
-          <DataList bid={bid} groups={groups} capabilities={capabilities} showSpinner={bucket.busy} />
+          <DataList
+            bid={bid}
+            groups={groups}
+            capabilities={capabilities}
+            showSpinner={bucket.busy}
+          />
         )}
         {listActions}
       </BucketTabs>

--- a/src/components/bucket/BucketGroups.tsx
+++ b/src/components/bucket/BucketGroups.tsx
@@ -30,7 +30,7 @@ export default function BucketCollections({
     params: { bid },
   } = match;
   const { groups } = bucket;
-
+  
   const listActions = (
     <ListActions bid={bid} session={session} bucket={bucket} />
   );
@@ -42,12 +42,12 @@ export default function BucketCollections({
       </h1>
       <BucketTabs bid={bid} selected="groups" capabilities={capabilities}>
         {listActions}
-        {groups.length === 0 ? (
+        {!bucket.busy && groups.length === 0 ? (
           <div className="alert alert-info">
             <p>This bucket has no groups.</p>
           </div>
         ) : (
-          <DataList bid={bid} groups={groups} capabilities={capabilities} />
+          <DataList bid={bid} groups={groups} capabilities={capabilities} showSpinner={bucket.busy} />
         )}
         {listActions}
       </BucketTabs>

--- a/src/components/bucket/BucketPermissions.tsx
+++ b/src/components/bucket/BucketPermissions.tsx
@@ -19,9 +19,6 @@ export function BucketPermissions() {
 
   const { busy, permissions } = bucket;
   const acls = ["read", "write", "collection:create", "group:create"];
-  if (busy) {
-    return <Spinner />;
-  }
   return (
     <div>
       <h1>
@@ -32,12 +29,13 @@ export function BucketPermissions() {
         capabilities={session.serverInfo.capabilities}
         selected="permissions"
       >
+        { busy ? <Spinner /> : 
         <PermissionsForm
           permissions={permissions}
           acls={acls}
           readonly={!canEditBucket(session, bucket.data.id)}
           onSubmit={onSubmit}
-        />
+        />}
       </BucketTabs>
     </div>
   );

--- a/src/components/bucket/BucketPermissions.tsx
+++ b/src/components/bucket/BucketPermissions.tsx
@@ -29,13 +29,16 @@ export function BucketPermissions() {
         capabilities={session.serverInfo.capabilities}
         selected="permissions"
       >
-        { busy ? <Spinner /> : 
-        <PermissionsForm
-          permissions={permissions}
-          acls={acls}
-          readonly={!canEditBucket(session, bucket.data.id)}
-          onSubmit={onSubmit}
-        />}
+        {busy ? (
+          <Spinner />
+        ) : (
+          <PermissionsForm
+            permissions={permissions}
+            acls={acls}
+            readonly={!canEditBucket(session, bucket.data.id)}
+            onSubmit={onSubmit}
+          />
+        )}
       </BucketTabs>
     </div>
   );

--- a/src/components/bucket/CollectionDataList.tsx
+++ b/src/components/bucket/CollectionDataList.tsx
@@ -1,10 +1,10 @@
+import Spinner from "../Spinner";
 import AdminLink from "@src/components/AdminLink";
 import PaginatedTable from "@src/components/PaginatedTable";
 import { canCreateCollection } from "@src/permission";
 import { timeago } from "@src/utils";
 import React from "react";
 import { ClockHistory, Gear, Justify } from "react-bootstrap-icons";
-import Spinner from "../Spinner";
 
 export function ListActions(props) {
   const { bid, session, bucket } = props;
@@ -29,7 +29,13 @@ export function ListActions(props) {
 }
 
 export function DataList(props) {
-  const { bid, collections, capabilities, listBucketNextCollections, showSpinner } = props;
+  const {
+    bid,
+    collections,
+    capabilities,
+    listBucketNextCollections,
+    showSpinner,
+  } = props;
   const { loaded, entries, hasNextPage } = collections;
   const thead = (
     <thead>
@@ -46,9 +52,13 @@ export function DataList(props) {
 
   const tbody = (
     <tbody className={!loaded ? "loading" : ""}>
-      {showSpinner && <tr>
-        <td colSpan={6}>
-          <Spinner /></td></tr>}
+      {showSpinner && (
+        <tr>
+          <td colSpan={6}>
+            <Spinner />
+          </td>
+        </tr>
+      )}
       {entries.map((collection, index) => {
         const {
           id: cid,

--- a/src/components/bucket/CollectionDataList.tsx
+++ b/src/components/bucket/CollectionDataList.tsx
@@ -4,6 +4,7 @@ import { canCreateCollection } from "@src/permission";
 import { timeago } from "@src/utils";
 import React from "react";
 import { ClockHistory, Gear, Justify } from "react-bootstrap-icons";
+import Spinner from "../Spinner";
 
 export function ListActions(props) {
   const { bid, session, bucket } = props;
@@ -28,7 +29,7 @@ export function ListActions(props) {
 }
 
 export function DataList(props) {
-  const { bid, collections, capabilities, listBucketNextCollections } = props;
+  const { bid, collections, capabilities, listBucketNextCollections, showSpinner } = props;
   const { loaded, entries, hasNextPage } = collections;
   const thead = (
     <thead>
@@ -45,6 +46,9 @@ export function DataList(props) {
 
   const tbody = (
     <tbody className={!loaded ? "loading" : ""}>
+      {showSpinner && <tr>
+        <td colSpan={6}>
+          <Spinner /></td></tr>}
       {entries.map((collection, index) => {
         const {
           id: cid,

--- a/src/components/bucket/GroupDataList.tsx
+++ b/src/components/bucket/GroupDataList.tsx
@@ -4,9 +4,10 @@ import { timeago } from "@src/utils";
 import React from "react";
 import { Gear } from "react-bootstrap-icons";
 import { ClockHistory } from "react-bootstrap-icons";
+import Spinner from "../Spinner";
 
 export function DataList(props) {
-  const { bid, groups, capabilities } = props;
+  const { bid, groups, capabilities, showSpinner } = props;
   return (
     <table className="table table-striped table-bordered record-list">
       <thead>
@@ -18,6 +19,10 @@ export function DataList(props) {
         </tr>
       </thead>
       <tbody>
+        {showSpinner && <tr>
+          <td colSpan={4}>
+          <Spinner />
+            </td></tr>}
         {groups.map((group, index) => {
           const { id: gid, members, last_modified } = group;
           const date = new Date(last_modified);

--- a/src/components/bucket/GroupDataList.tsx
+++ b/src/components/bucket/GroupDataList.tsx
@@ -1,10 +1,10 @@
+import Spinner from "../Spinner";
 import AdminLink from "@src/components/AdminLink";
 import { canCreateGroup } from "@src/permission";
 import { timeago } from "@src/utils";
 import React from "react";
 import { Gear } from "react-bootstrap-icons";
 import { ClockHistory } from "react-bootstrap-icons";
-import Spinner from "../Spinner";
 
 export function DataList(props) {
   const { bid, groups, capabilities, showSpinner } = props;
@@ -19,10 +19,13 @@ export function DataList(props) {
         </tr>
       </thead>
       <tbody>
-        {showSpinner && <tr>
-          <td colSpan={4}>
-          <Spinner />
-            </td></tr>}
+        {showSpinner && (
+          <tr>
+            <td colSpan={4}>
+              <Spinner />
+            </td>
+          </tr>
+        )}
         {groups.map((group, index) => {
           const { id: gid, members, last_modified } = group;
           const date = new Date(last_modified);

--- a/src/components/collection/CollectionAttributes.tsx
+++ b/src/components/collection/CollectionAttributes.tsx
@@ -63,10 +63,6 @@ export default function CollectionAttributes({
   } = match;
   const { busy, data: formData } = collection;
 
-  if (busy) {
-    return <Spinner />;
-  }
-
   return (
     <div>
       <h1>
@@ -82,16 +78,20 @@ export default function CollectionAttributes({
         selected="attributes"
         capabilities={capabilities}
       >
-        <CollectionForm
-          bid={bid}
-          cid={cid}
-          session={session}
-          bucket={bucket}
-          collection={collection}
-          deleteCollection={handleDeleteCollection}
-          formData={formData}
-          onSubmit={onSubmit}
-        />
+        {busy ? (
+          <Spinner />
+        ) : (
+          <CollectionForm
+            bid={bid}
+            cid={cid}
+            session={session}
+            bucket={bucket}
+            collection={collection}
+            deleteCollection={handleDeleteCollection}
+            formData={formData}
+            onSubmit={onSubmit}
+          />
+        )}
       </CollectionTabs>
     </div>
   );

--- a/src/components/collection/CollectionPermissions.tsx
+++ b/src/components/collection/CollectionPermissions.tsx
@@ -28,9 +28,6 @@ export function CollectionPermissions() {
     );
   };
 
-  if (busy) {
-    return <Spinner />;
-  }
   return (
     <div>
       <h1>
@@ -46,12 +43,16 @@ export function CollectionPermissions() {
         capabilities={session.serverInfo.capabilities}
         selected="permissions"
       >
-        <PermissionsForm
-          permissions={permissions}
-          acls={acls}
-          readonly={!canEditCollection(session, bucket.data.id, collection)}
-          onSubmit={onSubmit}
-        />
+        {busy ? (
+          <Spinner />
+        ) : (
+          <PermissionsForm
+            permissions={permissions}
+            acls={acls}
+            readonly={!canEditCollection(session, bucket.data.id, collection)}
+            onSubmit={onSubmit}
+          />
+        )}
       </CollectionTabs>
     </div>
   );

--- a/src/components/group/GroupAttributes.tsx
+++ b/src/components/group/GroupAttributes.tsx
@@ -60,10 +60,6 @@ export default function GroupAttributes(props: Props) {
     [bid, deleteGroup]
   );
 
-  if (busy || formData == null) {
-    return <Spinner />;
-  }
-
   return (
     <div>
       <h1>
@@ -79,16 +75,20 @@ export default function GroupAttributes(props: Props) {
         selected="attributes"
         capabilities={capabilities}
       >
-        <GroupForm
-          bid={bid}
-          gid={gid}
-          session={session}
-          bucket={bucket}
-          group={group}
-          deleteGroup={onDeleteGroup}
-          formData={formData}
-          onSubmit={onSubmit}
-        />
+        {busy || formData == null ? (
+          <Spinner />
+        ) : (
+          <GroupForm
+            bid={bid}
+            gid={gid}
+            session={session}
+            bucket={bucket}
+            group={group}
+            deleteGroup={onDeleteGroup}
+            formData={formData}
+            onSubmit={onSubmit}
+          />
+        )}
       </GroupTabs>
     </div>
   );

--- a/src/components/group/GroupAttributes.tsx
+++ b/src/components/group/GroupAttributes.tsx
@@ -43,6 +43,7 @@ export default function GroupAttributes(props: Props) {
     params: { bid, gid },
   } = match;
   const { busy, data: formData } = group;
+  console.log(group);
 
   const onSubmit = useCallback(
     (formData: GroupData) => {
@@ -75,7 +76,7 @@ export default function GroupAttributes(props: Props) {
         selected="attributes"
         capabilities={capabilities}
       >
-        {busy || formData == null ? (
+        {busy || formData == null ? ( // formData will be null until it is fetched, busy will be false until the fetch starts, need to wait for for both conditions before rendering
           <Spinner />
         ) : (
           <GroupForm

--- a/src/components/group/GroupPermissions.tsx
+++ b/src/components/group/GroupPermissions.tsx
@@ -22,9 +22,6 @@ export function GroupPermissions() {
   const onSubmit = ({ formData }: { formData: GroupPermissionsType }) => {
     dispatch(BucketActions.updateGroup(bid, gid, { permissions: formData }));
   };
-  if (busy) {
-    return <Spinner />;
-  }
   return (
     <div>
       <h1>
@@ -40,12 +37,16 @@ export function GroupPermissions() {
         capabilities={session.serverInfo.capabilities}
         selected="permissions"
       >
-        <PermissionsForm
-          permissions={permissions}
-          acls={["read", "write"]}
-          readonly={!canEditGroup(session, bucket.data.id, group)}
-          onSubmit={onSubmit}
-        />
+        {busy ? (
+          <Spinner />
+        ) : (
+          <PermissionsForm
+            permissions={permissions}
+            acls={["read", "write"]}
+            readonly={!canEditGroup(session, bucket.data.id, group)}
+            onSubmit={onSubmit}
+          />
+        )}
       </GroupTabs>
     </div>
   );

--- a/src/components/record/RecordPermissions.tsx
+++ b/src/components/record/RecordPermissions.tsx
@@ -26,9 +26,6 @@ export function RecordPermissions() {
   };
   const { busy, permissions } = record;
   const acls = ["read", "write"];
-  if (busy) {
-    return <Spinner />;
-  }
   return (
     <div>
       <h1>
@@ -45,12 +42,16 @@ export function RecordPermissions() {
         capabilities={session.serverInfo.capabilities}
         selected="permissions"
       >
-        <PermissionsForm
-          permissions={permissions}
-          acls={acls}
-          readonly={!canEditRecord(session, bid, collection, record)}
-          onSubmit={onSubmit}
-        />
+        {busy ? (
+          <Spinner />
+        ) : (
+          <PermissionsForm
+            permissions={permissions}
+            acls={acls}
+            readonly={!canEditRecord(session, bid, collection, record)}
+            onSubmit={onSubmit}
+          />
+        )}
       </RecordTabs>
     </div>
   );

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -139,10 +139,7 @@ export default function SimpleReview({
         Not authenticated
       </div>
     );
-  } else if (
-    session.authenticating ||
-    session.busy
-  ) {
+  } else if (session.authenticating || session.busy) {
     return <Spinner />;
   }
   const handleRollback = (text: string) => {
@@ -197,8 +194,8 @@ export default function SimpleReview({
     );
   };
 
-  console.warn(records)
-  
+  console.warn(records);
+
   return (
     <div className="list-page">
       <h1>

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -116,6 +116,8 @@ export default function SimpleReview({
             console.error(ex);
           }
         }
+      } else {
+        setRecords({ oldRecords: [], newRecords: [], loading: false });
       }
     }
     getRecords();
@@ -139,8 +141,7 @@ export default function SimpleReview({
     );
   } else if (
     session.authenticating ||
-    session.busy ||
-    (records.loading && signoffSource && signoffDest)
+    session.busy
   ) {
     return <Spinner />;
   }
@@ -196,6 +197,8 @@ export default function SimpleReview({
     );
   };
 
+  console.warn(records)
+  
   return (
     <div className="list-page">
       <h1>
@@ -212,7 +215,7 @@ export default function SimpleReview({
         capabilities={capabilities || {}}
         totalRecords={collection?.totalRecords || 0}
       >
-        <SignoffContent />
+        {records.loading ? <Spinner /> : <SignoffContent />}
       </CollectionTabs>
     </div>
   );

--- a/src/components/signoff/SimpleReview/index.tsx
+++ b/src/components/signoff/SimpleReview/index.tsx
@@ -194,8 +194,6 @@ export default function SimpleReview({
     );
   };
 
-  console.warn(records);
-
   return (
     <div className="list-page">
       <h1>

--- a/test/components/bucket/CollectionDataList_test.tsx
+++ b/test/components/bucket/CollectionDataList_test.tsx
@@ -64,6 +64,10 @@ describe("Bucket CollectionDataList", () => {
     expect(screen.queryByTitle("Browse collection")).toBeDefined();
     expect(screen.queryByTitle("Edit collection attributes")).toBeDefined();
   });
+  it("Should render a spinner when showSpinner is true", () => {
+    renderWithProvider(<DataList {...props} showSpinner={true} />);
+    expect(screen.queryByTestId("spinner")).toBeDefined();
+  });
 });
 
 describe("Bucket CollectionListActions", () => {

--- a/test/components/bucket/GroupDataList_test.tsx
+++ b/test/components/bucket/GroupDataList_test.tsx
@@ -36,6 +36,11 @@ describe("Bucket GroupDataList", () => {
     expect(screen.queryByText("memberA-1, memberA-2")).toBeDefined();
     expect(screen.queryByText("memberB-1, memberB-2")).toBeDefined();
   });
+
+  it("Should render a spinner when showSpinner is true", () => {
+    renderWithProvider(<DataList {...props} showSpinner={true} />);
+    expect(screen.queryByTestId("spinner")).toBeDefined();
+  });
 });
 
 describe("Bucket GroupListActions", () => {

--- a/test/components/signoff/SimpleReview/SimpleReview_test.tsx
+++ b/test/components/signoff/SimpleReview/SimpleReview_test.tsx
@@ -117,7 +117,7 @@ describe("SimpleTest component", () => {
   it("should render not reviewable", async () => {
     renderSimpleReview({ signoff: undefined });
     expect(
-      screen.getByText(/This collection does not support/).textContent
+      (await screen.findByText(/This collection does not support/)).textContent
     ).toBe(
       "This collection does not support reviews, or you do not have permission to review."
     );


### PR DESCRIPTION
Goal of this PR is to add missing spinners and standardize spinner placement.

- Fixes #689 by showing a spinner while groups are loading
- If a spinner exists on a component using a tab control (ex: `BucketTabs`), spinner should exist inside of the tab control if we have enough context
- If a spinner exists on a component that renders a table (ex: `CollectionDataList`), spinner should exist inside the table if we have enough context
- Updated unit tests where adding or moving the spinner required a test update