### PR TITLE
Fix #3426: show warning if missing attachments capability

### DIFF
--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -224,20 +224,35 @@ export default function RecordForm() {
       </div>
     );
 
+  let attachmentInfo = null;
+  if (collectionAttachmentEnabled) {
+    if (serverAttachmentEnabled) {
+      if (isUpdate) {
+        attachmentInfo = (
+          <AttachmentInfo
+            allowEditing={allowEditing}
+            capabilities={serverInfo?.capabilities}
+            record={record}
+            attachmentRequired={attachment?.required}
+            callback={() => {
+              setCacheVal(cacheVal + 1);
+            }}
+          />
+        );
+      }
+    } else {
+      attachmentInfo = (
+        <div className="alert alert-warning">
+          Attachments are not enabled on this server.
+        </div>
+      );
+    }
+  }
+
   return (
     <div>
       {alert}
-      {isUpdate && attachmentConfig.enabled && (
-        <AttachmentInfo
-          allowEditing={allowEditing}
-          capabilities={serverInfo?.capabilities}
-          record={record}
-          attachmentRequired={attachment?.required}
-          callback={() => {
-            setCacheVal(cacheVal + 1);
-          }}
-        />
-      )}
+      {attachmentInfo}
       {getForm()}
     </div>
   );

--- a/src/components/record/RecordForm.tsx
+++ b/src/components/record/RecordForm.tsx
@@ -55,8 +55,11 @@ export default function RecordForm() {
   }
 
   const { schema = {}, uiSchema = {}, attachment } = collection;
+  const collectionAttachmentEnabled = attachment?.enabled;
+  const serverAttachmentEnabled = !!serverInfo?.capabilities.attachments;
+
   const attachmentConfig = {
-    enabled: attachment?.enabled,
+    enabled: collectionAttachmentEnabled && serverAttachmentEnabled,
     required: attachment?.required && !record?.data?.attachment, // allows records to be edited without requiring a new attachment to be uploaded
   };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,11 @@ export const DEFAULT_SERVERINFO = {
   project_name: "Kinto",
   project_docs: "https://remote-settings.readthedocs.io/",
 };
