### PR TITLE
Ref mozilla/remote-settings#949: add simple checkboxes to reduce history

### DIFF
--- a/src/components/HistoryTable.tsx
+++ b/src/components/HistoryTable.tsx
@@ -3,18 +3,13 @@ import PaginatedTable from "./PaginatedTable";
 import Spinner from "./Spinner";
 import { getClient } from "@src/client";
 import { notifyError } from "@src/hooks/notifications";
-import type {
-  RecordData,
-  ResourceHistoryEntry,
-  RouteLocation,
-} from "@src/types";
-import { diffJson, humanDate, parseHistoryFilters, timeago } from "@src/utils";
+import type { RecordData, ResourceHistoryEntry } from "@src/types";
+import { diffJson, humanDate, timeago } from "@src/utils";
 import { omit, sortHistoryEntryPermissions } from "@src/utils";
 import React, { useState } from "react";
 import { Eye } from "react-bootstrap-icons";
 import { EyeSlash } from "react-bootstrap-icons";
 import { SkipStart } from "react-bootstrap-icons";
-import { useSearchParams } from "react-router";
 
 function Diff({ source, target }: { source: any; target: any }) {
   const diff = diffJson(source, target);
@@ -197,22 +192,15 @@ function HistoryRow({
 }
 
 type FilterInfoProps = {
-  location: RouteLocation;
+  since: string;
   enableDiffOverview: boolean;
   onViewJournalClick: () => void;
   onDiffOverviewClick: (timestamp: string) => void;
 };
 
 function FilterInfo(props: FilterInfoProps) {
-  const {
-    location,
-    enableDiffOverview,
-    onViewJournalClick,
-    onDiffOverviewClick,
-  } = props;
-  const {
-    query: { since },
-  } = location;
+  const { since, enableDiffOverview, onViewJournalClick, onDiffOverviewClick } =
+    props;
 
   return (
     <p>
@@ -283,6 +271,7 @@ type HistoryTableProps = {
   hasNextHistory: boolean;
   listNextHistory?;
   enableDiffOverview?: boolean;
+  sinceFilter?: string;
 };
 
 export default function HistoryTable({
@@ -293,13 +282,13 @@ export default function HistoryTable({
   hasNextHistory,
   listNextHistory,
   enableDiffOverview = false,
+  sinceFilter = "",
 }: HistoryTableProps) {
   const [diffOverview, setDiffOverview] = useState(false);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
   const [current, setCurrent] = useState(null);
   const [previous, setPrevious] = useState(null);
-  const [params, _] = useSearchParams();
 
   const nextHistoryWrapper = async () => {
     setLoading(true);
@@ -333,11 +322,6 @@ export default function HistoryTable({
     setCurrent(null);
     setPrevious(null);
   };
-
-  const query = parseHistoryFilters(params);
-  const routeLocation = { pathname: location.pathname, query };
-  const { since } = query;
-  const isFiltered = !!since;
 
   const thead = (
     <thead>
@@ -378,9 +362,9 @@ export default function HistoryTable({
 
   return (
     <div>
-      {isFiltered && (
+      {!!sinceFilter && (
         <FilterInfo
-          location={routeLocation}
+          since={sinceFilter}
           enableDiffOverview={enableDiffOverview}
           onDiffOverviewClick={onDiffOverviewClick}
           onViewJournalClick={onViewJournalClick}
@@ -389,7 +373,7 @@ export default function HistoryTable({
       {busy ? (
         <Spinner />
       ) : diffOverview ? (
-        <DiffOverview since={since} source={previous} target={current} />
+        <DiffOverview since={sinceFilter} source={previous} target={current} />
       ) : (
         <PaginatedTable
           colSpan={6}

--- a/src/components/collection/CollectionHistory.tsx
+++ b/src/components/collection/CollectionHistory.tsx
@@ -1,15 +1,39 @@
 import CollectionTabs from "./CollectionTabs";
 import HistoryTable from "@src/components/HistoryTable";
 import { useCollectionHistory } from "@src/hooks/collection";
+import {
+  useExcludeNonHumans,
+  useExcludeSignerPlugin,
+} from "@src/hooks/preferences";
+import { useServerInfo } from "@src/hooks/session";
 import { parseHistoryFilters } from "@src/utils";
 import React from "react";
 import { useParams, useSearchParams } from "react-router";
 
 export default function CollectionHistory() {
   const { bid, cid } = useParams();
+
+  // History filters can be passed from URL
   const [params, _] = useSearchParams();
   const filters = parseHistoryFilters(params);
+
+  // But users can toggle them, and their choice is persisted
+  const [excludeSignerPlugin, setExcludeSignerPlugin] = useExcludeSignerPlugin(
+    filters.exclude_signer_plugin
+  );
+  const [excludeNonHumans, setExcludeNonHumans] = useExcludeNonHumans(
+    filters.exclude_non_humans
+  );
+  filters.exclude_signer_plugin = excludeSignerPlugin;
+  filters.exclude_non_humans = excludeNonHumans;
+
+  // Refetch from the server when filters change.
   const history = useCollectionHistory(bid, cid, filters);
+
+  // Hide the non human filters if the server does not support openid or signer
+  const serverInfo = useServerInfo();
+  const hasOpenID = "openid" in serverInfo.capabilities;
+  const hasSigner = "signer" in serverInfo.capabilities;
 
   return (
     <div>
@@ -20,6 +44,35 @@ export default function CollectionHistory() {
         </b>
       </h1>
       <CollectionTabs bid={bid} cid={cid} selected="history">
+        {hasOpenID && (
+          <div className="form-check form-check-inline mb-3">
+            <input
+              className="form-check-input"
+              type="checkbox"
+              checked={excludeNonHumans}
+              onChange={e => setExcludeNonHumans(e.currentTarget.checked)}
+              id="excludeNonHumans"
+            />
+            <label className="form-check-label" htmlFor="excludeNonHumans">
+              Exclude non humans
+            </label>
+          </div>
+        )}
+        {hasSigner && (
+          <div className="form-check form-check-inline mb-3">
+            <input
+              className="form-check-input"
+              type="checkbox"
+              checked={excludeNonHumans || excludeSignerPlugin}
+              onChange={e => setExcludeSignerPlugin(e.currentTarget.checked)}
+              id="excludeSignerPlugin"
+              disabled={excludeNonHumans}
+            />
+            <label className="form-check-label" htmlFor="excludeSignerPlugin">
+              Exclude signer plugin
+            </label>
+          </div>
+        )}
         <HistoryTable
           enableDiffOverview
           bid={bid}

--- a/src/components/collection/CollectionHistory.tsx
+++ b/src/components/collection/CollectionHistory.tsx
@@ -32,8 +32,8 @@ export default function CollectionHistory() {
 
   // Hide the non human filters if the server does not support openid or signer
   const serverInfo = useServerInfo();
-  const hasOpenID = "openid" in serverInfo.capabilities;
-  const hasSigner = "signer" in serverInfo.capabilities;
+  const hasOpenID = serverInfo && "openid" in serverInfo.capabilities;
+  const hasSigner = serverInfo && "signer" in serverInfo.capabilities;
 
   return (
     <div>
@@ -52,6 +52,7 @@ export default function CollectionHistory() {
               checked={excludeNonHumans}
               onChange={e => setExcludeNonHumans(e.currentTarget.checked)}
               id="excludeNonHumans"
+              data-testid="excludeNonHumans"
             />
             <label className="form-check-label" htmlFor="excludeNonHumans">
               Exclude non humans
@@ -66,6 +67,7 @@ export default function CollectionHistory() {
               checked={excludeNonHumans || excludeSignerPlugin}
               onChange={e => setExcludeSignerPlugin(e.currentTarget.checked)}
               id="excludeSignerPlugin"
+              data-testid="excludeSignerPlugin"
               disabled={excludeNonHumans}
             />
             <label className="form-check-label" htmlFor="excludeSignerPlugin">

--- a/src/components/collection/CollectionHistory.tsx
+++ b/src/components/collection/CollectionHistory.tsx
@@ -28,6 +28,7 @@ export default function CollectionHistory() {
           history={history.data || []}
           hasNextHistory={history.hasNextPage}
           listNextHistory={history.next}
+          sinceFilter={filters.since}
         />
       </CollectionTabs>
     </div>

--- a/src/components/signoff/Review.tsx
+++ b/src/components/signoff/Review.tsx
@@ -154,7 +154,7 @@ export function DiffInfo(props: {
       query={{
         since,
         resource_name: "record",
-        exclude_user_id: "plugin:remote-settings",
+        exclude_signer_plugin: true,
       }}
     >
       details...

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,5 +18,15 @@ export const SERVERINFO_WITH_ATTACHMENTS_CAPABILITY = {
   ...DEFAULT_SERVERINFO,
   capabilities: {
     attachments: {},
+    ...DEFAULT_SERVERINFO.capabilities,
+  },
+};
+
+export const SERVERINFO_WITH_SIGNER_AND_HISTORY_CAPABILITIES = {
+  ...DEFAULT_SERVERINFO,
+  capabilities: {
+    signer: {},
+    openid: {},
+    ...DEFAULT_SERVERINFO.capabilities,
   },
 };

--- a/src/hooks/collection.ts
+++ b/src/hooks/collection.ts
@@ -125,11 +125,9 @@ export function useCollectionHistory(
   if (filters.exclude_signer_plugin) {
     const pluginUserId =
       serverInfo.capabilities.signer.plugin_user_id || "plugin:remote-settings";
-    if (serverFilters.exclude_user_id) {
-      serverFilters.exclude_user_id += `,${pluginUserId}`;
-    } else {
-      serverFilters.exclude_user_id = pluginUserId;
-    }
+    serverFilters.exclude_user_id = serverFilters.exclude_user_id
+      ? `${serverFilters.exclude_user_id},${pluginUserId}`
+      : pluginUserId;
   }
   if (filters.exclude_non_humans && "openid" in serverInfo.capabilities) {
     // Human authType is openid for now. Become smart when needed.

--- a/src/hooks/collection.ts
+++ b/src/hooks/collection.ts
@@ -1,9 +1,11 @@
 import { notifyError } from "./notifications";
+import { useServerInfo } from "./session";
 import { getClient } from "@src/client";
 import { MAX_PER_PAGE } from "@src/constants";
 import {
   CollectionData,
   CollectionPermissions,
+  HistoryFilters,
   ListHistoryResult,
   ListResult,
 } from "@src/types";
@@ -106,14 +108,38 @@ async function fetchCollections(bid: string, curData, setVal, nextPageFn?) {
 export function useCollectionHistory(
   bid: string,
   cid: string,
-  filters: any,
+  filters: HistoryFilters,
   cacheBust?: number
 ): ListHistoryResult {
   const [val, setVal] = useState({});
 
+  const serverInfo = useServerInfo();
+  // Turn the HistoryFilters into server filters.
+  const serverFilters: { [key: string]: string } = {
+    resource_name: filters.resource_name,
+    "gt_target.data.last_modified": filters.since,
+  };
+  if (filters.exclude_user_id) {
+    serverFilters.exclude_user_id = filters.exclude_user_id;
+  }
+  if (filters.exclude_signer_plugin) {
+    const pluginUserId =
+      serverInfo.capabilities.signer.plugin_user_id || "plugin:remote-settings";
+    if (serverFilters.exclude_user_id) {
+      serverFilters.exclude_user_id += `,${pluginUserId}`;
+    } else {
+      serverFilters.exclude_user_id = pluginUserId;
+    }
+  }
+  if (filters.exclude_non_humans && "openid" in serverInfo.capabilities) {
+    // Human authType is openid for now. Become smart when needed.
+    const authType = serverInfo.capabilities.openid.providers[0].name;
+    serverFilters.like_user_id = `${authType}:*`;
+  }
+
   useEffect(() => {
     setVal({});
-    fetchHistory(bid, cid, filters, [], setVal);
+    fetchHistory(bid, cid, serverFilters, [], setVal);
   }, [bid, cid, ...Object.values(filters), cacheBust]);
 
   return val;
@@ -122,7 +148,7 @@ export function useCollectionHistory(
 async function fetchHistory(
   bid: string,
   cid: string,
-  filters: any,
+  filters: { [key: string]: string },
   curData,
   setVal,
   nextPageFn?
@@ -133,16 +159,13 @@ async function fetchHistory(
     if (nextPageFn) {
       result = await nextPageFn();
     } else {
-      const { resource_name, exclude_user_id, since } = filters;
       result = await getClient()
         .bucket(bid)
         .listHistory({
           limit: MAX_PER_PAGE,
           filters: {
-            resource_name,
-            exclude_user_id,
             collection_id: cid,
-            "gt_target.data.last_modified": since,
+            ...filters,
           },
         });
     }

--- a/src/hooks/preferences.ts
+++ b/src/hooks/preferences.ts
@@ -29,3 +29,17 @@ export function useShowDiffAllLines(): [boolean, (boolean) => void] {
   const [val, setVal] = useLocalStorage("showDiffAllLines", false);
   return [val, setVal] as [boolean, (boolean) => void];
 }
+
+export function useExcludeNonHumans(
+  byDefault: boolean
+): [boolean, (boolean) => void] {
+  const [val, setVal] = useLocalStorage("excludeNonHumans", byDefault);
+  return [val, setVal] as [boolean, (boolean) => void];
+}
+
+export function useExcludeSignerPlugin(
+  byDefault: boolean
+): [boolean, (boolean) => void] {
+  const [val, setVal] = useLocalStorage("excludeSignerPlugin", byDefault);
+  return [val, setVal] as [boolean, (boolean) => void];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,11 +55,17 @@ export type SignerCapabilityResourceEntry = {
   collection: string;
 };
 
+export type OpenIDProvider = {
+  name: string;
+};
+
 export type Capabilities = {
   attachments?: any;
   changes?: any;
   default_bucket?: any;
-  openid?: any;
+  openid?: {
+    providers: OpenIDProvider[];
+  };
   history?: any;
   permissions_endpoint?: any;
   schema?: any;
@@ -68,6 +74,7 @@ export type Capabilities = {
     editors_group: string;
     reviewers_group: string;
     to_review_enabled: boolean;
+    plugin_user_id?: string;
   };
 };
 
@@ -90,6 +97,8 @@ export type HistoryFilters = {
   since?: string;
   resource_name?: string;
   exclude_user_id?: string;
+  exclude_signer_plugin?: boolean;
+  exclude_non_humans?: boolean;
 };
 
 export type CollectionData = {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -320,19 +320,17 @@ export const getAuthLabel = (authType: string) => {
 };
 
 export function parseHistoryFilters(params: URLSearchParams): HistoryFilters {
-  const ret: HistoryFilters = {};
-  const since = params.get("since");
-  if (since) {
-    ret.since = since;
-  }
-  const resourceName = params.get("resource_name");
-  if (resourceName) {
-    ret.resource_name = resourceName;
-  }
-  const excludeUserId = params.get("exclude_user_id");
-  if (excludeUserId) {
-    ret.exclude_user_id = excludeUserId;
-  }
+  const ret: HistoryFilters = [
+    "since",
+    "resource_name",
+    "exclude_user_id",
+    "exclude_signer_plugin",
+    "exclude_non_humans",
+  ].reduce((acc, field) => {
+    const val = params.get(field);
+    if (val) acc[field] = val == "true" ? true : val;
+    return acc;
+  }, {});
   return ret;
 }
 

--- a/test/components/CollectionHistory_test.tsx
+++ b/test/components/CollectionHistory_test.tsx
@@ -1,0 +1,131 @@
+import CollectionHistory from "@src/components/collection/CollectionHistory";
+import {
+  DEFAULT_SERVERINFO,
+  SERVERINFO_WITH_SIGNER_AND_HISTORY_CAPABILITIES,
+} from "@src/constants";
+import * as collectionHooks from "@src/hooks/collection";
+import * as preferenceHooks from "@src/hooks/preferences";
+import * as sessionHooks from "@src/hooks/session";
+import {
+  canCreateRecord,
+  canEditCollection,
+  canEditRecord,
+} from "@src/permission";
+import { renderWithRouter } from "@test/testUtils";
+import { fireEvent, screen } from "@testing-library/react";
+import React from "react";
+
+vi.mock("@src/permission", () => ({
+  __esModule: true,
+  canCreateRecord: vi.fn(),
+  canEditRecord: vi.fn(),
+  canEditCollection: vi.fn(),
+}));
+
+describe("CollectionHistory component", () => {
+  const routeProps = {
+    route: "/default/history",
+    path: "/:bid/:cid/:tab?",
+    initialEntries: ["/default/collection/history"],
+    initialState: {
+      session: {
+        serverInfo: {
+          capabilities: {
+            history: {},
+            signer: {},
+            openid: {},
+          },
+        },
+      },
+    },
+  };
+
+  const useCollectionHistoryMock = vi.fn();
+  const useExcludeSignerPluginMock = vi.fn();
+  const useExcludeNonHumansMock = vi.fn();
+
+  beforeEach(() => {
+    canCreateRecord.mockReturnValue(true);
+    canEditRecord.mockReturnValue(true);
+    canEditCollection.mockReturnValue(true);
+
+    vi.spyOn(collectionHooks, "useCollectionHistory").mockImplementation(
+      useCollectionHistoryMock
+    );
+    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(
+      SERVERINFO_WITH_SIGNER_AND_HISTORY_CAPABILITIES
+    );
+    vi.spyOn(preferenceHooks, "useExcludeSignerPlugin").mockImplementation(
+      () => [false, useExcludeSignerPluginMock]
+    );
+    vi.spyOn(preferenceHooks, "useExcludeNonHumans").mockImplementation(() => [
+      false,
+      useExcludeNonHumansMock,
+    ]);
+
+    useCollectionHistoryMock.mockReturnValue({
+      data: [],
+      hasNextPage: false,
+      next: vi.fn(),
+    });
+  });
+
+  describe("Without capabilities", () => {
+    beforeEach(() => {
+      vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(
+        DEFAULT_SERVERINFO
+      );
+      renderWithRouter(<CollectionHistory />, routeProps);
+    });
+
+    it("should hide filters when capabilities are missing", () => {
+      expect(screen.queryByTestId("excludeNonHumans")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("excludeSignerPlugin")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("With filters enabled", () => {
+    let rendered;
+    beforeEach(() => {
+      rendered = renderWithRouter(<CollectionHistory />, routeProps);
+    });
+
+    it("should render the history table", () => {
+      expect(screen.getByTestId("paginatedTable")).toBeInTheDocument();
+    });
+
+    it("should render both filters when supported", () => {
+      expect(screen.getByTestId("excludeNonHumans")).toBeInTheDocument();
+      expect(screen.getByTestId("excludeSignerPlugin")).toBeInTheDocument();
+    });
+
+    it("should have no filter checked by default", () => {
+      expect(screen.getByTestId("excludeNonHumans")).not.toBeChecked();
+      expect(screen.getByTestId("excludeSignerPlugin")).not.toBeChecked();
+    });
+
+    it("should disable signer plugin filter if excludeNonHumans is checked", () => {
+      vi.spyOn(preferenceHooks, "useExcludeNonHumans").mockReturnValue([
+        true,
+        useExcludeNonHumansMock,
+      ]);
+      rendered.rerender(<CollectionHistory />);
+      const signerCheckbox = screen.getByTestId("excludeSignerPlugin");
+      expect(signerCheckbox).toBeDisabled();
+    });
+
+    it("should update excludeNonHumans filter when toggled", () => {
+      const checkbox = screen.getByTestId("excludeNonHumans");
+      fireEvent.click(checkbox);
+      expect(useExcludeNonHumansMock).toHaveBeenCalledWith(true);
+    });
+
+    it("should update excludeSignerPlugin filter when toggled", () => {
+      const checkbox = screen.getByTestId("excludeSignerPlugin");
+      fireEvent.click(checkbox);
+      expect(useExcludeSignerPluginMock).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/test/hooks/preferences_test.ts
+++ b/test/hooks/preferences_test.ts
@@ -70,4 +70,26 @@ describe("preferences hooks", () => {
       expect(setValMock).toHaveBeenCalledWith(true);
     });
   });
+
+  describe("useExcludeNonHumans", () => {
+    it("returns storage val and setVal", async () => {
+      const setValMock = vi.fn();
+      mock.mockReturnValue([false, setValMock]);
+      const [val, setVal] = preferencesHooks.useExcludeNonHumans(false);
+      setVal(true);
+      expect(val).toBe(false);
+      expect(setValMock).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("useExcludeSignerPlugin", () => {
+    it("returns storage val and setVal", async () => {
+      const setValMock = vi.fn();
+      mock.mockReturnValue([false, setValMock]);
+      const [val, setVal] = preferencesHooks.useExcludeSignerPlugin(false);
+      setVal(true);
+      expect(val).toBe(false);
+      expect(setValMock).toHaveBeenCalledWith(true);
+    });
+  });
 });

--- a/test/utils_test.ts
+++ b/test/utils_test.ts
@@ -7,6 +7,7 @@ import {
   getServerByPriority,
   humanDate,
   makeObservable,
+  parseHistoryFilters,
   renderDisplayField,
   sortHistoryEntryPermissions,
   timeago,
@@ -469,5 +470,18 @@ describe("makeObservable", () => {
     expect(testFn3).toHaveBeenCalledWith("string2");
     expect(testFn3).toHaveBeenCalledWith("string3");
     expect(testFn3).not.toHaveBeenCalledWith("string4");
+  });
+});
+
+describe("parseHistoryFilters", () => {
+  it("should parse querystrings", async () => {
+    expect(
+      parseHistoryFilters(
+        new URLSearchParams("?resource_name=record&exclude_signer_plugin=true")
+      )
+    ).toEqual({
+      resource_name: "record",
+      exclude_signer_plugin: true,
+    });
   });
 });


### PR DESCRIPTION
Ref mozilla/remote-settings#949

While we consolidate a design for mozilla/remote-settings#949, which may require adding new server side filtering features and could take a while to rollout, we can at least offer these checkboxes that will allow users to exclude annoying history entries (`account:*` (signature refresh)  and `plugin:remote-settings` (internal updates))

<img width="1412" height="601" alt="Screenshot 2025-07-30 at 13 29 17" src="https://github.com/user-attachments/assets/aa1c0f9d-a393-4b60-9b77-a06480c25000" />

Related https://github.com/mozilla/remote-settings/pull/962