### PR TITLE
Fixing dropdown rendering issue with react v19

### DIFF
--- a/src/components/collection/RecordRow.tsx
+++ b/src/components/collection/RecordRow.tsx
@@ -3,7 +3,7 @@ import AdminLink from "@src/components/AdminLink";
 import { useAuth } from "@src/hooks/session";
 import type { RecordData } from "@src/types";
 import { buildAttachmentUrl, renderDisplayField, timeago } from "@src/utils";
-import React from "react";
+import React, { useRef } from "react";
 import { Dropdown } from "react-bootstrap";
 import {
   ClipboardCheck,
@@ -37,6 +37,7 @@ export default function RecordRow({
 }: RowProps) {
   const navigate = useNavigate();
   const auth = useAuth();
+  const toggle = useRef();
 
   const lastModified = () => {
     const lastModified = record.last_modified;
@@ -111,6 +112,7 @@ export default function RecordRow({
             style={{
               margin: "1pt",
             }}
+            ref={toggle}
           />
           <Dropdown.Menu
             style={{
@@ -142,15 +144,18 @@ export default function RecordRow({
             >
               <Lock className="icon" /> Edit Permissions
             </AdminLink>
-            <Dropdown.Item
+            <button
+              className="dropdown-item"
               onClick={() => {
                 navigator.clipboard.writeText(
                   `${auth.server}/buckets/${bid}/collections/${cid}/records/${record.id}`
                 );
+                // @ts-expect-error
+                toggle.current.click();
               }}
             >
               <ClipboardCheck className="icon" /> Copy Link to Clipboard
-            </Dropdown.Item>
+            </button>
           </Dropdown.Menu>
         </Dropdown>
       </td>

--- a/src/components/homepage/ServerHistory.tsx
+++ b/src/components/homepage/ServerHistory.tsx
@@ -1,7 +1,7 @@
 import { ANONYMOUS_AUTH } from "@src/constants";
 import { clearServersHistory } from "@src/hooks/servers";
 import { debounce } from "@src/utils";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import Dropdown from "react-bootstrap/Dropdown";
 import DropdownButton from "react-bootstrap/DropdownButton";
 import FormControl from "react-bootstrap/FormControl";
@@ -25,10 +25,16 @@ const debounceMillis = 400;
 
 export default function ServerHistory(props: ServerHistoryProps) {
   const [value, setValue] = useState(props.value);
+  const toggleRef = useRef();
+  const toggleDropdown = () => {
+    // @ts-expect-error
+    toggleRef.current.click();
+  };
 
   const select = useCallback(
     server => event => {
       event.preventDefault();
+      toggleDropdown();
       props.onChange(server);
       debouncedFetchServerInfo(server);
       setValue(server);
@@ -39,6 +45,7 @@ export default function ServerHistory(props: ServerHistoryProps) {
   const clear = useCallback(
     event => {
       event.preventDefault();
+      toggleDropdown();
       clearServersHistory();
     },
     [props]
@@ -92,22 +99,27 @@ export default function ServerHistory(props: ServerHistoryProps) {
         variant="outline-secondary"
         title="Servers"
         disabled={disabled}
+        ref={toggleRef}
       >
         {servers.length === 0 ? (
-          <Dropdown.Item>
+          <button className="dropdown-item">
             <em>No server history</em>
-          </Dropdown.Item>
+          </button>
         ) : (
           servers.map(({ server }, key) => (
-            <Dropdown.Item key={key} onClick={select(server)}>
+            <button
+              className="dropdown-item"
+              key={key}
+              onClick={select(server)}
+            >
               {server}
-            </Dropdown.Item>
+            </button>
           ))
         )}
         <Dropdown.Divider />
-        <Dropdown.Item href="#" onClick={clear}>
+        <button className="dropdown-item" onClick={clear}>
           Clear
-        </Dropdown.Item>
+        </button>
       </DropdownButton>
     </InputGroup>
   );


### PR DESCRIPTION
Since updating to react 19, we seem to have a small rendering issue with the `react-bootstrap` dropdown items. We only use these in a couple places so it seems easy enough to replace them with buttons.