### PR TITLE
Ref #3566 - Fixing expired auth bug and deep link redirects.

### DIFF
--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -452,7 +452,10 @@ export default function AuthForm() {
       authType = "openid";
     }
 
-    const extendedFormData = { ...formData, redirectURL: location.pathname };
+    const extendedFormData = {
+      ...formData,
+      redirectURL: `${location.pathname || "/"}${location.hash || ""}`,
+    };
     switch (authType) {
       case "fxa":
       case "portier": {

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -72,7 +72,7 @@ export function HomePage() {
 
     // Check for an incoming authentication.
     try {
-      let { server, authType } = JSON.parse(atob(payload));
+      let { server, authType, redirectURL } = JSON.parse(atob(payload));
       let decodedToken = decodeURIComponent(token);
 
       let authData: OpenIDAuth | TokenAuth | PortierAuth;
@@ -124,7 +124,7 @@ export function HomePage() {
         throw new Error(`Unsupported token authentication "${authType}"`);
       }
       setAuth(authData);
-      navigate("/");
+      navigate(redirectURL || "/");
     } catch (error) {
       const message = "Couldn't proceed with authentication.";
       notifyError(message, error);

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -52,6 +52,10 @@ export function logout() {
 export function useAuth(): AuthData | undefined {
   const [val, setVal] = useLocalStorage("kinto-admin-auth", authState.get());
 
+  if (val && val.expiresAt && val.expiresAt < new Date().getTime()) {
+    setVal(undefined);
+  }
+
   useEffect(() => {
     if (authState.get() === undefined && val !== undefined) {
       authState.set(val);

--- a/test/components/AuthForm_test.tsx
+++ b/test/components/AuthForm_test.tsx
@@ -94,7 +94,7 @@ describe("AuthForm component", () => {
               username: "user",
               password: "pass",
             },
-            redirectURL: undefined,
+            redirectURL: "/",
           });
         });
       });
@@ -122,14 +122,14 @@ describe("AuthForm component", () => {
               username: "you@email.com",
               password: "pass",
             },
-            redirectURL: undefined,
+            redirectURL: "/",
           });
         });
       });
     });
 
     describe("FxA", () => {
-      it("should navigate to external auth URL", async () => {
+      it("should navigate to external auth URL with our redirect URL", async () => {
         fireEvent.change(screen.queryByLabelText("Server*"), {
           target: { value: "http://test.server/v1" },
         });
@@ -137,13 +137,13 @@ describe("AuthForm component", () => {
         fireEvent.click(screen.getByLabelText("Firefox Account"));
         fireEvent.click(screen.getByText(/Sign in using/));
         expect(window.location.href).toBe(
-          "http://test.server/v1/fxa-oauth/login?redirect=http%3A%2F%2Flocalhost%3A3000%2F%23%2Fauth%2FeyJzZXJ2ZXIiOiJodHRwOi8vdGVzdC5zZXJ2ZXIvdjEiLCJhdXRoVHlwZSI6ImZ4YSJ9%2F"
+          "http://test.server/v1/fxa-oauth/login?redirect=http%3A%2F%2Flocalhost%3A3000%2F%23%2Fauth%2FeyJzZXJ2ZXIiOiJodHRwOi8vdGVzdC5zZXJ2ZXIvdjEiLCJhdXRoVHlwZSI6ImZ4YSIsInJlZGlyZWN0VVJMIjoiLyJ9%2F"
         );
       });
     });
 
     describe("OpenID", () => {
-      it("should navigate to external auth URL", async () => {
+      it("should navigate to external auth URL with our redirect URL", async () => {
         fireEvent.change(screen.queryByLabelText("Server*"), {
           target: { value: "http://test.server/v1" },
         });
@@ -151,7 +151,7 @@ describe("AuthForm component", () => {
         fireEvent.click(screen.getByLabelText("OpenID Connect (Google)"));
         fireEvent.click(screen.getByText(/Sign in using/));
         expect(window.location.href).toBe(
-          "http://test.server/v1/auth_path?callback=http%3A%2F%2Flocalhost%3A3000%2F%23%2Fauth%2FeyJzZXJ2ZXIiOiJodHRwOi8vdGVzdC5zZXJ2ZXIvdjEiLCJhdXRoVHlwZSI6Im9wZW5pZC1nb29nbGUifQ%3D%3D%2F&scope=openid email"
+          "http://test.server/v1/auth_path?callback=http%3A%2F%2Flocalhost%3A3000%2F%23%2Fauth%2FeyJzZXJ2ZXIiOiJodHRwOi8vdGVzdC5zZXJ2ZXIvdjEiLCJhdXRoVHlwZSI6Im9wZW5pZC1nb29nbGUiLCJyZWRpcmVjdFVSTCI6Ii8ifQ%3D%3D%2F&scope=openid email"
         );
       });
     });

--- a/test/hooks/session_test.ts
+++ b/test/hooks/session_test.ts
@@ -108,6 +108,23 @@ describe("session hooks", () => {
     });
   });
 
+  it("useAuth should wipe stored state if the expiresAt timestamp has elapsed", async () => {
+    const testVal = {
+      foo: "bar",
+      credentials: {},
+      expiresAt: 42,
+    };
+    const setMock = vi.fn();
+    vi.spyOn(storageHooks, "useLocalStorage").mockReturnValue([
+      testVal,
+      setMock,
+    ]);
+    renderHook(() => useAuth());
+    await vi.waitFor(() => {
+      expect(setMock).toHaveBeenCalledWith(undefined);
+    });
+  });
+
   describe("usePermissions", () => {
     beforeEach(async () => {
       const { result: auth } = renderHook(() => useAuth());


### PR DESCRIPTION
This corrects #3566 ([939](https://github.com/mozilla/remote-settings/issues/939) in remote-settings repo).

1. Adjusted `useAuth` hook to check for `expiresAt` property and remove saved state if it's passed the current timestamp
2. Added a unit test to cover that
3. Adjusted `redirectURL` handling so we deep link correctly to the page the user was trying to land on
4. Adjusted existing unit tests that checked for `redirectURL` values