### PR TITLE
fix: allow breadcrumbs to wrap on narrow screens

### DIFF
--- a/src/components/Breadcrumbs/style.css
+++ b/src/components/Breadcrumbs/style.css
@@ -1,5 +1,25 @@
-.breadcrumbs {
+nav.breadcrumbs {
+  display: block;
+  overflow-wrap: anywhere;
   padding-top: 0.5em;
   font-size: 1.2em;
   text-transform: lowercase;
+}
+
+.breadcrumbs > div {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.breadcrumbs > div > span {
+  display: inline-flex;
+  min-width: 0;
+}
+
+.breadcrumbs a {
+  overflow-wrap: anywhere;
+}
+
+.breadcrumbs > div > span > span {
+  flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary

- allows breadcrumbs to wrap on narrow screens
- keeps the styling scoped to the breadcrumb layout

Closes #3599.

## Test plan

- `git diff --check`
- `npm run cs-check` could not run because local dependencies are not installed.