### PR TITLE
Fix mozilla/remote-settings#1089 and mozilla/remote-settings#947 race conditions

### DIFF
--- a/src/hooks/bucket.ts
+++ b/src/hooks/bucket.ts
@@ -11,7 +11,7 @@ import {
   PermissionsListEntry,
 } from "@src/types";
 import { historyFiltersToServerFilters, makeObservable } from "@src/utils";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 export function useBucket(
   bid: string,
@@ -61,16 +61,18 @@ export function useBucketsCollectionsList(
 export function useBucketList(): BucketData[] | undefined {
   const [val, setVal] = useState(undefined);
 
-  useMemo(async () => {
+  useEffect(() => {
     setVal(undefined);
-    const client = getClient();
-    try {
-      const buckets = (await client.listBuckets()).data;
-      setVal(buckets);
-    } catch (ex) {
-      notifyError("Unable to load buckets list", ex);
-    }
+    getClient()
+      .listBuckets()
+      .then(result => {
+        setVal(result.data);
+      })
+      .catch(err => {
+        notifyError("Unable to load buckets list", err);
+      });
   }, []);
+
   return val;
 }
 

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -51,15 +51,19 @@ export function logout() {
 export function useAuth(): AuthData | undefined {
   const [val, setVal] = useLocalStorage("kinto-admin-auth", authState.get());
 
-  if (val?.expiresAt && val.expiresAt < new Date().getTime()) {
+  const isExpired = val?.expiresAt && val.expiresAt < new Date().getTime();
+  if (isExpired) {
     setVal(undefined);
   }
 
+  // Restore client synchronously on first render so descendant hooks
+  // that call getClient() during mount don't race the auth effect.
+  if (!isExpired && val !== undefined && authState.get() === undefined) {
+    authState.set(val);
+    setupClient(val);
+  }
+
   useEffect(() => {
-    if (authState.get() === undefined && val !== undefined) {
-      authState.set(val);
-      setupClient(val);
-    }
     return authState.subscribe(setVal);
   }, []);
 

--- a/test/hooks/bucket_test.ts
+++ b/test/hooks/bucket_test.ts
@@ -7,8 +7,11 @@ import {
   useBucketPermissions,
   useBucketsCollectionsList,
 } from "@src/hooks/bucket";
+import { logout, useAuth } from "@src/hooks/session";
+import * as storageHooks from "@src/hooks/storage";
 import { mockNotifyError } from "@test/testUtils";
-import { renderHook } from "@testing-library/react";
+import { render, renderHook } from "@testing-library/react";
+import React from "react";
 
 describe("bucket hooks", () => {
   describe("useBucket", () => {
@@ -445,6 +448,74 @@ describe("bucket hooks", () => {
       const fooBucket = tree.find(b => b.id === "foo");
       expect(fooBucket).toBeDefined();
       expect(fooBucket.collections.find(c => c.id === "foo")).toBeDefined();
+    });
+  });
+
+  // Regression test for https://github.com/mozilla/remote-settings/issues/1089
+  //
+  // On page refresh, `useAuth` reads persisted auth from localStorage during
+  // render and immediately returns truthy, allowing descendants to render.
+  // React commits child effects before parent effects on mount, so if a child
+  // calls `getClient()` in its mount effect before `useAuth`'s effect runs
+  // `setupClient`, it would throw "Client not configured."
+  describe("useAuth + useBucketList race on refresh", () => {
+    beforeEach(() => {
+      // Drop spies installed by sibling describes (e.g. on client.getClient)
+      // so this test runs against the real client module.
+      vi.restoreAllMocks();
+      logout();
+      client.resetClient();
+    });
+
+    it("loads buckets when a descendant calls useBucketList on first mount with persisted auth", async () => {
+      const notifyErrorMock = mockNotifyError();
+      const persistedAuth = {
+        authType: "basicauth",
+        server: "http://localhost/v1",
+        credentials: { username: "u", password: "p" },
+      };
+      vi.spyOn(storageHooks, "useLocalStorage").mockReturnValue([
+        persistedAuth,
+        vi.fn(),
+      ]);
+      const listBucketsMock = vi
+        .fn()
+        .mockResolvedValue({ data: [{ id: "main" }] });
+      // Make the KintoClient instance produced by setupClient() expose our
+      // listBuckets stub, so the bucket list hook actually loads data.
+      vi.spyOn(client, "setupClient").mockImplementation(() => {
+        const instance = { listBuckets: listBucketsMock } as any;
+        client.setClient(instance);
+        return instance;
+      });
+
+      function Child() {
+        const buckets = useBucketList();
+        return React.createElement(
+          "div",
+          { "data-testid": "buckets" },
+          buckets ? buckets.map(b => b.id).join(",") : "loading"
+        );
+      }
+      function Parent() {
+        const auth = useAuth();
+        return React.createElement(
+          "div",
+          null,
+          auth ? React.createElement(Child) : "no-auth"
+        );
+      }
+
+      const { getByTestId } = render(React.createElement(Parent));
+
+      await vi.waitFor(() => {
+        expect(getByTestId("buckets").textContent).toBe("main");
+      });
+      expect(listBucketsMock).toHaveBeenCalled();
+      expect(notifyErrorMock).not.toHaveBeenCalledWith(
+        "Unable to load buckets list",
+        expect.objectContaining({ message: "Client not configured." })
+      );
     });
   });
 });


### PR DESCRIPTION
Fix mozilla/remote-settings#1089
Fix mozilla/remote-settings#947

- `useMemo` doesn't await, the returned promise's rejection was unhandled
-  In the signoff path, the rejection from getClient() is swallowed because there's no `.catch`, so the signoff state never populates and review/approve buttons never render. 

https://github.com/Kinto/kinto-admin/blob/2a1b4009a11ea2aa4d403c283d9eff521039a0d3/src/hooks/signoff.ts#L45