### PR TITLE
Issue 1267 - Don't show the copy auth button when logged in as anonymous

### DIFF
--- a/src/components/SessionInfoBar.tsx
+++ b/src/components/SessionInfoBar.tsx
@@ -43,17 +43,19 @@ export function SessionInfoBar() {
         )}
         {" on "}
         <strong>{url}</strong>{" "}
-        <a
-          href=""
-          className="btn btn-sm btn-link"
-          title="Copy authentication header"
-          onClick={event => {
-            event.preventDefault();
-            dispatch(SessionActions.copyAuthenticationHeader());
-          }}
-        >
-          <Clipboard className="icon" />
-        </a>
+        {user?.id && (
+          <a
+            href=""
+            className="btn btn-sm btn-link"
+            title="Copy authentication header"
+            onClick={event => {
+              event.preventDefault();
+              dispatch(SessionActions.copyAuthenticationHeader());
+            }}
+          >
+            <Clipboard className="icon" />
+          </a>
+        )}
         <a href={`${url}__heartbeat__`} target="_blank">
           {heartbeat.success !== false ? (
             <CircleFill

--- a/test/components/SessionInfoBar_test.tsx
+++ b/test/components/SessionInfoBar_test.tsx
@@ -55,8 +55,8 @@ describe("SessionInfoBar component", () => {
         session: {
           authenticated: true,
           serverInfo: { user: { id: "foo" } },
-        }
-      }
+        },
+      },
     });
     expect(screen.getByText("Logout")).toBeDefined();
     expect(screen.getByText("foo")).toBeDefined();

--- a/test/components/SessionInfoBar_test.tsx
+++ b/test/components/SessionInfoBar_test.tsx
@@ -32,10 +32,11 @@ describe("SessionInfoBar component", () => {
     });
 
     expect(screen.getByTitle(healthyStr)).toBeDefined();
-    expect(screen.getByTitle("Copy authentication header")).toBeDefined();
     expect(screen.getByText("Documentation")).toBeDefined();
     expect(screen.getByText("Logout")).toBeDefined();
     expect(screen.getByText("Anonymous")).toBeDefined();
+    // Copy auth header should not render for anonymous logins
+    expect(screen.queryByTitle("Copy authentication header")).toBeNull();
 
     // ensure execute is called every minute for 5 minutes
     for (let i = 1; i < 5; i++) {
@@ -46,6 +47,20 @@ describe("SessionInfoBar component", () => {
         });
       });
     }
+  });
+
+  it("Should show copy authentication header when a user is logged in", async () => {
+    renderWithProvider(<SessionInfoBar />, {
+      initialState: {
+        session: {
+          authenticated: true,
+          serverInfo: { user: { id: "foo" } },
+        }
+      }
+    });
+    expect(screen.getByText("Logout")).toBeDefined();
+    expect(screen.getByText("foo")).toBeDefined();
+    expect(screen.getByTitle("Copy authentication header")).toBeDefined();
   });
 
   it("Should show green server status when heartbeat returns all true checks", async () => {


### PR DESCRIPTION
#1267 - Don't need to show the copy auth button when logged in as anonymous.

![image](https://github.com/user-attachments/assets/dadc7950-201f-4720-b30d-64f84e0eec0d)
vs
![image](https://github.com/user-attachments/assets/3c9f530b-5850-4687-acad-552c6c5e7dc3)
