### PR TITLE
Fix mozilla/remote-settings#953: hide bottom action when few records

### DIFF
--- a/src/components/collection/CollectionRecords.tsx
+++ b/src/components/collection/CollectionRecords.tsx
@@ -97,7 +97,11 @@ export default function CollectionRecords() {
             }}
           />
         )}
-        {listActions}
+        {
+          records.data?.length > 10
+            ? listActions
+            : null /* Show actions in bottom only if there are more than 10 records */
+        }
       </CollectionTabs>
     </div>
   );

--- a/test/components/CollectionRecords_test.tsx
+++ b/test/components/CollectionRecords_test.tsx
@@ -177,6 +177,9 @@ describe("CollectionRecords component", () => {
           },
           displayFields: ["foo"],
         });
+      });
+
+      it("should render list actions", () => {
         useRecordList.mockReturnValue({
           data: [],
           hasNextPage: false,
@@ -184,9 +187,24 @@ describe("CollectionRecords component", () => {
           totalRecords: 0,
         });
         renderWithRouter(<CollectionRecords />, routeProps);
+
+        expect(screen.getAllByText("Create record").length).toBe(1);
+        expect(screen.getAllByText("Bulk create").length).toBe(1);
       });
 
-      it("should render list actions", () => {
+      it("should render list actions twice if list is long", () => {
+        useRecordList.mockReturnValue({
+          data: Array.from({ length: 11 }, (_, i) => ({
+            id: `id${i}`,
+            foo: `value${i}`,
+            last_modified: i,
+          })),
+          hasNextPage: false,
+          lastModified: 0,
+          totalRecords: 0,
+        });
+        renderWithRouter(<CollectionRecords />, routeProps);
+
         expect(screen.getAllByText("Create record").length).toBe(2);
         expect(screen.getAllByText("Bulk create").length).toBe(2);
       });


### PR DESCRIPTION
Fix mozilla/remote-settings#953