+
+
+export const SERVERINFO_WITH_ATTACHMENTS_CAPABILITY = {
+  ...DEFAULT_SERVERINFO,
+  capabilities: {
+    attachments: {},
+  },
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,6 @@ export const DEFAULT_SERVERINFO = {
   project_docs: "https://remote-settings.readthedocs.io/",
 };
 
-
 export const SERVERINFO_WITH_ATTACHMENTS_CAPABILITY = {
   ...DEFAULT_SERVERINFO,
   capabilities: {

--- a/test/components/RecordAttributes_test.tsx
+++ b/test/components/RecordAttributes_test.tsx
@@ -1,6 +1,6 @@
 import * as client from "@src/client";
 import RecordAttributes from "@src/components/record/RecordAttributes";
-import { DEFAULT_SERVERINFO } from "@src/constants";
+import { SERVERINFO_WITH_ATTACHMENTS_CAPABILITY } from "@src/constants";
 import * as collectionHooks from "@src/hooks/collection";
 import * as recordHooks from "@src/hooks/record";
 import * as sessionHooks from "@src/hooks/session";
@@ -37,7 +37,7 @@ describe("RecordAttributes component", () => {
 
   beforeEach(() => {
     canEditRecord.mockReturnValue(true);
-    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(DEFAULT_SERVERINFO);
+    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(SERVERINFO_WITH_ATTACHMENTS_CAPABILITY);
     vi.spyOn(recordHooks, "useRecord").mockReturnValue({
       data: { id: "abc", last_modified: 123, foo: "bar" },
     });

--- a/test/components/RecordAttributes_test.tsx
+++ b/test/components/RecordAttributes_test.tsx
@@ -1,6 +1,9 @@
 import * as client from "@src/client";
 import RecordAttributes from "@src/components/record/RecordAttributes";
-import { SERVERINFO_WITH_ATTACHMENTS_CAPABILITY } from "@src/constants";
+import {
+  DEFAULT_SERVERINFO,
+  SERVERINFO_WITH_ATTACHMENTS_CAPABILITY,
+} from "@src/constants";
 import * as collectionHooks from "@src/hooks/collection";
 import * as recordHooks from "@src/hooks/record";
 import * as sessionHooks from "@src/hooks/session";
@@ -37,7 +40,9 @@ describe("RecordAttributes component", () => {
 
   beforeEach(() => {
     canEditRecord.mockReturnValue(true);
-    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(SERVERINFO_WITH_ATTACHMENTS_CAPABILITY);
+    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(
+      SERVERINFO_WITH_ATTACHMENTS_CAPABILITY
+    );
     vi.spyOn(recordHooks, "useRecord").mockReturnValue({
       data: { id: "abc", last_modified: 123, foo: "bar" },
     });
@@ -131,6 +136,34 @@ describe("RecordAttributes component", () => {
           screen.getByTestId("attachmentInfo-currentSize").textContent
         ).toBe("100 kB");
       });
+    });
+  });
+
+  describe("Attachment warning shown", () => {
+    const record = {
+      data: {
+        id: "abc",
+        foo: "bar",
+        attachment: {
+          location: "path/file.png",
+          mimetype: "image/png",
+          size: 12345,
+        },
+      },
+    };
+
+    beforeEach(() => {
+      vi.spyOn(recordHooks, "useRecord").mockReturnValueOnce(record);
+      vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(
+        DEFAULT_SERVERINFO
+      );
+      renderWithRouter(<RecordAttributes />, routeProps);
+    });
+
+    it("should show a warning that server does not support attachments", () => {
+      expect(
+        screen.getByText("Attachments are not enabled on this server.")
+      ).toBeDefined();
     });
   });
 

--- a/test/components/record/RecordForm_test.tsx
+++ b/test/components/record/RecordForm_test.tsx
@@ -78,7 +78,9 @@ describe("RecordForm", () => {
     canEditRecord.mockReturnValue(true);
     vi.spyOn(recordHooks, "useRecord").mockReturnValue(undefined);
     vi.spyOn(collectionHooks, "useCollection").mockReturnValue(defaultCol);
-    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(SERVERINFO_WITH_ATTACHMENTS_CAPABILITY);
+    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(
+      SERVERINFO_WITH_ATTACHMENTS_CAPABILITY
+    );
     vi.spyOn(client, "getClient").mockReturnValue({
       bucket: bid => {
         return {

--- a/test/components/record/RecordForm_test.tsx
+++ b/test/components/record/RecordForm_test.tsx
@@ -1,6 +1,6 @@
 import * as client from "@src/client";
 import RecordForm from "@src/components/record/RecordForm";
-import { DEFAULT_SERVERINFO } from "@src/constants";
+import { SERVERINFO_WITH_ATTACHMENTS_CAPABILITY } from "@src/constants";
 import * as collectionHooks from "@src/hooks/collection";
 import * as recordHooks from "@src/hooks/record";
 import * as sessionHooks from "@src/hooks/session";
@@ -78,7 +78,7 @@ describe("RecordForm", () => {
     canEditRecord.mockReturnValue(true);
     vi.spyOn(recordHooks, "useRecord").mockReturnValue(undefined);
     vi.spyOn(collectionHooks, "useCollection").mockReturnValue(defaultCol);
-    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(DEFAULT_SERVERINFO);
+    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(SERVERINFO_WITH_ATTACHMENTS_CAPABILITY);
     vi.spyOn(client, "getClient").mockReturnValue({
       bucket: bid => {
         return {


### PR DESCRIPTION
Fix #3426

- Only show attachment form/info if capability is on server and enabled in collection
- Show warning if enabled on collection but no capabilty on server