### PR TITLE
Fix mozilla/remote-settings#966: show warning if collection history was disabled from config

### DIFF
--- a/src/components/HistoryTable.tsx
+++ b/src/components/HistoryTable.tsx
@@ -3,6 +3,7 @@ import PaginatedTable from "./PaginatedTable";
 import Spinner from "./Spinner";
 import { getClient } from "@src/client";
 import { notifyError } from "@src/hooks/notifications";
+import { useServerInfo } from "@src/hooks/session";
 import type { RecordData, ResourceHistoryEntry } from "@src/types";
 import { diffJson, humanDate, timeago } from "@src/utils";
 import { omit, sortHistoryEntryPermissions } from "@src/utils";
@@ -289,6 +290,22 @@ export default function HistoryTable({
   const [busy, setBusy] = useState(false);
   const [current, setCurrent] = useState(null);
   const [previous, setPrevious] = useState(null);
+
+  const serverInfo = useServerInfo();
+  const wasDisabled = (
+    serverInfo.capabilities.history?.excluded_resources || []
+  ).some(
+    resource =>
+      resource.bucket == bid &&
+      (resource.collection == cid || !resource.collection)
+  );
+  if (wasDisabled) {
+    return (
+      <div className="alert alert-warning" data-testid="warning">
+        <p>History was disabled for this collection in server configuration.</p>
+      </div>
+    );
+  }
 
   const nextHistoryWrapper = async () => {
     setLoading(true);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,7 @@ export const SERVERINFO_WITH_SIGNER_AND_HISTORY_CAPABILITIES = {
   capabilities: {
     signer: {},
     openid: {},
+    history: {},
     ...DEFAULT_SERVERINFO.capabilities,
   },
 };

--- a/test/components/HistoryTable_test.tsx
+++ b/test/components/HistoryTable_test.tsx
@@ -1,4 +1,6 @@
 import HistoryTable from "@src/components/HistoryTable";
+import { SERVERINFO_WITH_SIGNER_AND_HISTORY_CAPABILITIES } from "@src/constants";
+import * as sessionHooks from "@src/hooks/session";
 import { renderWithRouter } from "@test/testUtils";
 import { screen } from "@testing-library/react";
 import React from "react";
@@ -16,6 +18,26 @@ const props = {
 };
 
 describe("HistoryTable component", () => {
+  beforeAll(() => {
+    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue(
+      SERVERINFO_WITH_SIGNER_AND_HISTORY_CAPABILITIES
+    );
+  });
+
+  it("Should show banner if collection is excluded", async () => {
+    vi.spyOn(sessionHooks, "useServerInfo").mockReturnValue({
+      capabilities: {
+        history: {
+          excluded_resources: [{ bucket: "test" }],
+        },
+        ...SERVERINFO_WITH_SIGNER_AND_HISTORY_CAPABILITIES.capabilities,
+      },
+      ...SERVERINFO_WITH_SIGNER_AND_HISTORY_CAPABILITIES,
+    });
+    renderWithRouter(<HistoryTable {...props} historyLoaded={false} />);
+    expect(screen.queryByTestId("warning")).toBeDefined();
+  });
+
   it("Should render a spinner when not yet loaded", async () => {
     renderWithRouter(<HistoryTable {...props} historyLoaded={false} />);
     expect(screen.queryByTestId("spinner")).toBeDefined();


### PR DESCRIPTION
Fix mozilla/remote-settings#966