### PR TITLE
Fixes #3649 - Replacing react-bs-notifier with react-bootstrap/Toast component

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -576,44 +576,40 @@ form button[type="submit"].btn-primary {
   }
 }
 
-.notifications > div {
+@keyframes fadeIn {
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+.notifications {
+  position: absolute;
+  right: 1em;
+  top: 1em;
+  z-index: 999;
+}
+
+.notifications .toast-header {
+  font-weight: bold;
+  font-size: 20px;
+  padding-right: 3em;
+}
+
+.notifications .toast-body {
+  font-size: 16px;
+}
+
+.notifications .fade {
   top: 3em;
-}
-/*
- * react-bs-notifier uses Font Awesome: alias the classes to bootstrap icons instead.
- */
-i.fa {
-  position: relative;
-  top: 1px;
-  display: inline-block;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 1;
+  animation: fadeIn .5s;
 }
 
-i.fa:before {
-  display: inline-block;
-  content: "";
-  background-repeat: no-repeat;
-  background-size: 24px 24px;
-  width: 24px;
-  height: 24px;
+.notifications .close {
+  position: absolute;
+  right: .5em;
 }
 
-.fa.fa-check:before {
-  background-image: url("~bootstrap-icons/icons/check.svg");
-}
-
-.fa-exclamation-circle:before {
-  background-image: url("~bootstrap-icons/icons/exclamation-circle-fill.svg");
-}
-
-.fa-info:before {
-  background-image: url("~bootstrap-icons/icons/info-circle-fill.svg");
-}
-
-.fa-warning:before {
-  background-image: url("~bootstrap-icons/icons/exclamation-triangle-fill.svg");
+.notifications .bg-danger {
+  color: #fff;
 }
 
 .rjsf {

--- a/css/styles.css
+++ b/css/styles.css
@@ -596,6 +596,13 @@ form button[type="submit"].btn-primary {
 
 .notifications .toast-body {
   font-size: 16px;
+  background-color: rgba(255, 255, 255, 0.6);
+  color: black;
+}
+
+.notifications .toast-header {
+  background-color: inherit;
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .notifications .fade {
@@ -606,10 +613,6 @@ form button[type="submit"].btn-primary {
 .notifications .close {
   position: absolute;
   right: .5em;
-}
-
-.notifications .bg-danger {
-  color: #fff;
 }
 
 .rjsf {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "react": "^19.1.1",
         "react-bootstrap": "^1.6.7",
         "react-bootstrap-icons": "^1.11.3",
-        "react-bs-notifier": "^7.0.0",
         "react-dom": "^19.1.1",
         "react-router": "^7.6.0",
         "timeago.js": "^4.0.2"
@@ -929,19 +928,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",
-      "integrity": "sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==",
-      "dependencies": {
-        "@emotion/memoize": "0.7.1"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
-      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.1",
@@ -2604,12 +2590,11 @@
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.64",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.64.tgz",
-      "integrity": "sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==",
+      "version": "19.1.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.11.tgz",
+      "integrity": "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==",
+      "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -2631,11 +2616,6 @@
       "dependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.3",
@@ -4054,25 +4034,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-jss": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/css-jss/-/css-jss-10.10.0.tgz",
-      "integrity": "sha512-YyMIS/LsSKEGXEaVJdjonWe18p4vXLo8CMA4FrW/kcaEyqdIGKCFXao31gbJddXEdIxSXFFURWrenBJPlKTgAA==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "^10.10.0",
-        "jss-preset-default": "^10.10.0"
-      }
-    },
-    "node_modules/css-vendor": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
-      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.3",
-        "is-in-browser": "^1.0.2"
-      }
-    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -5462,19 +5423,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -5526,11 +5474,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/hyphenate-style-name": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -5826,11 +5769,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-in-browser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "node_modules/is-map": {
       "version": "2.0.3",
@@ -6258,158 +6196,6 @@
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jss": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
-      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "csstype": "^3.0.2",
-        "is-in-browser": "^1.1.3",
-        "tiny-warning": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/jss"
-      }
-    },
-    "node_modules/jss-plugin-camel-case": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
-      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "hyphenate-style-name": "^1.0.3",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-compose": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-compose/-/jss-plugin-compose-10.10.0.tgz",
-      "integrity": "sha512-F5kgtWpI2XfZ3Z8eP78tZEYFdgTIbpA/TMuX3a8vwrNolYtN1N4qJR/Ob0LAsqIwCMLojtxN7c7Oo/+Vz6THow==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-default-unit": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
-      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-expand": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-expand/-/jss-plugin-expand-10.10.0.tgz",
-      "integrity": "sha512-ymT62W2OyDxBxr7A6JR87vVX9vTq2ep5jZLIdUSusfBIEENLdkkc0lL/Xaq8W9s3opUq7R0sZQpzRWELrfVYzA==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-extend": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-extend/-/jss-plugin-extend-10.10.0.tgz",
-      "integrity": "sha512-sKYrcMfr4xxigmIwqTjxNcHwXJIfvhvjTNxF+Tbc1NmNdyspGW47Ey6sGH8BcQ4FFQhLXctpWCQSpDwdNmXSwg==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-global": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
-      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-nested": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
-      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-props-sort": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
-      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-plugin-rule-value-function": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
-      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-rule-value-observable": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-observable/-/jss-plugin-rule-value-observable-10.10.0.tgz",
-      "integrity": "sha512-ZLMaYrR3QE+vD7nl3oNXuj79VZl9Kp8/u6A1IbTPDcuOu8b56cFdWRZNZ0vNr8jHewooEeq2doy8Oxtymr2ZPA==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "symbol-observable": "^1.2.0"
-      }
-    },
-    "node_modules/jss-plugin-template": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-template/-/jss-plugin-template-10.10.0.tgz",
-      "integrity": "sha512-ocXZBIOJOA+jISPdsgkTs8wwpK6UbsvtZK5JI7VUggTD6LWKbtoxUzadd2TpfF+lEtlhUmMsCkTRNkITdPKa6w==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "tiny-warning": "^1.0.2"
-      }
-    },
-    "node_modules/jss-plugin-vendor-prefixer": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
-      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.8",
-        "jss": "10.10.0"
-      }
-    },
-    "node_modules/jss-preset-default": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-10.10.0.tgz",
-      "integrity": "sha512-GL175Wt2FGhjE+f+Y3aWh+JioL06/QWFgZp53CbNNq6ZkVU0TDplD8Bxm9KnkotAYn3FlplNqoW5CjyLXcoJ7Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "jss": "10.10.0",
-        "jss-plugin-camel-case": "10.10.0",
-        "jss-plugin-compose": "10.10.0",
-        "jss-plugin-default-unit": "10.10.0",
-        "jss-plugin-expand": "10.10.0",
-        "jss-plugin-extend": "10.10.0",
-        "jss-plugin-global": "10.10.0",
-        "jss-plugin-nested": "10.10.0",
-        "jss-plugin-props-sort": "10.10.0",
-        "jss-plugin-rule-value-function": "10.10.0",
-        "jss-plugin-rule-value-observable": "10.10.0",
-        "jss-plugin-template": "10.10.0",
-        "jss-plugin-vendor-prefixer": "10.10.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -7395,25 +7181,6 @@
         "react": ">=16.8.6"
       }
     },
