### PR TITLE
Fix #3061: Adjust table columns sizes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -159,12 +159,26 @@ h1 {
   margin-top: 2em;
 }
 
+.table-wrapper {
+  overflow-x: auto;
+  width: 100%;
+}
+
 table.record-list {
   margin-top: 1em;
+  border-collapse: collapse;
+  table-layout: auto;
+  width: max-content; /* Let the table shrink to fit its content */
+  min-width: 100%;    /* But not smaller than viewport/container */
 }
 
 table.record-list th {
   background: rgba(0, 0, 0, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  white-space: nowrap;
+  padding: 0.8em 0.5em;
 }
 
 table.record-list tbody.loading td {
@@ -172,29 +186,24 @@ table.record-list tbody.loading td {
   color: #777;
 }
 
-table.record-list td:not(.actions) {
-  max-width: 8vw;
+table.record-list th, table.record-list td {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   padding: 0.8em 0.5em;
+  max-width: 300px;
 }
 
 table.record-list td.lastmod {
-  white-space: nowrap;
   width: 120px;
-}
-
-table.record-list td.status {
-  white-space: nowrap;
-  width: 80px;
+  max-width: 120px;
 }
 
 table.record-list td.actions {
-  min-width: 150px;
-  width: 150px;
+  min-width: 110px;
+  width: 110px;
+  max-width: 110px;
   padding: 0.5em 0;
-  white-space: nowrap;
   text-align: center;
 }
 
@@ -262,8 +271,8 @@ table.record-list td.load-more {
 }
 
 .sort-link {
-  float: right;
   margin-top: 0.1em;
+  margin-left: 0.5em;
   color: #444;
 }
 

--- a/src/components/PaginatedTable.tsx
+++ b/src/components/PaginatedTable.tsx
@@ -19,38 +19,40 @@ export default function PaginatedTable({
   listNextPage,
 }: Props) {
   return (
-    <table
-      className="table table-striped table-bordered record-list"
-      data-testid="paginatedTable"
-    >
-      {thead}
-      {tbody}
-      {hasNextPage && (
-        <tfoot>
-          <tr>
-            <td colSpan={colSpan} className="load-more text-center">
-              {!dataLoaded ? (
-                <Spinner />
-              ) : (
-                <a
-                  href="."
-                  key="__3"
-                  onClick={event => {
-                    event.preventDefault();
-                    // FIXME: we should always have listNextPage if
-                    // we have hasNextPage
-                    if (listNextPage) {
-                      listNextPage();
-                    }
-                  }}
-                >
-                  Load more
-                </a>
-              )}
-            </td>
-          </tr>
-        </tfoot>
-      )}
-    </table>
+    <div className="table-wrapper">
+      <table
+        className="table table-striped table-bordered record-list"
+        data-testid="paginatedTable"
+      >
+        {thead}
+        {tbody}
+        {hasNextPage && (
+          <tfoot>
+            <tr>
+              <td colSpan={colSpan} className="load-more text-center">
+                {!dataLoaded ? (
+                  <Spinner />
+                ) : (
+                  <a
+                    href="."
+                    key="__3"
+                    onClick={event => {
+                      event.preventDefault();
+                      // FIXME: we should always have listNextPage if
+                      // we have hasNextPage
+                      if (listNextPage) {
+                        listNextPage();
+                      }
+                    }}
+                  >
+                    Load more
+                  </a>
+                )}
+              </td>
+            </tr>
+          </tfoot>
+        )}
+      </table>
+    </div>
   );
 }

--- a/src/components/bucket/CollectionDataList.tsx
+++ b/src/components/bucket/CollectionDataList.tsx
@@ -47,7 +47,7 @@ export function DataList(props) {
         <th>Schema</th>
         <th>Attachments</th>
         <th>Cache Expires</th>
-        <th>Last mod.</th>
+        <th>Last modified</th>
         <th>Actions</th>
       </tr>
     </thead>

--- a/src/components/bucket/CollectionDataList.tsx
+++ b/src/components/bucket/CollectionDataList.tsx
@@ -70,7 +70,11 @@ export function DataList(props) {
           const ageString = date && timeago(date.getTime());
           return (
             <tr key={index}>
-              <td>{cid}</td>
+              <td>
+                <AdminLink name="collection:records" params={{ bid, cid }}>
+                  {cid}
+                </AdminLink>
+              </td>
               <td>{schema ? "Yes" : "No"}</td>
               <td>
                 {attachment ? (attachment.required ? "Required" : "Yes") : "No"}

--- a/src/components/bucket/GroupDataList.tsx
+++ b/src/components/bucket/GroupDataList.tsx
@@ -11,67 +11,69 @@ export function DataList(props) {
   const serverInfo = useServerInfo();
   const { bid, groups, showSpinner } = props;
   return (
-    <table className="table table-striped table-bordered record-list">
-      <thead>
-        <tr>
-          <th>Id</th>
-          <th>Members</th>
-          <th>Last mod.</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        {showSpinner && (
+    <div className="table-wrapper">
+      <table className="table table-striped table-bordered record-list">
+        <thead>
           <tr>
-            <td colSpan={4}>
-              <Spinner />
-            </td>
+            <th>Id</th>
+            <th>Members</th>
+            <th>Last modified</th>
+            <th>Actions</th>
           </tr>
-        )}
-        {groups &&
-          groups.map((group, index) => {
-            const { id: gid, members, last_modified } = group;
-            const date = new Date(last_modified);
-            return (
-              <tr key={index}>
-                <td>
-                  <AdminLink name="group:attributes" params={{ bid, gid }}>
-                    {gid}
-                  </AdminLink>
-                </td>
-                <td>{members.join(", ")}</td>
-                <td>
-                  <span title={date.toISOString()}>
-                    {timeago(date.getTime())}
-                  </span>
-                </td>
-                <td className="actions">
-                  <div className="btn-group">
-                    {serverInfo && "history" in serverInfo.capabilities && (
+        </thead>
+        <tbody>
+          {showSpinner && (
+            <tr>
+              <td colSpan={4}>
+                <Spinner />
+              </td>
+            </tr>
+          )}
+          {groups &&
+            groups.map((group, index) => {
+              const { id: gid, members, last_modified } = group;
+              const date = new Date(last_modified);
+              return (
+                <tr key={index}>
+                  <td>
+                    <AdminLink name="group:attributes" params={{ bid, gid }}>
+                      {gid}
+                    </AdminLink>
+                  </td>
+                  <td>{members.join(", ")}</td>
+                  <td>
+                    <span title={date.toISOString()}>
+                      {timeago(date.getTime())}
+                    </span>
+                  </td>
+                  <td className="actions">
+                    <div className="btn-group">
+                      {serverInfo && "history" in serverInfo.capabilities && (
+                        <AdminLink
+                          name="group:history"
+                          params={{ bid, gid }}
+                          className="btn btn-sm btn-secondary"
+                          title="View group history"
+                        >
+                          <ClockHistory className="icon" />
+                        </AdminLink>
+                      )}
                       <AdminLink
-                        name="group:history"
+                        name="group:attributes"
                         params={{ bid, gid }}
                         className="btn btn-sm btn-secondary"
-                        title="View group history"
+                        title="Edit groups attributes"
                       >
-                        <ClockHistory className="icon" />
+                        <Gear className="icon" />
                       </AdminLink>
-                    )}
-                    <AdminLink
-                      name="group:attributes"
-                      params={{ bid, gid }}
-                      className="btn btn-sm btn-secondary"
-                      title="Edit groups attributes"
-                    >
-                      <Gear className="icon" />
-                    </AdminLink>
-                  </div>
-                </td>
-              </tr>
-            );
-          })}
-      </tbody>
-    </table>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+        </tbody>
+      </table>
+    </div>
   );
 }
 

--- a/src/components/collection/RecordRow.tsx
+++ b/src/components/collection/RecordRow.tsx
@@ -75,7 +75,7 @@ export default function RecordRow({
         </td>
       ))}
       <td className="lastmod">{lastModified()}</td>
-      <td className="actions text-right" data-testid={`${rid}-actions`}>
+      <td className="actions" data-testid={`${rid}-actions`}>
         <AdminLink
           name="record:attributes"
           params={{ bid, cid, rid }}

--- a/src/components/collection/RecordTable.tsx
+++ b/src/components/collection/RecordTable.tsx
@@ -202,7 +202,7 @@ export default function RecordTable({
           </th>
         ))}
         <th>
-          Last mod.
+          Last modified
           <ColumnSortLink
             currentSort={currentSort}
             column="last_modified"


### PR DESCRIPTION
Fix #3061

Seems to do the job:
- columns are fit to content
- when content is too long (>300px) and ellipsis is shown
- when screen is too narrow, an horizontal scroll is shown

<img width="1066" height="574" alt="Screenshot 2025-07-22 at 12 24 00" src="https://github.com/user-attachments/assets/aec3b301-c846-4749-ac5a-1184b835992a" />

<img width="787" height="402" alt="Screenshot 2025-07-22 at 12 28 22" src="https://github.com/user-attachments/assets/26f2658b-d394-457b-bb76-f6a3456cbea1" />
