### PR TITLE
Resolves #3063 - always show the current bucket and collection in the sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -152,7 +152,7 @@ type BucketsMenuProps = {
 };
 
 function filterBuckets(buckets, filters): BucketEntry[] {
-  const { showReadOnly, search } = filters;
+  const { showReadOnly, search, bid = null, cid = null } = filters;
   return buckets
     .slice(0)
     .reduce((acc, bucket) => {
@@ -174,13 +174,15 @@ function filterBuckets(buckets, filters): BucketEntry[] {
       if (showReadOnly) {
         return bucket;
       }
-      const writableCollections = bucket.collections.filter(c => !c.readonly);
-      if (bucket.readonly && writableCollections.length == 0) {
+      const visibleCollections = bucket.collections.filter(
+        c => !c.readonly || (bucket.id === bid && c.id === cid) // always return the current bucket/collection we're on
+      );
+      if (bucket.readonly && visibleCollections.length == 0) {
         return null;
       }
       return {
         ...bucket,
-        collections: writableCollections,
+        collections: visibleCollections,
       };
     })
     .filter(Boolean);
@@ -206,7 +208,12 @@ const BucketsMenu = (props: BucketsMenuProps) => {
     setSearch(event.target.value || null);
   };
 
-  const filteredBuckets = filterBuckets(buckets, { showReadOnly, search });
+  const filteredBuckets = filterBuckets(buckets, {
+    showReadOnly,
+    search,
+    bid,
+    cid,
+  });
   // Sort buckets by id.
   const sortedBuckets = filteredBuckets.sort((a, b) => (a.id > b.id ? 1 : -1));
   return (

--- a/src/components/group/GroupAttributes.tsx
+++ b/src/components/group/GroupAttributes.tsx
@@ -43,7 +43,6 @@ export default function GroupAttributes(props: Props) {
     params: { bid, gid },
   } = match;
   const { busy, data: formData } = group;
-  console.log(group);
 
   const onSubmit = useCallback(
     (formData: GroupData) => {

--- a/test/components/Sidebar_test.tsx
+++ b/test/components/Sidebar_test.tsx
@@ -91,6 +91,48 @@ describe("Sidebar component", () => {
     });
   });
 
+  describe("Read only collections", () => {
+    let bucketMenus;
+
+    beforeEach(() => {
+      renderWithProvider(
+        <Sidebar
+          match={{ params }}
+          location={location}
+          capabilities={capabilities}
+        />,
+        {
+          initialState: {
+            session: {
+              ...session,
+              buckets: session.buckets.map(b => {
+                return {
+                  ...b,
+                  collections: b.collections.map(c => {
+                    return {
+                      ...c,
+                      readonly: true,
+                    };
+                  }),
+                };
+              }),
+            },
+          },
+        }
+      );
+      bucketMenus = screen.getAllByTestId("sidebar-bucketMenu");
+    });
+
+    it("should highlight the selected collection even if it's read-only and we haven't enabled show read-only collections", () => {
+      const targetEntry = bucketMenus[0].querySelectorAll(
+        ".collections-menu-entry"
+      )[0];
+
+      expect(targetEntry.classList.contains("active")).toBe(true);
+      expect(screen.getAllByTestId("sidebar-menuEntry")).toHaveLength(1); // should only have 1 menu entry for the current read-only collection
+    });
+  });
+
   describe("Create bucket", () => {
     it("should be shown by default", () => {
       renderWithProvider(


### PR DESCRIPTION
Resolves #3063 - always show the current bucket and collection in the sidebar. Added unit tests.
Also removed a rogue console.log.