-    "node_modules/react-bs-notifier": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-bs-notifier/-/react-bs-notifier-7.0.0.tgz",
-      "integrity": "sha512-a+TOhca30rRfaNZUaTRNsrfb2znjBU7+I4I2xsFwh9iW2Qiw1ophozKeVBI2Qe9zIpdC4dpfUwAv3Rn+5gnpiQ==",
-      "dependencies": {
-        "prop-types": "^15.7.2",
-        "react-jss": "^10.4.0",
-        "react-transition-group": "^4.4.1",
-        "toetag": "^3.3.7"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/react-display-name": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/react-display-name/-/react-display-name-0.2.5.tgz",
-      "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
-    },
     "node_modules/react-dom": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
@@ -7430,27 +7197,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
-    "node_modules/react-jss": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-10.10.0.tgz",
-      "integrity": "sha512-WLiq84UYWqNBF6579/uprcIUnM1TSywYq6AIjKTTTG5ziJl9Uy+pwuvpN3apuyVwflMbD60PraeTKT7uWH9XEQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@emotion/is-prop-valid": "^0.7.3",
-        "css-jss": "10.10.0",
-        "hoist-non-react-statics": "^3.2.0",
-        "is-in-browser": "^1.1.3",
-        "jss": "10.10.0",
-        "jss-preset-default": "10.10.0",
-        "prop-types": "^15.6.0",
-        "shallow-equal": "^1.2.0",
-        "theming": "^3.3.0",
-        "tiny-warning": "^1.0.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -7928,11 +7674,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8407,14 +8148,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8490,32 +8223,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/theming": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/theming/-/theming-3.3.0.tgz",
-      "integrity": "sha512-u6l4qTJRDaWZsqa8JugaNt7Xd8PPl9+gonZaIe28vAhqgHMIG/DOyFPqiKN/gQLQYj05tHv+YQdNILL4zoiAVA==",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0",
-        "prop-types": "^15.5.8",
-        "react-display-name": "^0.2.4",
-        "tiny-warning": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": ">=16.3"
-      }
-    },
     "node_modules/timeago.js": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.2.tgz",
       "integrity": "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -8672,11 +8383,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/toetag": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/toetag/-/toetag-3.3.7.tgz",
