### PR TITLE
Fix mozilla/remote-settings#954: add record history to drop down

### DIFF
--- a/src/components/collection/RecordRow.tsx
+++ b/src/components/collection/RecordRow.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { Dropdown } from "react-bootstrap";
 import {
   ClipboardCheck,
+  ClockHistory,
   Lock,
   Paperclip,
   Pencil,
@@ -122,6 +123,13 @@ export default function RecordRow({
                 <Paperclip className="icon" /> View Attachment
               </a>
             )}
+            <AdminLink
+              name="record:history"
+              params={{ bid, cid, rid }}
+              className="dropdown-item"
+            >
+              <ClockHistory className="icon" /> History
+            </AdminLink>
             <AdminLink
               name="record:permissions"
               params={{ bid, cid, rid }}


### PR DESCRIPTION
Fix mozilla/remote-settings#954