### PR TITLE
Removing windows from github ci actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,7 @@ jobs:
         run: npm run lint
   
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with: 
@@ -56,10 +53,7 @@ jobs:
         run: npm run test:ci
   
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with: 


### PR DESCRIPTION
It seems like something has changed in github, as the windows actions are becoming flaky. Maybe a performance issue or some recently updated build images, I'm not sure.

Given that this is a web UI project, it seems pretty safe to just run these checks on linux.

Examples of test flakiness on windows:

- https://github.com/Kinto/kinto-admin/actions/runs/24349519930/attempts/1
- https://github.com/Kinto/kinto-admin/actions/runs/23907365298/attempts/1
- https://github.com/Kinto/kinto-admin/actions/runs/23750867146/attempts/1