-      "integrity": "sha512-O/8mKaXwH7rZdMNqLOqEPOw8hCpiI8eknS26IR6dUVZKduQHeBFnFPDhOnuyEQMj9RH+M/3mDpNRkODF3Nz7pA=="
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "react": "^19.1.1",
     "react-bootstrap": "^1.6.7",
     "react-bootstrap-icons": "^1.11.3",
-    "react-bs-notifier": "^7.0.0",
     "react-dom": "^19.1.1",
     "react-router": "^7.6.0",
     "timeago.js": "^4.0.2"

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -1,41 +1,64 @@
 import { removeNotification, useNotifications } from "@src/hooks/notifications";
 import type { Notifications } from "@src/types";
 import React from "react";
-import { AlertList } from "react-bs-notifier";
+import Toast from "react-bootstrap/Toast";
 
 function NotificationDetails({ details }: { details: string[] }) {
   if (details.length === 0) {
     return null;
   }
   if (details.length === 1) {
-    return <span>{details[0]}</span>;
+    return (
+      <Toast.Body>
+        <span>{details[0]}</span>
+      </Toast.Body>
+    );
   }
   return (
-    <ul>
-      {details.map((detail, index) => {
-        return <li key={index}>{detail}</li>;
-      })}
-    </ul>
+    <Toast.Body>
+      <ul>
+        {details.map((detail, index) => {
+          return <li key={index}>{detail}</li>;
+        })}
+      </ul>
+    </Toast.Body>
   );
 }
 
 export default function Notifications() {
   const notifications = useNotifications();
+
   const alerts = notifications.map(
-    ({ message: headline, details = [], ...attrs }, i) => {
-      const message = <NotificationDetails details={details} />;
-      return { id: i, headline, message, ...attrs };
+    ({ message: headline, details = [], timeout, type }, i) => {
+      console.log(details);
+      return (
+        <Toast
+          className={`bg-${type}`}
+          key={`notification-${i}`}
+          autohide={timeout > 0}
+          delay={timeout > 0 ? timeout : undefined}
+          onClose={() => {
+            removeNotification(i);
+          }}
+        >
+          <Toast.Header closeButton={false}>
+            {headline}
+            <button
+              className="close"
+              title="Dismiss"
+              aria-label="Dismiss"
+              onClick={() => {
+                removeNotification(i);
+              }}
+            >
+              x
+            </button>
+          </Toast.Header>
+          <NotificationDetails details={details} />
+        </Toast>
+      );
     }
   );
 
-  const onDismiss = ({ id: index }) => removeNotification(index);
-  return (
-    <div className="notifications">
-      <AlertList
-        alerts={alerts}
-        onDismiss={onDismiss}
-        data-testid="notifications"
-      />
-    </div>
-  );
+  return <div className="notifications">{alerts}</div>;
 }

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -29,15 +29,15 @@ export default function Notifications() {
   const notifications = useNotifications();
 
   const alerts = notifications.map(
-    ({ message: headline, details = [], timeout, type }, i) => {
+    ({ id, message: headline, details = [], timeout, type }) => {
       return (
         <Toast
           className={`bg-${type}`}
-          key={`notification-${i}`}
+          key={`notification-${id}`}
           autohide={timeout > 0}
           delay={timeout > 0 ? timeout : undefined}
           onClose={() => {
-            removeNotification(i);
+            removeNotification(id);
           }}
         >
           <Toast.Header closeButton={false}>
@@ -47,7 +47,7 @@ export default function Notifications() {
               title="Dismiss"
               aria-label="Dismiss"
               onClick={() => {
-                removeNotification(i);
+                removeNotification(id);
               }}
             >
               x

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -30,7 +30,6 @@ export default function Notifications() {
 
   const alerts = notifications.map(
     ({ message: headline, details = [], timeout, type }, i) => {
-      console.log(details);
       return (
         <Toast
           className={`bg-${type}`}

--- a/src/components/collection/RecordRow.tsx
+++ b/src/components/collection/RecordRow.tsx
@@ -38,7 +38,7 @@ export default function RecordRow({
 }: RowProps) {
   const navigate = useNavigate();
   const auth = useAuth();
-  const toggle = useRef<HTMLButtonElement>();
+  const toggle = useRef<HTMLButtonElement>(null);
 
   const onDoubleClick = (event: React.MouseEvent) => {
     event.preventDefault();

--- a/src/components/homepage/ServerHistory.tsx
+++ b/src/components/homepage/ServerHistory.tsx
@@ -25,7 +25,7 @@ const debounceMillis = 400;
 
 export default function ServerHistory(props: ServerHistoryProps) {
   const [value, setValue] = useState(props.value);
-  const toggleRef = useRef<HTMLButtonElement>();
+  const toggleRef = useRef<HTMLButtonElement>(null);
   const toggleDropdown = () => {
     toggleRef.current.click();
   };

--- a/src/hooks/notifications.ts
+++ b/src/hooks/notifications.ts
@@ -32,15 +32,15 @@ function notify(type: Levels, message: string, options: NotificationOptions) {
       message: message,
       details: options?.details ?? [],
       timeout: options?.timeout,
+      id: Math.random().toString(),
     },
   ];
   state.set(notifications);
 }
 
-export function removeNotification(index: number) {
+export function removeNotification(id: string) {
   const notifications = [...state.get()];
-  notifications.splice(index, 1);
-  state.set(notifications);
+  state.set(notifications.filter(x => x.id !== id));
 }
 
 export function clearNotifications() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,7 @@ export interface GroupPermissions {
 }
 
 export interface Notification {
+  id: string;
   type: string;
   message: string;
   details: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,7 @@ export interface Notification {
   type: string;
   message: string;
   details: string[];
+  timeout?: number;
 }
 
 export type Notifications = Notification[];

--- a/test/components/Notifications_test.tsx
+++ b/test/components/Notifications_test.tsx
@@ -10,8 +10,8 @@ describe("Notifications component", () => {
     removeNotificationParam = null;
     useNotificationsMock = vi.spyOn(notificationsHooks, "useNotifications");
     vi.spyOn(notificationsHooks, "removeNotification").mockImplementation(
-      idx => {
-        removeNotificationParam = idx;
+      id => {
+        removeNotificationParam = id;
       }
     );
   });
@@ -39,21 +39,23 @@ describe("Notifications component", () => {
   });
 
   it("should remove a single notif when the list has one", () => {
-    useNotificationsMock.mockReturnValue([{ type: "info", message: "plop" }]);
+    useNotificationsMock.mockReturnValue([
+      { type: "info", message: "plop", id: "id" },
+    ]);
     render(<Notifications />);
 
     fireEvent.click(screen.getByTitle("Dismiss"));
-    expect(removeNotificationParam).toBe(0);
+    expect(removeNotificationParam).toBe("id");
   });
 
   it("should remove a single notif when the list has two", () => {
     useNotificationsMock.mockReturnValue([
-      { type: "info", message: "plop" },
-      { type: "info", message: "plap" },
+      { type: "info", message: "plop", id: "id1" },
+      { type: "info", message: "plap", id: "id2" },
     ]);
     render(<Notifications />);
     // second notification close button clicked
     fireEvent.click(screen.getAllByTitle("Dismiss")[1]);
-    expect(removeNotificationParam).toBe(1);
+    expect(removeNotificationParam).toBe("id2");
   });
 });

--- a/test/hooks/notifications_test.ts
+++ b/test/hooks/notifications_test.ts
@@ -86,7 +86,7 @@ describe("notifications hooks", () => {
       expect(result.current.length).toBe(3);
     });
 
-    removeNotification(1);
+    removeNotification(result.current[1].id);
 
     await vi.waitFor(() => {
       expect(result.current.length).toBe(2);
@@ -145,7 +145,7 @@ describe("notifications hooks", () => {
       expect(result3.current).toMatchObject(match);
     });
 
-    removeNotification(1);
+    removeNotification(result1.current[1].id);
 
     await vi.waitFor(() => {
       const match = [{ message: "Test info" }, { message: "Test error" }];


### PR DESCRIPTION
Fixes #3649 - replacing `react-bs-notifier` with `react-bootstrap/Toast` components.

Looking for feedback on this styling. This is at least readable (to me) and easy to understand when there is a warning/error. We can tune it further though.

<img width="349" height="516" alt="image" src="https://github.com/user-attachments/assets/ab35eced-80a0-4e56-8667-d3d229314c42" />
