### PR TITLE
Fix RTL errors about wrapping react state updates in `act`

### DIFF
--- a/test/components/signoff/SimpleReview/SimpleReview_test.tsx
+++ b/test/components/signoff/SimpleReview/SimpleReview_test.tsx
@@ -104,7 +104,7 @@ describe("SimpleTest component", () => {
     renderSimpleReview({
       session: sessionFactory({ authenticated: false, authenticating: true }),
     });
-    expect(screen.queryByTestId("spinner")).toBeDefined();
+    expect(screen.findByTestId("spinner")).toBeDefined();
   });
 
   it("should render not authenticated", async () => {
@@ -208,7 +208,7 @@ describe("SimpleTest component", () => {
     renderSimpleReview({ session });
 
     // Since Simple Review is the default, this means we're in the legacy UI
-    expect(screen.queryByText("Switch to Default Review UI")).toBeDefined();
+    expect(screen.findByText("Switch to Default Review UI")).toBeDefined();
   });
 
   describe("to_review_enabled checks", () => {


### PR DESCRIPTION
When I ran the test suite on `master`, I noticed this output for some tests:

```
When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */
```

this PR fixes the tests that were emitting those messages.