### PR TITLE
Refactor group list code to match collection list

### DIFF
--- a/src/components/bucket/BucketGroups.tsx
+++ b/src/components/bucket/BucketGroups.tsx
@@ -17,7 +17,7 @@ export default function BucketGroups() {
       </h1>
       <BucketTabs bid={bid} selected="groups">
         {listActions}
-        {groups && groups.length === 0 ? (
+        {groups && groups.data.length === 0 ? (
           <div className="alert alert-info">
             <p>This bucket has no groups.</p>
           </div>

--- a/src/components/bucket/GroupDataList.tsx
+++ b/src/components/bucket/GroupDataList.tsx
@@ -1,79 +1,12 @@
 import Spinner from "../Spinner";
 import AdminLink from "@src/components/AdminLink";
+import PaginatedTable from "@src/components/PaginatedTable";
 import { usePermissions, useServerInfo } from "@src/hooks/session";
 import { canCreateGroup } from "@src/permission";
 import { timeago } from "@src/utils";
-import React from "react";
+import React, { useState } from "react";
 import { Gear } from "react-bootstrap-icons";
 import { ClockHistory } from "react-bootstrap-icons";
-
-export function DataList(props) {
-  const serverInfo = useServerInfo();
-  const { bid, groups, showSpinner } = props;
-  return (
-    <table className="table table-striped table-bordered record-list">
-      <thead>
-        <tr>
-          <th>Id</th>
-          <th>Members</th>
-          <th>Last mod.</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        {showSpinner && (
-          <tr>
-            <td colSpan={4}>
-              <Spinner />
-            </td>
-          </tr>
-        )}
-        {groups &&
-          groups.map((group, index) => {
-            const { id: gid, members, last_modified } = group;
-            const date = new Date(last_modified);
-            return (
-              <tr key={index}>
-                <td>
-                  <AdminLink name="group:attributes" params={{ bid, gid }}>
-                    {gid}
-                  </AdminLink>
-                </td>
-                <td>{members.join(", ")}</td>
-                <td>
-                  <span title={date.toISOString()}>
-                    {timeago(date.getTime())}
-                  </span>
-                </td>
-                <td className="actions">
-                  <div className="btn-group">
-                    {serverInfo && "history" in serverInfo.capabilities && (
-                      <AdminLink
-                        name="group:history"
-                        params={{ bid, gid }}
-                        className="btn btn-sm btn-secondary"
-                        title="View group history"
-                      >
-                        <ClockHistory className="icon" />
-                      </AdminLink>
-                    )}
-                    <AdminLink
-                      name="group:attributes"
-                      params={{ bid, gid }}
-                      className="btn btn-sm btn-secondary"
-                      title="Edit groups attributes"
-                    >
-                      <Gear className="icon" />
-                    </AdminLink>
-                  </div>
-                </td>
-              </tr>
-            );
-          })}
-      </tbody>
-    </table>
-  );
-}
 
 export function ListActions({ bid, busy }) {
   const permissions = usePermissions();
@@ -90,5 +23,89 @@ export function ListActions({ bid, busy }) {
         Create group
       </AdminLink>
     </div>
+  );
+}
+
+export function DataList(props) {
+  const [loading, setLoading] = useState(false);
+  const serverInfo = useServerInfo();
+  const { bid, groups, showSpinner } = props;
+
+  if (showSpinner) {
+    return <Spinner />;
+  }
+
+  const thead = (
+    <thead>
+      <tr>
+        <th>Id</th>
+        <th>Members</th>
+        <th>Last modified</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+  );
+  const { data, hasNextPage, next } = groups;
+  const nextWrapper = async () => {
+    setLoading(true);
+    await next();
+    setLoading(false);
+  };
+
+  const tbody = (
+    <tbody className={""}>
+      {data &&
+        data.map((group, index) => {
+          const { id: gid, members, last_modified } = group;
+          const date = new Date(last_modified);
+          return (
+            <tr key={index}>
+              <td>
+                <AdminLink name="group:attributes" params={{ bid, gid }}>
+                  {gid}
+                </AdminLink>
+              </td>
+              <td>{members.join(", ")}</td>
+              <td>
+                <span title={date.toISOString()}>
+                  {timeago(date.getTime())}
+                </span>
+              </td>
+              <td className="actions">
+                <div className="btn-group">
+                  {serverInfo && "history" in serverInfo.capabilities && (
+                    <AdminLink
+                      name="group:history"
+                      params={{ bid, gid }}
+                      className="btn btn-sm btn-secondary"
+                      title="View group history"
+                    >
+                      <ClockHistory className="icon" />
+                    </AdminLink>
+                  )}
+                  <AdminLink
+                    name="group:attributes"
+                    params={{ bid, gid }}
+                    className="btn btn-sm btn-secondary"
+                    title="Edit groups attributes"
+                  >
+                    <Gear className="icon" />
+                  </AdminLink>
+                </div>
+              </td>
+            </tr>
+          );
+        })}
+    </tbody>
+  );
+  return (
+    <PaginatedTable
+      thead={thead}
+      tbody={tbody}
+      dataLoaded={!loading}
+      colSpan={4}
+      hasNextPage={hasNextPage}
+      listNextPage={nextWrapper}
+    />
   );
 }

--- a/test/hooks/group_test.ts
+++ b/test/hooks/group_test.ts
@@ -80,7 +80,7 @@ describe("group hooks", () => {
       const { result } = renderHook(() => useGroupList("bid", "cid", "sort"));
       expect(result.current).toBeUndefined();
       await vi.waitFor(() => {
-        expect(result.current).toMatchObject(testGroups);
+        expect(result.current).toMatchObject({ data: testGroups });
       });
       expect(listGroupsMock).toHaveBeenCalled();
     });
@@ -107,7 +107,7 @@ describe("group hooks", () => {
       renderHook(() => useGroupList("bid"));
       await vi.waitFor(() => {
         expect(notifyErrorMock).toHaveBeenCalledWith(
-          "Unable to load group list",
+          "Error fetching group list",
           expect.any(Error)
         );
       });


### PR DESCRIPTION
For some reason the hook and table were built differently on buckets collections lists and buckets groups lists 