### PR TITLE
Fix #625: Show an error message when rjsf component crashes

### DIFF
--- a/src/components/BaseForm.tsx
+++ b/src/components/BaseForm.tsx
@@ -12,6 +12,7 @@ const FormWithTheme = withTheme(Bootstrap4Theme);
 
 export type BaseFormProps = Omit<FormProps, "validator"> & {
   showSpinner?: boolean;
+  formCrashMsg?: ReactNode;
   onSubmit: (data: RJSFSchema) => void;
 };
 
@@ -37,7 +38,7 @@ export default function BaseForm(props: BaseFormProps) {
 
   return (
     <div className="formWrapper" ref={formRef} data-testid="formWrapper">
-      <ErrorBoundary>
+      <ErrorBoundary formCrashMsg={props.formCrashMsg}>
         <FormWithTheme
           {...restProps}
           focusOnFirstError={errorFocus}
@@ -67,6 +68,7 @@ class ErrorBoundary extends Component {
 
   declare props: {
     children: ReactNode;
+    formCrashMsg?: ReactNode;
   };
 
   constructor(props) {
@@ -85,10 +87,7 @@ class ErrorBoundary extends Component {
       return (
         <>
           <h2>Error rendering form</h2>
-          <div>
-            This is likely caused by a bad <code>ui:widget</code> value in this
-            collection's UI schema.
-          </div>
+          {this.props.formCrashMsg || <></>}
           <code>
             {this.state.thrown.name}: {this.state.thrown.message}
           </code>

--- a/src/components/record/RecordBulk.tsx
+++ b/src/components/record/RecordBulk.tsx
@@ -98,6 +98,16 @@ export default function RecordBulk({
     bulkFormData = ["{}", "{}"];
   }
 
+  const formCrashMsg = (
+    <div>
+      This is likely caused by a bad <code>ui:widget</code> value in this{" "}
+      <AdminLink name="collection:attributes" params={{ bid, cid }}>
+        collection's UI schema
+      </AdminLink>
+      .
+    </div>
+  );
+
   return (
     <div>
       <h1>
@@ -117,6 +127,7 @@ export default function RecordBulk({
               uiSchema={bulkUiSchema}
               formData={bulkFormData}
               onSubmit={onSubmit}
+              formCrashMsg={formCrashMsg}
             >
               <input
                 type="submit"

--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -192,12 +192,23 @@ export default function RecordForm(props: Props) {
     _uiSchema = extendUiSchemaWithAttachment(_uiSchema, attachmentConfig);
     _uiSchema = extendUiSchemaWhenDisabled(_uiSchema, !allowEditing);
 
+    const formCrashMsg = (
+      <div>
+        This is likely caused by a bad <code>ui:widget</code> value in this{" "}
+        <AdminLink name="collection:attributes" params={{ bid, cid }}>
+          collection's UI schema
+        </AdminLink>
+        .
+      </div>
+    );
+
     return (
       <BaseForm
         schema={_schema}
         uiSchema={_uiSchema}
         formData={recordData}
         onSubmit={handleOnSubmit}
+        formCrashMsg={formCrashMsg}
       >
         {buttons}
       </BaseForm>

--- a/test/components/BaseForm_test.tsx
+++ b/test/components/BaseForm_test.tsx
@@ -172,4 +172,22 @@ describe("BaseForm component", () => {
     fireEvent.click(submit);
     expect(testFn).toHaveBeenCalledTimes(1);
   });
+
+  it("Should show an error message when bad config causes the rjsf component to crash", async () => {
+    render(
+      <BaseForm
+        className="testClass"
+        schema={testSchema}
+        uiSchema={{
+          ...testUiSchema,
+          content: {
+            "ui:widget": "foo-not-real-thing",
+          },
+        }}
+      />
+    );
+
+    expect(await screen.findByText(/Error rendering form/)).toBeDefined();
+    expect(await screen.findByText(/foo-not-real-thing/)).toBeDefined();
+  });
 });

--- a/test/components/BaseForm_test.tsx
+++ b/test/components/BaseForm_test.tsx
@@ -184,10 +184,12 @@ describe("BaseForm component", () => {
             "ui:widget": "foo-not-real-thing",
           },
         }}
+        formCrashMsg={<div>My custom crash message</div>}
       />
     );
 
     expect(await screen.findByText(/Error rendering form/)).toBeDefined();
     expect(await screen.findByText(/foo-not-real-thing/)).toBeDefined();
+    expect(await screen.findByText(/My custom crash message/)).toBeDefined();
   });
 });


### PR DESCRIPTION
Resolves #625 - Show an error message when rjsf component crashes due to bad config.
Added comments detailing why we're doing things this way and unit test to verify it works as expected.

![image](https://github.com/Kinto/kinto-admin/assets/148472676/1706f4f8-7fee-4d3e-994a-255536537b05)
