### PR TITLE
Do not let stale request overwrite latest info

### DIFF
--- a/src/components/signoff/SignoffToolBar.tsx
+++ b/src/components/signoff/SignoffToolBar.tsx
@@ -98,7 +98,9 @@ export default function SignoffToolBar({ callback }: SignoffToolBarProps) {
   }
 
   if (!("status" in signoff.source)) {
-    return <Spinner />;
+    // Check whether it is not enabled or still loading.
+    const signoffSourceInfo = signoff.source as SignoffSourceInfo;
+    return signoffSourceInfo.isLoading === false ? null : <Spinner />;
   }
 
   // At this point, signoff is loaded (not null and with `status` field)

--- a/src/hooks/signoff.ts
+++ b/src/hooks/signoff.ts
@@ -1,3 +1,4 @@
+import { notifyError } from "./notifications";
 import { getClient } from "@src/client";
 import type {
   ChangesList,
@@ -7,7 +8,6 @@ import type {
   SignerCapabilityResourceEntry,
   SignoffCollectionStatus,
   SignoffCollectionsInfo,
-  SignoffSourceInfo,
 } from "@src/types";
 import { hasHistoryDisabled } from "@src/utils";
 import { useEffect, useState } from "react";
@@ -32,17 +32,40 @@ export function useSignoff(
     bid,
     cid
   );
-  const [val, setVal] = useState(resource);
+  const [val, setVal] = useState<
+    null | SignerCapabilityResource | SignoffCollectionsInfo
+  >(resource);
 
   useEffect(() => {
-    if (resource?.source) {
-      const emptyInfos = resource.source as SignoffSourceInfo;
-      emptyInfos.isLoading = true;
-      setVal({ ...resource, ...emptyInfos });
-      calculateChangesInfo(resource).then((infos: SignoffCollectionsInfo) =>
-        setVal(infos)
-      );
+    if (!resource?.source) {
+      // Either it not loaded, and signoff is not enabled.
+      // Reset the UI anyway.
+      setVal(resource);
+      return;
     }
+    // Effect is ran again, mark as loading and recompute changes infos.
+    setVal({ ...resource, source: { ...resource.source, isLoading: true } });
+
+    let cancelled = false;
+    calculateChangesInfo(resource)
+      .then((infos: SignoffCollectionsInfo) => {
+        if (cancelled) return;
+        // Normal case.
+        setVal(infos);
+      })
+      .catch(err => {
+        if (cancelled) return;
+        // Notify error to user.
+        notifyError("Unable to load signoff information", err);
+        setVal({
+          ...resource,
+          source: { ...resource.source, isLoading: false },
+        });
+      });
+    return () => {
+      // Abort useEffect().
+      cancelled = true;
+    };
   }, [resource?.source?.bucket, resource?.source?.collection, cacheBust]);
 
   return val;

--- a/test/hooks/signoff_test.ts
+++ b/test/hooks/signoff_test.ts
@@ -1,5 +1,7 @@
 import * as client from "@src/client";
 import { useSignoff } from "@src/hooks/signoff";
+import type { SignoffCollectionsInfo } from "@src/types";
+import { mockNotifyError } from "@test/testUtils";
 import { renderHook } from "@testing-library/react";
 
 const signer = {
@@ -183,6 +185,70 @@ describe("signoff hooks", () => {
           since: "42",
           fields: ["deleted"],
         });
+      });
+    });
+
+    it("Notifies and leaves the loading state if loading fails", async () => {
+      const notifyErrorMock = mockNotifyError();
+      getDataMock.mockRejectedValue(new Error("boom"));
+
+      const { result } = renderHook(() =>
+        useSignoff("source", "cid", serverInfo)
+      );
+
+      await vi.waitFor(() => {
+        expect(notifyErrorMock).toHaveBeenCalled();
+      });
+      expect((result.current as SignoffCollectionsInfo).source.isLoading).toBe(
+        false
+      );
+    });
+
+    it("Stale request should not overwrite latest info", async () => {
+      let resolveStale;
+      getDataMock.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            // Won't resolve immediately.
+            resolveStale = () =>
+              resolve({ status: "work-in-progress", last_modified: 1 });
+          })
+      );
+      const { result, rerender } = renderHook(
+        ({ cacheBust }) => useSignoff("source", "cid", serverInfo, cacheBust),
+        { initialProps: { cacheBust: 0 } }
+      );
+
+      // Bump the cache, while the other is still pending.
+      getDataMock.mockResolvedValue({ status: "to-review", last_modified: 2 });
+      rerender({ cacheBust: 1 });
+      await vi.waitFor(() => {
+        expect((result.current as SignoffCollectionsInfo).source.status).toBe(
+          "to-review"
+        );
+      });
+
+      // Resolve first promise. Shouldn't overwrite the content of the lastest one.
+      resolveStale();
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect((result.current as SignoffCollectionsInfo).source.status).toBe(
+        "to-review"
+      );
+    });
+
+    it("Resets when the collection is not concerned with signoff anymore", async () => {
+      const { result, rerender } = renderHook(
+        ({ bid }) => useSignoff(bid, "cid", serverInfo),
+        { initialProps: { bid: "source" } }
+      );
+      await vi.waitFor(() => {
+        expect((result.current as SignoffCollectionsInfo).source.status).toBe(
+          "work-in-progress"
+        );
+      });
+      rerender({ bid: "unsigned" });
+      await vi.waitFor(() => {
+        expect(result.current).toBeNull();
       });
     });
   });


### PR DESCRIPTION
- Distinguish loading from not enabled
- if `useEffect()` is canceled, do not overwrite state

